### PR TITLE
[FEAT] Run docker in CLI and API mode simultaneously. Remove commands…

### DIFF
--- a/vagrant/scripts/vm3-docker-config.sh
+++ b/vagrant/scripts/vm3-docker-config.sh
@@ -8,11 +8,8 @@ echo "[*] Exposing docker daemon port:"
 mkdir /etc/systemd/system/docker.service.d
 sh -c "echo '[Service]' >> /etc/systemd/system/docker.service.d/override.conf"
 sh -c "echo 'ExecStart=' >> /etc/systemd/system/docker.service.d/override.conf"
-sh -c "echo 'ExecStart=/usr/bin/dockerd -H tcp://0.0.0.0:2376' >> /etc/systemd/system/docker.service.d/override.conf"   
+sh -c "echo 'ExecStart=/usr/bin/dockerd -H unix:///var/run/docker.sock -H tcp://0.0.0.0:2376' >> /etc/systemd/system/docker.service.d/override.conf"   
 systemctl enable --now docker.service
 echo "[*] Restarting docker:" 
 systemctl stop docker
 systemctl start docker
-echo "[*] Downloading huskyci docker images:"
-curl -X POST http://localhost:2376/v1.24/images/create?fromImage=huskyci/enry 
-curl -X POST http://localhost:2376/v1.24/images/create?fromImage=huskyci/gas 


### PR DESCRIPTION
… to download images

Activate CLI function to Docker for a better management.

With future feature, images will be managed by HuskyCI API. Thereby, it won't be necessary download images from script.