### PR TITLE
[FIX] Fix log level parameter in glbgelf

### DIFF
--- a/analysis/analysis.go
+++ b/analysis/analysis.go
@@ -240,7 +240,7 @@ func monitorAnalysisCheckStatus(RID string) (bool, error) {
 	if err != nil {
 		if errLog := glbgelf.Logger.SendLog(map[string]interface{}{
 			"action": "monitorAnalysisCheckStatus",
-			"info":   "ANALYSIS"}, "Could not find analysis:", err); errLog != nil {
+			"info":   "ANALYSIS"}, "ERROR", "Could not find analysis:", err); errLog != nil {
 			fmt.Println("glbgelf error: ", errLog)
 		}
 	}


### PR DESCRIPTION
The level parameter was missing in `SendLog` function from `glbgelf`. This was causing an _invalid log level_ error.

This pull request inserts the missing _ERROR_ parameter in `monitorAnalysisCheckStatus` function from _analysis/analysis.go_.