### PR TITLE
[FIX] Add a new Regex into analysis.go

### DIFF
--- a/analysis/analysis.go
+++ b/analysis/analysis.go
@@ -29,8 +29,9 @@ func ReceiveRequest(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, map[string]string{"result": "error", "details": "Error binding repository."})
 	}
 
-	// check-01: is this a git repository URL?
-	regexpGit := `^(?:git|https?|ssh|git@[-\w.]+):(//)?(.*?)(\.git)(/?|#[-\d\w._]+?)$`
+	// check-01: is this a git repository URL? default format = gitlab@gitlab.example.com:folder/project.git
+	// regexpGit := `^(?:git|https?|ssh|git@[-\w.]+):(//)?(.*?)(\.git)(/?|#[-\d\w._]+?)$`
+	regexpGit := `((git|gitlab@[\w\.]+))(:(//)?)([\w\.@\:/\-~]+)(\.git)(/)?`
 	valid, err := regexp.MatchString(regexpGit, repository.URL)
 	if err != nil {
 		return c.JSON(http.StatusBadRequest, map[string]string{"result": "error", "details": "Internal error."})


### PR DESCRIPTION
## Closes issue #70 

Initial idea was to use CI_REPOSITORY_URL from GitlabCI runner to use it as a parameter to Husky. However, by doing some checks (example bellow), it is possible to realize that it is better to force HuskyCI user to hardcode its repository URL in this format `git@github.com:globocom/husky.git`.

Example from GitlabCI: 
```
$ echo "hi! this is my $CI_REPOSITORY_URL"
hi! this is my http://gitlab-ci-token:xxxxxxxxxxxxxxxxxxxx@gitlab.example.com/project/project.git
```

#### analysis/analysis.go:
* Chaged `regexpGit` value to `((git|gitlab@[\w\.]+))(:(//)?)([\w\.@\:/\-~]+)(\.git)(/)?\`.