### PR TITLE
[FEAT] Add connection pool

### DIFF
--- a/analysis/huskydb.go
+++ b/analysis/huskydb.go
@@ -14,109 +14,81 @@ import (
 // FindOneDBRepository checks if a given repository is present into RepositoryCollection.
 func FindOneDBRepository(mapParams map[string]interface{}) (types.Repository, error) {
 	repositoryResponse := types.Repository{}
-	session, err := db.Connect()
-	if err != nil {
-		return repositoryResponse, err
-	}
 	repositoryQuery := []bson.M{}
 	for k, v := range mapParams {
 		repositoryQuery = append(repositoryQuery, bson.M{k: v})
 	}
 	repositoryFinalQuery := bson.M{"$and": repositoryQuery}
-	err = session.SearchOne(repositoryFinalQuery, nil, db.RepositoryCollection, &repositoryResponse)
+	err := db.Conn.SearchOne(repositoryFinalQuery, nil, db.RepositoryCollection, &repositoryResponse)
 	return repositoryResponse, err
 }
 
 // FindOneDBSecurityTest checks if a given securityTest is present into SecurityTestCollection.
 func FindOneDBSecurityTest(mapParams map[string]interface{}) (types.SecurityTest, error) {
 	securityTestResponse := types.SecurityTest{}
-	session, err := db.Connect()
-	if err != nil {
-		return securityTestResponse, err
-	}
 	securityTestQuery := []bson.M{}
 	for k, v := range mapParams {
 		securityTestQuery = append(securityTestQuery, bson.M{k: v})
 	}
 	securityTestFinalQuery := bson.M{"$and": securityTestQuery}
-	err = session.SearchOne(securityTestFinalQuery, nil, db.SecurityTestCollection, &securityTestResponse)
+	err := db.Conn.SearchOne(securityTestFinalQuery, nil, db.SecurityTestCollection, &securityTestResponse)
 	return securityTestResponse, err
 }
 
 // FindOneDBAnalysis checks if a given analysis is present into AnalysisCollection.
 func FindOneDBAnalysis(mapParams map[string]interface{}) (types.Analysis, error) {
 	analysisResponse := types.Analysis{}
-	session, err := db.Connect()
-	if err != nil {
-		return analysisResponse, err
-	}
 	analysisQuery := []bson.M{}
 	for k, v := range mapParams {
 		analysisQuery = append(analysisQuery, bson.M{k: v})
 	}
 	analysisFinalQuery := bson.M{"$and": analysisQuery}
 
-	err = session.SearchOne(analysisFinalQuery, nil, db.AnalysisCollection, &analysisResponse)
+	err := db.Conn.SearchOne(analysisFinalQuery, nil, db.AnalysisCollection, &analysisResponse)
 	return analysisResponse, err
 }
 
 // FindAllDBRepository returns all Repository of a given query present into RepositoryCollection.
 func FindAllDBRepository(mapParams map[string]interface{}) ([]types.Repository, error) {
-	session, err := db.Connect()
-	if err != nil {
-		return nil, err
-	}
 	repositoryQuery := []bson.M{}
 	for k, v := range mapParams {
 		repositoryQuery = append(repositoryQuery, bson.M{k: v})
 	}
 	repositoryFinalQuery := bson.M{"$and": repositoryQuery}
 	repositoryResponse := []types.Repository{}
-	err = session.Search(repositoryFinalQuery, nil, db.RepositoryCollection, &repositoryResponse)
+	err := db.Conn.Search(repositoryFinalQuery, nil, db.RepositoryCollection, &repositoryResponse)
 	return repositoryResponse, err
 }
 
 // FindAllDBSecurityTest returns all SecurityTests of a given query present into SecurityTestCollection.
 func FindAllDBSecurityTest(mapParams map[string]interface{}) ([]types.SecurityTest, error) {
-	session, err := db.Connect()
-	if err != nil {
-		return nil, err
-	}
 	securityTestQuery := []bson.M{}
 	for k, v := range mapParams {
 		securityTestQuery = append(securityTestQuery, bson.M{k: v})
 	}
 	securityTestFinalQuery := bson.M{"$and": securityTestQuery}
 	securityTestResponse := []types.SecurityTest{}
-	err = session.Search(securityTestFinalQuery, nil, db.SecurityTestCollection, &securityTestResponse)
+	err := db.Conn.Search(securityTestFinalQuery, nil, db.SecurityTestCollection, &securityTestResponse)
 	return securityTestResponse, err
 }
 
 // FindAllDBAnalysis returns all Analysis of a given query present into AnalysisCollection.
 func FindAllDBAnalysis(mapParams map[string]interface{}) ([]types.Analysis, error) {
-	session, err := db.Connect()
-	if err != nil {
-		return nil, err
-	}
 	analysisQuery := []bson.M{}
 	for k, v := range mapParams {
 		analysisQuery = append(analysisQuery, bson.M{k: v})
 	}
 	analysisFinalQuery := bson.M{"$and": analysisQuery}
 	analysisResponse := []types.Analysis{}
-	err = session.Search(analysisFinalQuery, nil, db.AnalysisCollection, &analysisResponse)
+	err := db.Conn.Search(analysisFinalQuery, nil, db.AnalysisCollection, &analysisResponse)
 	return analysisResponse, err
 }
 
 // InsertDBRepository inserts a new repository with default securityTests into RepositoryCollection.
 func InsertDBRepository(repository types.Repository) error {
-	session, err := db.Connect()
-	if err != nil {
-		return err
-	}
 	repository.CreatedAt = time.Now()
 	securityTestList := []types.SecurityTest{}
-	err = errors.New("")
+	err := errors.New("")
 	maxQueryAllowed := 8
 
 	if len(repository.SecurityTestName) == 0 {
@@ -174,16 +146,12 @@ func InsertDBRepository(repository types.Repository) error {
 		Languages:     repository.Languages,
 	}
 
-	err = session.Insert(newRepository, db.RepositoryCollection)
+	err = db.Conn.Insert(newRepository, db.RepositoryCollection)
 	return err
 }
 
 // InsertDBSecurityTest inserts a new securityTest into SecurityTestCollection.
 func InsertDBSecurityTest(securityTest types.SecurityTest) error {
-	session, err := db.Connect()
-	if err != nil {
-		return err
-	}
 	newSecurityTest := bson.M{
 		"name":           securityTest.Name,
 		"image":          securityTest.Image,
@@ -192,16 +160,12 @@ func InsertDBSecurityTest(securityTest types.SecurityTest) error {
 		"default":        securityTest.Default,
 		"timeOutSeconds": securityTest.TimeOutInSeconds,
 	}
-	err = session.Insert(newSecurityTest, db.SecurityTestCollection)
+	err := db.Conn.Insert(newSecurityTest, db.SecurityTestCollection)
 	return err
 }
 
 // InsertDBAnalysis inserts a new analysis into AnalysisCollection.
 func InsertDBAnalysis(analysis types.Analysis) error {
-	session, err := db.Connect()
-	if err != nil {
-		return err
-	}
 	newAnalysis := bson.M{
 		"RID":          analysis.RID,
 		"URL":          analysis.URL,
@@ -211,67 +175,51 @@ func InsertDBAnalysis(analysis types.Analysis) error {
 		"result":       analysis.Result,
 		"containers":   analysis.Containers,
 	}
-	err = session.Insert(newAnalysis, db.AnalysisCollection)
+	err := db.Conn.Insert(newAnalysis, db.AnalysisCollection)
 	return err
 }
 
 // UpdateOneDBRepository checks if a given repository is present into RepositoryCollection and update it.
 func UpdateOneDBRepository(mapParams, updateQuery map[string]interface{}) error {
-	session, err := db.Connect()
-	if err != nil {
-		return err
-	}
 	repositoryQuery := []bson.M{}
 	for k, v := range mapParams {
 		repositoryQuery = append(repositoryQuery, bson.M{k: v})
 	}
 	repositoryFinalQuery := bson.M{"$and": repositoryQuery}
-	err = session.Update(repositoryFinalQuery, updateQuery, db.RepositoryCollection)
+	err := db.Conn.Update(repositoryFinalQuery, updateQuery, db.RepositoryCollection)
 	return err
 }
 
 // UpdateOneDBSecurityTest checks if a given securityTest is present into SecurityTestCollection and update it.
 func UpdateOneDBSecurityTest(mapParams map[string]interface{}, updatedSecurityTest types.SecurityTest) error {
-	session, err := db.Connect()
-	if err != nil {
-		return err
-	}
 	securityTestQuery := []bson.M{}
 	for k, v := range mapParams {
 		securityTestQuery = append(securityTestQuery, bson.M{k: v})
 	}
 	securityTestFinalQuery := bson.M{"$and": securityTestQuery}
-	err = session.Update(securityTestFinalQuery, updatedSecurityTest, db.SecurityTestCollection)
+	err := db.Conn.Update(securityTestFinalQuery, updatedSecurityTest, db.SecurityTestCollection)
 	return err
 }
 
 // UpdateOneDBAnalysis checks if a given analysis is present into AnalysisCollection and update it.
 func UpdateOneDBAnalysis(mapParams map[string]interface{}, updatedAnalysis types.Analysis) error {
-	session, err := db.Connect()
-	if err != nil {
-		return err
-	}
 	analysisQuery := []bson.M{}
 	for k, v := range mapParams {
 		analysisQuery = append(analysisQuery, bson.M{k: v})
 	}
 	analysisFinalQuery := bson.M{"$and": analysisQuery}
-	err = session.Update(analysisFinalQuery, updatedAnalysis, db.AnalysisCollection)
+	err := db.Conn.Update(analysisFinalQuery, updatedAnalysis, db.AnalysisCollection)
 	return err
 }
 
 // UpdateOneDBAnalysisContainer checks if a given analysis is present into AnalysisCollection and update the container associated in it.
 func UpdateOneDBAnalysisContainer(mapParams, updateQuery map[string]interface{}) error {
-	session, err := db.Connect()
-	if err != nil {
-		return err
-	}
 	analysisQuery := []bson.M{}
 	for k, v := range mapParams {
 		analysisQuery = append(analysisQuery, bson.M{k: v})
 	}
 	analysisFinalQuery := bson.M{"$and": analysisQuery}
-	err = session.Update(analysisFinalQuery, updateQuery, db.AnalysisCollection)
+	err := db.Conn.Update(analysisFinalQuery, updateQuery, db.AnalysisCollection)
 	return err
 }
 

--- a/context/config.go
+++ b/context/config.go
@@ -144,8 +144,8 @@ func getMongoTimeout() time.Duration {
 
 func getMongoPoolLimit() int {
 	mongoPoolLimit, err := strconv.Atoi(os.Getenv("MONGO_POOL_LIMIT"))
-	if err != nil {
-		return 10
+	if err != nil && mongoPoolLimit <= 0 {
+		return 1000
 	}
 	return mongoPoolLimit
 }

--- a/context/config.go
+++ b/context/config.go
@@ -19,6 +19,7 @@ type MongoConfig struct {
 	Timeout      time.Duration
 	Username     string
 	Password     string
+	PoolLimit    int
 }
 
 // DockerHostsConfig represents Docker Hosts configuration.
@@ -41,7 +42,7 @@ type APIConfig struct {
 	BrakemanSecurityTest *types.SecurityTest
 }
 
-var apiConfig *APIConfig
+var ApiConfig *APIConfig
 var onceConfig sync.Once
 
 func init() {
@@ -54,7 +55,7 @@ func init() {
 // GetAPIConfig returns the instance of an APIConfig.
 func GetAPIConfig() *APIConfig {
 	onceConfig.Do(func() {
-		apiConfig = &APIConfig{
+		ApiConfig = &APIConfig{
 			MongoDBConfig:        getMongoConfig(),
 			DockerHostsConfig:    getDockerHostsConfig(),
 			HuskyAPIPort:         getAPIHostPort(),
@@ -64,7 +65,7 @@ func GetAPIConfig() *APIConfig {
 			BrakemanSecurityTest: getBrakemanConfig(),
 		}
 	})
-	return apiConfig
+	return ApiConfig
 }
 
 func getDockerHostsConfig() *DockerHostsConfig {
@@ -103,6 +104,7 @@ func getMongoConfig() *MongoConfig {
 	mongoTimeout := getMongoTimeout()
 	mongoPort := getMongoPort()
 	mongoAddress := fmt.Sprintf("%s:%d", mongoHost, mongoPort)
+	mongoPoolLimit := getMongoPoolLimit()
 
 	return &MongoConfig{
 		Address:      mongoAddress,
@@ -110,6 +112,7 @@ func getMongoConfig() *MongoConfig {
 		Timeout:      mongoTimeout,
 		Username:     mongoUserName,
 		Password:     mongoPassword,
+		PoolLimit:    mongoPoolLimit,
 	}
 }
 
@@ -139,6 +142,13 @@ func getMongoTimeout() time.Duration {
 	return time.Duration(mongoTimeout) * time.Second
 }
 
+func getMongoPoolLimit() int {
+	mongoPoolLimit, err := strconv.Atoi(os.Getenv("MONGO_POOL_LIMIT"))
+	if err != nil {
+		return 10
+	}
+	return mongoPoolLimit
+}
 func getEnryConfig() *types.SecurityTest {
 	return &types.SecurityTest{
 		Name:             viper.GetString("enry.name"),

--- a/server.go
+++ b/server.go
@@ -166,7 +166,7 @@ func checkDockerHosts(configAPI *apiContext.APIConfig) error {
 
 func checkMongoDB() error {
 
-	_, err := db.Connect()
+	err := db.Connect()
 
 	if err != nil {
 		mongoError := fmt.Sprintf("check mongoDB: %s", err)


### PR DESCRIPTION
This pull request implements a connection pool.

**analysis/huskdb.go:**
- Deletes connect code from all functions in this file that call db functions.
- Changes _session_ by _db.Conn_.

**context/config.go**
- Adds _PoolLimit_ parameter in _MongoConfig_ struct. This parameter allows huskyci defines the max number of connections in the connection pool.
- Exports variable _apiConfig_ by changing its name to _ApiConfig_.
- Adds the function `getMongoPoolLimit` that sets a default value to _PoolLimit_ if it's not defined. To define a custom value for PoolLimit parameter, the environment variable _MONGO_POOL_LIMIT_ has to be an integer value greater than 0. This function is called in `getDockerHostsConfig`.

**db/mongo/db.go**
- Creates the exported variable _Conn_ that holds the db session.
- Adds info logs in `Connect` and `autoReconnect` functions.
- Uses the _MongoConfig_ struct defined in context/config.go instead of _mongoConfig_ (local struct).
- Changes `Connect` function to returns only an error. The session is now accessed from the exported variable _Conn_.
- Changes function `autoReconnect` to use the global variable _Conn_.

**server.go**
- Modifies the return parameters when call `Connect`. `Connect` now returns only an error. 

--------------
Closes #76