### PR TITLE
[FIX] Change gas' cmd to return only a JSON output

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ db.createUser({user:"husky", pwd:"superENVPassword", roles: ["readWrite"]})
 ENRY:
 
 ```
-curl -H "Content-Type: application/json" -d '{"name":"enry", "image": "huskyci/enry", "cmd": "git clone %GIT_REPO% code && cd code && enry --json" , "language": "Generic", "default":true}' http://localhost:9999/securitytest
+curl -H "Content-Type: application/json" -d '{"name":"enry", "image": "huskyci/enry", "cmd": "git clone %GIT_REPO% code --quiet && cd code && enry --json" , "language": "Generic", "default":true}' http://localhost:9999/securitytest
 ```
 
 GAS:


### PR DESCRIPTION
#### README.md:

* The cmd being used had a ";" to concatenate each cmd to be run. Besides that, git clone was sending the message "Cloning into ...".
* `&` and `--quiet` have been added to solve this issue.
* Changed repository URL example to `https://github.com/tsuru/cst.git`
