### PR TITLE
Refactor glbgelf using a new log package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ check-env:
 	cat .env
 
 ## Perfoms all make tests
-test: get-deps lint check-sec
+test: get-test-deps lint check-sec
 
 ## Runs lint
 lint:

--- a/analysis/analysis.go
+++ b/analysis/analysis.go
@@ -37,7 +37,7 @@ func ReceiveRequest(c echo.Context) error {
 	repository := types.Repository{}
 	err := c.Bind(&repository)
 	if err != nil {
-		log.Warning("ReceiveRequest", "ANALYSIS", 101, err)
+		log.Error("ReceiveRequest", "ANALYSIS", 1015, err)
 		return c.String(http.StatusBadRequest, "This is an invalid JSON.\n")
 	}
 
@@ -50,7 +50,7 @@ func ReceiveRequest(c echo.Context) error {
 		return c.String(http.StatusInternalServerError, "Internal error 1008.\n")
 	}
 	if !valid {
-		log.Warning("ReceiveRequest", "ANALYSIS", 102, repository.URL)
+		log.Error("ReceiveRequest", "ANALYSIS", 1016, repository.URL)
 		return c.String(http.StatusBadRequest, "This is not a valid repository URL.\n")
 	}
 	matches := r.FindString(repository.URL)
@@ -63,7 +63,7 @@ func ReceiveRequest(c echo.Context) error {
 		return c.String(http.StatusInternalServerError, "Internal error 1008.\n")
 	}
 	if !valid {
-		log.Warning("ReceiveRequest", "ANALYSIS", 103, repository.Branch)
+		log.Error("ReceiveRequest", "ANALYSIS", 1017, repository.Branch)
 		return c.String(http.StatusBadRequest, "This is not a valid branch.\n")
 	}
 
@@ -188,7 +188,7 @@ func monitorAnalysisUpdateStatus(RID string) error {
 	analysisQuery := map[string]interface{}{"RID": RID}
 	analysisResult, err := FindOneDBAnalysis(analysisQuery)
 	if err != nil {
-		log.Error("monitorAnalysisCheckStatus", "ANALYSIS", 2014, RID, err)
+		log.Error("monitorAnalysisUpdateStatus", "ANALYSIS", 2014, RID, err)
 		return err
 	}
 	// analyze each cResult from each container to determine what is the value of analysis.Result
@@ -207,7 +207,7 @@ func monitorAnalysisUpdateStatus(RID string) error {
 	}
 	err = UpdateOneDBAnalysisContainer(analysisQuery, updateAnalysisQuery)
 	if err != nil {
-		log.Error("monitorAnalysisCheckStatus", "ANALYSIS", 2007, err)
+		log.Error("monitorAnalysisUpdateStatus", "ANALYSIS", 2007, err)
 	}
 	return err
 }
@@ -238,7 +238,7 @@ func StatusAnalysis(c echo.Context) error {
 	regexpRID := `^[a-zA-Z0-9]*$`
 	valid, err := regexp.MatchString(regexpRID, RID)
 	if err != nil {
-		log.Error("StatusAnalysist", "ANALYSIS", 1008, "RID regexp ", err)
+		log.Error("StatusAnalysis", "ANALYSIS", 1008, "RID regexp ", err)
 		return c.String(http.StatusInternalServerError, "Internal error 1008.\n")
 	}
 	if !valid {

--- a/analysis/bandit.go
+++ b/analysis/bandit.go
@@ -68,11 +68,7 @@ func BanditStartAnalysis(CID string, cOutput string) {
 		}
 		err := UpdateOneDBAnalysisContainer(analysisQuery, updateContainerAnalysisQuery)
 		if err != nil {
-			if errLog := glbgelf.Logger.SendLog(map[string]interface{}{
-				"action": "BanditStartAnalysis",
-				"info":   "BANDIT"}, "ERROR", "Error updating AnalysisCollection (inside bandit.go):", err); errLog != nil {
-				fmt.Println("glbgelf error: ", errLog)
-			}
+			log.Error("BanditStartAnalysis", "BANDIT", 2007, "Step 1,5", err)
 		}
 		return
 	}

--- a/analysis/bandit.go
+++ b/analysis/bandit.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/globocom/glbgelf"
+	"github.com/globocom/huskyci/log"
 	"gopkg.in/mgo.v2/bson"
 )
 
@@ -48,28 +48,14 @@ func BanditStartAnalysis(CID string, cOutput string) {
 		}
 		err := UpdateOneDBAnalysisContainer(analysisQuery, updateContainerAnalysisQuery)
 		if err != nil {
-			if errLog := glbgelf.Logger.SendLog(map[string]interface{}{
-				"action": "BanditStartAnalysis",
-				"info":   "BANDIT"}, "ERROR", "Error updating AnalysisCollection (inside bandit.go):", err); errLog != nil {
-				fmt.Println("glbgelf error: ", errLog)
-			}
+			log.Error("BanditStartAnalysis", "BANDIT", 2007, "Step 1", err)
 		}
 		return
 	}
 
 	var banditResult BanditOutput
 	if err := json.Unmarshal([]byte(cOutput), &banditResult); err != nil {
-		if errLog := glbgelf.Logger.SendLog(map[string]interface{}{
-			"action": "BanditStartAnalysis",
-			"info":   "BANDIT"}, "ERROR", "Unmarshall error (bandit.go):", err); errLog != nil {
-			fmt.Println("glbgelf error: ", errLog)
-		}
-
-		if errLog := glbgelf.Logger.SendLog(map[string]interface{}{
-			"action": "BanditStartAnalysis",
-			"info":   "BANDIT"}, "INFO", "cOutput result:", cOutput); errLog != nil {
-			fmt.Println("glbgelf error: ", errLog)
-		}
+		log.Error("BanditStartAnalysis", "BANDIT", 1006, cOutput, err)
 		return
 	}
 
@@ -82,11 +68,7 @@ func BanditStartAnalysis(CID string, cOutput string) {
 		}
 		err := UpdateOneDBAnalysisContainer(analysisQuery, updateContainerAnalysisQuery)
 		if err != nil {
-			if errLog := glbgelf.Logger.SendLog(map[string]interface{}{
-				"action": "BanditStartAnalysis",
-				"info":   "BANDIT"}, "ERROR", "Error updating AnalysisCollection (inside bandit.go):", err); errLog != nil {
-				fmt.Println("glbgelf error: ", errLog)
-			}
+			log.Error("BanditStartAnalysis", "BANDIT", 2007, "Step 2", err)
 		}
 	}
 
@@ -106,11 +88,7 @@ func BanditStartAnalysis(CID string, cOutput string) {
 		},
 	}
 	if err := UpdateOneDBAnalysisContainer(analysisQuery, updateContainerAnalysisQuery); err != nil {
-		if errLog := glbgelf.Logger.SendLog(map[string]interface{}{
-			"action": "BanditStartAnalysis",
-			"info":   "BANDIT"}, "ERROR", "Error updating AnalysisCollection (inside bandit.go):", err); errLog != nil {
-			fmt.Println("glbgelf error: ", errLog)
-		}
+		log.Error("BanditStartAnalysis", "BANDIT", 2007, "Step 3", err)
 		return
 	}
 }

--- a/analysis/brakeman.go
+++ b/analysis/brakeman.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/globocom/glbgelf"
+	"github.com/globocom/huskyci/log"
 	"gopkg.in/mgo.v2/bson"
 )
 
@@ -40,11 +40,7 @@ func BrakemanStartAnalysis(CID string, cOutput string) {
 		}
 		err := UpdateOneDBAnalysisContainer(analysisQuery, updateContainerAnalysisQuery)
 		if err != nil {
-			if errLog := glbgelf.Logger.SendLog(map[string]interface{}{
-				"action": "BrakemanStartAnalysis",
-				"info":   "BRAKEMAN"}, "ERROR", "Error updating AnalysisCollection (inside brakeman.go):", err); errLog != nil {
-				fmt.Println("glbgelf error: ", errLog)
-			}
+			log.Error("BrakemanStartAnalysis", "BRAKEMAN", 2007, "Step 0.1 ", err)
 		}
 		return
 	}
@@ -60,11 +56,7 @@ func BrakemanStartAnalysis(CID string, cOutput string) {
 		}
 		err := UpdateOneDBAnalysisContainer(analysisQuery, updateContainerAnalysisQuery)
 		if err != nil {
-			if errLog := glbgelf.Logger.SendLog(map[string]interface{}{
-				"action": "BrakemanStartAnalysis",
-				"info":   "BRAKEMAN"}, "ERROR", "Error updating AnalysisCollection (inside brakeman.go):", err); errLog != nil {
-				fmt.Println("glbgelf error: ", errLog)
-			}
+			log.Error("BrakemanStartAnalysis", "BRAKEMAN", 2007, "Step 0.2 ", err)
 		}
 		return
 	}
@@ -73,11 +65,7 @@ func BrakemanStartAnalysis(CID string, cOutput string) {
 	brakemanOutput := BrakemanOutput{}
 	err := json.Unmarshal([]byte(cOutput), &brakemanOutput)
 	if err != nil {
-		if errLog := glbgelf.Logger.SendLog(map[string]interface{}{
-			"action": "BrakemanStartAnalysis",
-			"info":   "BRAKEMAN"}, "ERROR", "Unmarshall error (brakeman.go):", err); errLog != nil {
-			fmt.Println("glbgelf error: ", errLog)
-		}
+		log.Error("BrakemanStartAnalysis", "BRAKEMAN", 1005, cOutput, err)
 		return
 	}
 
@@ -95,11 +83,7 @@ func BrakemanStartAnalysis(CID string, cOutput string) {
 	}
 	err = UpdateOneDBAnalysisContainer(analysisQuery, updateContainerAnalysisQuery)
 	if err != nil {
-		if errLog := glbgelf.Logger.SendLog(map[string]interface{}{
-			"action": "BrakemanStartAnalysis",
-			"info":   "BRAKEMAN"}, "ERROR", "Error updating AnalysisCollection (inside brakeman.go):", err); errLog != nil {
-			fmt.Println("glbgelf error: ", errLog)
-		}
+		log.Error("BrakemanStartAnalysis", "BRAKEMAN", 2007, "Step 3 ", err)
 		return
 	}
 }

--- a/analysis/enry.go
+++ b/analysis/enry.go
@@ -10,7 +10,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/globocom/glbgelf"
+	"github.com/globocom/huskyci/log"
 	"github.com/globocom/huskyci/types"
 	"gopkg.in/mgo.v2/bson"
 )
@@ -22,11 +22,7 @@ func EnryStartAnalysis(CID string, cOutput string, RID string) {
 	analysisQuery := map[string]interface{}{"containers.CID": CID}
 	analysis, err := FindOneDBAnalysis(analysisQuery)
 	if err != nil {
-		if errLog := glbgelf.Logger.SendLog(map[string]interface{}{
-			"action": "EnryStartAnalysis",
-			"info":   "ENRY"}, "ERROR", "Could not find analysis by this CID:", err); errLog != nil {
-			fmt.Println("glbgelf error: ", errLog)
-		}
+		log.Error("EnryStartAnalysis", "ENRY", 2008, CID, err)
 		return
 	}
 
@@ -41,11 +37,7 @@ func EnryStartAnalysis(CID string, cOutput string, RID string) {
 		}
 		err := UpdateOneDBAnalysisContainer(analysisQuery, updateContainerAnalysisQuery)
 		if err != nil {
-			if errLog := glbgelf.Logger.SendLog(map[string]interface{}{
-				"action": "EnryStartAnalysis",
-				"info":   "ENRY"}, "ERROR", "Error updating AnalysisCollection (inside enry.go):", err); errLog != nil {
-				fmt.Println("glbgelf error: ", errLog)
-			}
+			log.Error("EnryStartAnalysis", "ENRY", 2007, err)
 		}
 		return
 	}
@@ -54,11 +46,7 @@ func EnryStartAnalysis(CID string, cOutput string, RID string) {
 	mapLanguages := make(map[string][]interface{})
 	err = json.Unmarshal([]byte(cOutput), &mapLanguages)
 	if err != nil {
-		if errLog := glbgelf.Logger.SendLog(map[string]interface{}{
-			"action": "EnryStartAnalysis",
-			"info":   "ENRY"}, "ERROR", "Unmarshall error (enry.go):", err); errLog != nil {
-			fmt.Println("glbgelf error: ", errLog)
-		}
+		log.Error("EnryStartAnalysis", "ENRY", 1003, cOutput, err)
 		return
 	}
 	repositoryLanguages := []types.Language{}
@@ -69,11 +57,7 @@ func EnryStartAnalysis(CID string, cOutput string, RID string) {
 			if reflect.TypeOf(f).String() == "string" {
 				fs = append(fs, f.(string))
 			} else {
-				if errLog := glbgelf.Logger.SendLog(map[string]interface{}{
-					"action": "EnryStartAnalysis",
-					"info":   "ENRY"}, "ERROR", "Error mapping languages."); errLog != nil {
-					fmt.Println("glbgelf error: ", errLog)
-				}
+				log.Error("EnryStartAnalysis", "ENRY", 1004, err)
 				return
 			}
 		}
@@ -90,11 +74,7 @@ func EnryStartAnalysis(CID string, cOutput string, RID string) {
 	genericSecurityTestQuery := map[string]interface{}{"language": "Generic", "default": true}
 	genericSecurityTests, err := FindAllDBSecurityTest(genericSecurityTestQuery)
 	if err != nil {
-		if errLog := glbgelf.Logger.SendLog(map[string]interface{}{
-			"action": "EnryStartAnalysis",
-			"info":   "ENRY"}, "ERROR", "Error finding securityTest (language=Generic and default=true):", err); errLog != nil {
-			fmt.Println("glbgelf error: ", errLog)
-		}
+		log.Error("EnryStartAnalysis", "ENRY", 2009, err)
 		return
 	}
 
@@ -105,7 +85,7 @@ func EnryStartAnalysis(CID string, cOutput string, RID string) {
 		languageSecurityTestResult, err := FindOneDBSecurityTest(languageSecurityTestQuery)
 		if err == nil {
 			newLanguageSecurityTests = append(newLanguageSecurityTests, languageSecurityTestResult)
-		} // else {} is OK to not find a securityTest by language.Name! for the future: log this error?
+		}
 	}
 
 	allSecurityTests := append(genericSecurityTests, newLanguageSecurityTests...)
@@ -120,11 +100,7 @@ func EnryStartAnalysis(CID string, cOutput string, RID string) {
 	}
 	err = UpdateOneDBRepository(repositoryQuery, updateRepositoryQuery)
 	if err != nil {
-		if errLog := glbgelf.Logger.SendLog(map[string]interface{}{
-			"action": "EnryStartAnalysis",
-			"info":   "ENRY"}, "ERROR", "Could not update repository's securityTests:", err); errLog != nil {
-			fmt.Println("glbgelf error: ", errLog)
-		}
+		log.Error("EnryStartAnalysis", "ENRY", 2010, err)
 		return
 	}
 
@@ -132,11 +108,7 @@ func EnryStartAnalysis(CID string, cOutput string, RID string) {
 	analysis.SecurityTests = allSecurityTests
 	err = UpdateOneDBAnalysis(analysisQuery, analysis)
 	if err != nil {
-		if errLog := glbgelf.Logger.SendLog(map[string]interface{}{
-			"action": "EnryStartAnalysis",
-			"info":   "ENRY"}, "ERROR", "Error updating AnalysisCollection:", err); errLog != nil {
-			fmt.Println("glbgelf error: ", errLog)
-		}
+		log.Error("EnryStartAnalysis", "ENRY", 2007, err)
 		return
 	}
 

--- a/analysis/gosec.go
+++ b/analysis/gosec.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/globocom/glbgelf"
+	"github.com/globocom/huskyci/log"
 	"gopkg.in/mgo.v2/bson"
 )
 
@@ -54,11 +54,7 @@ func GosecStartAnalysis(CID string, cOutput string) {
 		}
 		err := UpdateOneDBAnalysisContainer(analysisQuery, updateContainerAnalysisQuery)
 		if err != nil {
-			if errLog := glbgelf.Logger.SendLog(map[string]interface{}{
-				"action": "GosecStartAnalysis",
-				"info":   "GOSEC"}, "ERROR", "Error updating AnalysisCollection (inside gosec.go):", err); errLog != nil {
-				fmt.Println("glbgelf error: ", errLog)
-			}
+			log.Error("GosecStartAnalysis", "GOSEC", 2007, "Step 0.1 ", err)
 		}
 		return
 	}
@@ -74,11 +70,7 @@ func GosecStartAnalysis(CID string, cOutput string) {
 		}
 		err := UpdateOneDBAnalysisContainer(analysisQuery, updateContainerAnalysisQuery)
 		if err != nil {
-			if errLog := glbgelf.Logger.SendLog(map[string]interface{}{
-				"action": "GosecStartAnalysis",
-				"info":   "GOSEC"}, "ERROR", "Error updating AnalysisCollection (inside gosec.go):", err); errLog != nil {
-				fmt.Println("glbgelf error: ", errLog)
-			}
+			log.Error("GosecStartAnalysis", "GOSEC", 2007, "Step 0.2 ", err)
 		}
 		return
 	}
@@ -87,16 +79,7 @@ func GosecStartAnalysis(CID string, cOutput string) {
 	gosecOutput := GosecOutput{}
 	err := json.Unmarshal([]byte(cOutput), &gosecOutput)
 	if err != nil {
-		if errLog := glbgelf.Logger.SendLog(map[string]interface{}{
-			"action": "GosecStartAnalysis",
-			"info":   "GOSEC"}, "ERROR", "Unmarshall error (gosec.go):", err); errLog != nil {
-			fmt.Println("glbgelf error: ", errLog)
-		}
-		if errLog := glbgelf.Logger.SendLog(map[string]interface{}{
-			"action": "GosecStartAnalysis",
-			"info":   "GOSEC"}, "ERROR", cOutput); errLog != nil {
-			fmt.Println("glbgelf error: ", errLog)
-		}
+		log.Error("GosecStartAnalysis", "GOSEC", 1002, cOutput, err)
 		return
 	}
 
@@ -117,11 +100,7 @@ func GosecStartAnalysis(CID string, cOutput string) {
 	}
 	err = UpdateOneDBAnalysisContainer(analysisQuery, updateContainerAnalysisQuery)
 	if err != nil {
-		if errLog := glbgelf.Logger.SendLog(map[string]interface{}{
-			"action": "GosecStartAnalysis",
-			"info":   "GOSEC"}, "ERROR", "Error updating AnalysisCollection (inside gosec.go):", err); errLog != nil {
-			fmt.Println("glbgelf error: ", errLog)
-		}
+		log.Error("GosecStartAnalysis", "GOSEC", 2007, "Step 3 ", err)
 		return
 	}
 }

--- a/analysis/huskydb.go
+++ b/analysis/huskydb.go
@@ -6,11 +6,10 @@ package analysis
 
 import (
 	"errors"
-	"fmt"
 	"time"
 
-	"github.com/globocom/glbgelf"
 	db "github.com/globocom/huskyci/db/mongo"
+	"github.com/globocom/huskyci/log"
 	"github.com/globocom/huskyci/types"
 	"gopkg.in/mgo.v2/bson"
 )
@@ -100,11 +99,7 @@ func InsertDBRepository(repository types.Repository) error {
 		securityTestQuery := map[string]interface{}{"default": true, "language": "Generic"}
 		securityTestList, err = FindAllDBSecurityTest(securityTestQuery)
 		if err != nil {
-			if errLog := glbgelf.Logger.SendLog(map[string]interface{}{
-				"action": "InsertDBRepository",
-				"info":   "HUSKYDB"}, "ERROR", "Could not find default securityTests:", err); errLog != nil {
-				fmt.Println("glbgelf error: ", errLog)
-			}
+			log.Error("InsertDBRepository", "HUSKYDB", 2005, err)
 		}
 	} else {
 		// checking if a given securityTestName matches a securityTest
@@ -114,11 +109,7 @@ func InsertDBRepository(repository types.Repository) error {
 				securityTestQuery := map[string]interface{}{"name": securityTestName}
 				securityTestResult, err := FindOneDBSecurityTest(securityTestQuery)
 				if err != nil {
-					if errLog := glbgelf.Logger.SendLog(map[string]interface{}{
-						"action": "InsertDBRepository",
-						"info":   "HUSKYDB"}, "ERROR", "Could not find securityTestName:", securityTestName); errLog != nil {
-						fmt.Println("glbgelf error: ", errLog)
-					}
+					log.Error("InsertDBRepository", "HUSKYDB", 2006, err)
 				} else {
 					securityTestList = append(securityTestList, securityTestResult)
 				}
@@ -128,11 +119,7 @@ func InsertDBRepository(repository types.Repository) error {
 				securityTestQuery := map[string]interface{}{"name": securityTestName}
 				securityTestResult, err := FindOneDBSecurityTest(securityTestQuery)
 				if err != nil {
-					if errLog := glbgelf.Logger.SendLog(map[string]interface{}{
-						"action": "InsertDBRepository",
-						"info":   "HUSKYDB"}, "ERROR", "Could not find securityTestName:", securityTestName); errLog != nil {
-						fmt.Println("glbgelf error: ", errLog)
-					}
+					log.Error("InsertDBRepository", "HUSKYDB", 2006, err)
 				} else {
 					securityTestList = append(securityTestList, securityTestResult)
 				}

--- a/analysis/retirejs.go
+++ b/analysis/retirejs.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/globocom/glbgelf"
+	"github.com/globocom/huskyci/log"
 	"gopkg.in/mgo.v2/bson"
 )
 
@@ -66,11 +66,7 @@ func RetirejsStartAnalysis(CID string, cOutput string) {
 		}
 		err := UpdateOneDBAnalysisContainer(analysisQuery, updateContainerAnalysisQuery)
 		if err != nil {
-			if errLog := glbgelf.Logger.SendLog(map[string]interface{}{
-				"action": "RetirejsStartAnalysis",
-				"info":   "RETIREJS"}, "ERROR", "Error updating AnalysisCollection (inside retirejs.go):", err); errLog != nil {
-				fmt.Println("glbgelf error: ", errLog)
-			}
+			log.Error("RetirejsStartAnalysis", "RETIREJS", 2007, err)
 		}
 		return
 	}
@@ -79,16 +75,7 @@ func RetirejsStartAnalysis(CID string, cOutput string) {
 	retirejsOutput := RetirejsOutput{}
 	err := json.Unmarshal([]byte(cOutput), &retirejsOutput)
 	if err != nil {
-		if errLog := glbgelf.Logger.SendLog(map[string]interface{}{
-			"action": "RetirejsStartAnalysis",
-			"info":   "RETIREJS"}, "ERROR", "Unmarshall error (inside retirejs.go):", err); errLog != nil {
-			fmt.Println("glbgelf error: ", errLog)
-		}
-		if errLog := glbgelf.Logger.SendLog(map[string]interface{}{
-			"action": "RetirejsStartAnalysis",
-			"info":   "RETIREJS"}, "ERROR", cOutput); errLog != nil {
-			fmt.Println("glbgelf error: ", errLog)
-		}
+		log.Error("RetirejsStartAnalysis", "RETIREJS", 1014, cOutput, err)
 		return
 	}
 
@@ -101,11 +88,7 @@ func RetirejsStartAnalysis(CID string, cOutput string) {
 		}
 		err := UpdateOneDBAnalysisContainer(analysisQuery, updateContainerAnalysisQuery)
 		if err != nil {
-			if errLog := glbgelf.Logger.SendLog(map[string]interface{}{
-				"action": "RetirejsStartAnalysis",
-				"info":   "RETIREJS"}, "ERROR", "Error updating AnalysisCollection (inside retirejs.go):", err); errLog != nil {
-				fmt.Println("glbgelf error: ", errLog)
-			}
+			log.Error("RetirejsStartAnalysis", "RETIREJS", 2007, err)
 		}
 		return
 	}
@@ -131,11 +114,7 @@ func RetirejsStartAnalysis(CID string, cOutput string) {
 	}
 	err = UpdateOneDBAnalysisContainer(analysisQuery, updateContainerAnalysisQuery)
 	if err != nil {
-		if errLog := glbgelf.Logger.SendLog(map[string]interface{}{
-			"action": "RetirejsStartAnalysis",
-			"info":   "RETIREJS"}, "ERROR", "Error updating AnalysisCollection (inside retirejs.go):", err); errLog != nil {
-			fmt.Println("glbgelf error: ", errLog)
-		}
+		log.Error("RetirejsStartAnalysis", "RETIREJS", 2007, err)
 		return
 	}
 }

--- a/context/config.go
+++ b/context/config.go
@@ -46,7 +46,8 @@ type APIConfig struct {
 	BrakemanSecurityTest *types.SecurityTest
 }
 
-var ApiConfig *APIConfig
+// APIConfiguration holds all API configuration.
+var APIConfiguration *APIConfig
 var onceConfig sync.Once
 
 func init() {
@@ -59,7 +60,7 @@ func init() {
 // GetAPIConfig returns the instance of an APIConfig.
 func GetAPIConfig() *APIConfig {
 	onceConfig.Do(func() {
-		ApiConfig = &APIConfig{
+		APIConfiguration = &APIConfig{
 			MongoDBConfig:        getMongoConfig(),
 			DockerHostsConfig:    getDockerHostsConfig(),
 			HuskyAPIPort:         getAPIHostPort(),
@@ -69,9 +70,10 @@ func GetAPIConfig() *APIConfig {
 			BrakemanSecurityTest: getBrakemanConfig(),
 		}
 	})
-	return ApiConfig
+	return APIConfiguration
 }
 
+// getDockerHostsConfig gets the Docker API hosts' configuration.
 func getDockerHostsConfig() *DockerHostsConfig {
 
 	dockerAPIPort := getDockerAPIPort()
@@ -138,6 +140,7 @@ func getAPIHostPort() int {
 	return apiPort
 }
 
+// getMongoTimeout returns MongoDB timeout retrieved form an environment variable.
 func getMongoTimeout() time.Duration {
 	mongoTimeout, err := strconv.Atoi(os.Getenv("MONGO_TIMEOUT"))
 	if err != nil {
@@ -146,6 +149,7 @@ func getMongoTimeout() time.Duration {
 	return time.Duration(mongoTimeout) * time.Second
 }
 
+// getMongoPoolLimit returns MongoDB pool limit retrieved form an environment variable.
 func getMongoPoolLimit() int {
 	mongoPoolLimit, err := strconv.Atoi(os.Getenv("MONGO_POOL_LIMIT"))
 	if err != nil && mongoPoolLimit <= 0 {
@@ -153,6 +157,8 @@ func getMongoPoolLimit() int {
 	}
 	return mongoPoolLimit
 }
+
+// getEnryConfig returns Enry configuration form config.yml using viper.
 func getEnryConfig() *types.SecurityTest {
 	return &types.SecurityTest{
 		Name:             viper.GetString("enry.name"),
@@ -164,6 +170,7 @@ func getEnryConfig() *types.SecurityTest {
 	}
 }
 
+// getBrakemanConfig returns Brakeman configuration form config.yml using viper.
 func getBrakemanConfig() *types.SecurityTest {
 	return &types.SecurityTest{
 		Name:             viper.GetString("brakeman.name"),
@@ -175,6 +182,7 @@ func getBrakemanConfig() *types.SecurityTest {
 	}
 }
 
+// getGosecConfig returns Gosec configuration form config.yml using viper.
 func getGosecConfig() *types.SecurityTest {
 	return &types.SecurityTest{
 		Name:             viper.GetString("gosec.name"),
@@ -186,6 +194,7 @@ func getGosecConfig() *types.SecurityTest {
 	}
 }
 
+// getBanditConfig returns Bandit configuration form config.yml using viper.
 func getBanditConfig() *types.SecurityTest {
 	return &types.SecurityTest{
 		Name:             viper.GetString("bandit.name"),
@@ -196,6 +205,8 @@ func getBanditConfig() *types.SecurityTest {
 		TimeOutInSeconds: viper.GetInt("bandit.timeOutInSeconds"),
 	}
 }
+
+// loagViper loads Vipers configuration using config.yml file.
 func loadViper() error {
 	viper.SetConfigName("config")
 	viper.AddConfigPath(".")

--- a/log/log.go
+++ b/log/log.go
@@ -1,0 +1,60 @@
+package log
+
+import (
+	"log"
+	"os"
+	"strings"
+
+	"github.com/globocom/glbgelf"
+)
+
+// InitLog starts glbgelf logging.
+func InitLog() {
+
+	isDev := true
+	graylogAddr := os.Getenv("HUSKYCI_GRAYLOG_ADDR")
+	gralogProto := os.Getenv("HUSKYCI_GRAYLOG_PROTO")
+	appName := os.Getenv("HUSKYCI_APP_NAME")
+	tags := os.Getenv("HUSKYCI_TAGS")
+
+	if strings.EqualFold(os.Getenv("HUSKYCI_DEV"), "false") {
+		isDev = false
+	}
+
+	glbgelf.InitLogger(graylogAddr, appName, tags, isDev, gralogProto)
+}
+
+// Info sends an info type log using glbgelf.
+func Info(action, info string, msgCode int, message ...interface{}) {
+	if err := glbgelf.Logger.SendLog(map[string]interface{}{
+		"action": action,
+		"info":   info},
+		"INFO", MsgCode[msgCode], message); err != nil {
+		ErrorGlbgelf(err)
+	}
+}
+
+// Warning sends a warning type log using glbgelf.
+func Warning(action, info string, msgCode int, message ...interface{}) {
+	if err := glbgelf.Logger.SendLog(map[string]interface{}{
+		"action": action,
+		"info":   info},
+		"WARNING", MsgCode[msgCode], message); err != nil {
+		ErrorGlbgelf(err)
+	}
+}
+
+// Error sends an error type log using glbgelf.
+func Error(action, info string, msgCode int, message ...interface{}) {
+	if err := glbgelf.Logger.SendLog(map[string]interface{}{
+		"action": action,
+		"info":   info},
+		"ERROR", MsgCode[msgCode], message); err != nil {
+		ErrorGlbgelf(err)
+	}
+}
+
+// ErrorGlbgelf handles glbgelf error.
+func ErrorGlbgelf(err error) {
+	log.Println(err)
+}

--- a/log/messagecodes.go
+++ b/log/messagecodes.go
@@ -1,0 +1,97 @@
+package log
+
+// MsgCode holds all log messages and their respective codes.
+var MsgCode = map[int]string{
+
+	// HuskyCI API infos
+	11: "Starting HuskyCI",
+	12: "Environment variables set properly.",
+	13: "Docker API is up and running.",
+	14: "Connection with MongoDB succeed.",
+	15: "Default securityTests found on MongoDB.",
+	16: "Request received to start the following branch and repository: ",
+	17: "Repository created into MongoDB: ",
+	18: "SecurityTest created into MongoDB: ",
+
+	// HuskyCI API warnings
+	101: "Received an invalid repository JSON.",
+	102: "Received an invalid repository URL: ",
+	103: "Received an invalid repository branch: ",
+	104: "An analysis is already in place for this URL: ",
+	105: "The following analysis timed out inside MonitorAnalysis: ",
+	106: "Analysis not found using the following RID: ",
+	107: "Received an invalid RID: ",
+	108: "Received an invalid security Test JSON: ",
+	109: "The following security test is already in MongoDB: ",
+	110: "The following repository is already in MongoDB: ",
+
+	// HuskyCI API errors
+	1001: "Error(s) found when starting HuskyCI API: ",
+	1002: "Could not Unmarshall the following gosecOutput: ",
+	1003: "Could not Unmarshall the following enryOutput: ",
+	1004: "Error mapping languages: ",
+	1005: "Could not Unmarshall the following brakemanOutput: ",
+	1006: "Could not Unmarshall the following banditOutput: ",
+	1007: "Could not bind repository JSON: ",
+	1008: "Internal error MatchString: ",
+	1009: "MongoDB message in FindOneDBAnalysis: ",
+	1010: "Internal error inserting repository received into MongoDB: ",
+	1011: "Internal error finding repository just inserted into MongoDB: ",
+	1012: "MongoDB message in FindOneDBSecurityTest: ",
+	1013: "MongoDB message in FindOneDBRepository: ",
+
+	// MongoDB infos
+	21: "Connecting to MongoDB.",
+	22: "Initializing MongoDB auto reconnect.",
+	23: "Reconnect to MongoDB successful.",
+
+	// MongoDB warnings
+	201: "Enry securityTest not found.",
+	202: "Gosec securityTest not found.",
+	203: "Brakeman securityTest not found.",
+	204: "Bandit securityTest not found.",
+
+	// MongoDB errors
+	2001: "Error connecting to MongoDB: ",
+	2002: "Error pinging MongoDB after connection: ",
+	2003: "Error pinging MongoDB in autoReconnect: ",
+	2004: "Reconnect to MongoDB failed: ",
+	2005: "Could not find default securityTests: ",
+	2006: "Could not find securityTestName: ",
+	2007: "Could not update AnalysisCollection: ",
+	2008: "Could not find an analysis using the following CID: ",
+	2009: "Error finding securityTest (language=Generic and default=true): ",
+	2010: "Could not update repository's securityTests: ",
+	2011: "Error inserting new analysis: ",
+	2012: "Could not find securityTest into MongoDB using the following name: ",
+	2013: "Could not update container status to timedout of an analysis: ",
+	2014: "Could not find an analysis using the following RID: ",
+	2015: "Could not create a new repository: ",
+	2016: "Could not create a new securityTest: ",
+
+	// Docker API info
+	31: "Waiting pull image...",
+
+	// Docker API warning
+	301: "",
+
+	// Docker API errors
+	3001: "Could not set DOCKER_HOST enviroment variable.",
+	3002: "Could not start a new Docker API client: ",
+	3003: "Could not read/parse private/public key pair: ",
+	3004: "Could not read carootFile: ",
+	3005: "Could not create a new container via d.client: ",
+	3006: "Could not get containers' logs: ",
+	3007: "Could not read containers' STDOUT: ",
+	3008: "Could not read containers' STDERR: ",
+	3009: "Could not pull image into Docker API via d.client: ",
+	3010: "Could not get docker image list from Docker API: ",
+	3011: "Docker API Healthcheck failed: ",
+	3012: "Could not create a new docker via HuskyCI: ",
+	3013: "Could not pull image via HuskyCI: ",
+	3014: "Could not create a new container via HuskyCI: ",
+	3015: "Could not start a new container via HuskyCI: ",
+	3016: "Could not wait container via HuskyCI: ",
+	3017: "Could not read container output via HuskyCI: ",
+	3018: "Unexpected securityTest.Name: ",
+}

--- a/log/messagecodes.go
+++ b/log/messagecodes.go
@@ -4,7 +4,7 @@ package log
 var MsgCode = map[int]string{
 
 	// HuskyCI API infos
-	11: "Starting HuskyCI",
+	11: "Starting HuskyCI.",
 	12: "Environment variables set properly.",
 	13: "Docker API is up and running.",
 	14: "Connection with MongoDB succeed.",
@@ -14,9 +14,6 @@ var MsgCode = map[int]string{
 	18: "SecurityTest created into MongoDB: ",
 
 	// HuskyCI API warnings
-	101: "Received an invalid repository JSON.",
-	102: "Received an invalid repository URL: ",
-	103: "Received an invalid repository branch: ",
 	104: "An analysis is already in place for this URL: ",
 	105: "The following analysis timed out inside MonitorAnalysis: ",
 	106: "Analysis not found using the following RID: ",
@@ -40,6 +37,9 @@ var MsgCode = map[int]string{
 	1012: "MongoDB message in FindOneDBSecurityTest: ",
 	1013: "MongoDB message in FindOneDBRepository: ",
 	1014: "Could not Unmarshall the following retirejsOutput: ",
+	1015: "Received an invalid repository JSON: ",
+	1016: "Received an invalid repository URL: ",
+	1017: "Received an invalid repository branch: ",
 
 	// MongoDB infos
 	21: "Connecting to MongoDB.",

--- a/log/messagecodes.go
+++ b/log/messagecodes.go
@@ -39,6 +39,7 @@ var MsgCode = map[int]string{
 	1011: "Internal error finding repository just inserted into MongoDB: ",
 	1012: "MongoDB message in FindOneDBSecurityTest: ",
 	1013: "MongoDB message in FindOneDBRepository: ",
+	1014: "Could not Unmarshall the following retirejsOutput: ",
 
 	// MongoDB infos
 	21: "Connecting to MongoDB.",
@@ -50,6 +51,7 @@ var MsgCode = map[int]string{
 	202: "Gosec securityTest not found.",
 	203: "Brakeman securityTest not found.",
 	204: "Bandit securityTest not found.",
+	205: "RetireJS securityTest not found.",
 
 	// MongoDB errors
 	2001: "Error connecting to MongoDB: ",

--- a/server.go
+++ b/server.go
@@ -197,11 +197,7 @@ func checkDefaultSecurityTests(configAPI *apiContext.APIConfig) error {
 	retirejs, err := analysis.FindOneDBSecurityTest(retirejsQuery)
 	if err == mgo.ErrNotFound {
 		// As RetireJS securityTest is not set into MongoDB, HuskyCI will insert it.
-		if errLog := glbgelf.Logger.SendLog(map[string]interface{}{
-			"action": "checkDefaultSecurityTests",
-			"info":   "SERVER"}, "ERROR", "RetireJS securityTest not found!"); errLog != nil {
-			fmt.Println("glbgelf error: ", errLog)
-		}
+		log.Warning("checkDefaultSecurityTests", "SERVER", 205)
 		retirejs = *configAPI.RetirejsSecurityTest
 		if err := analysis.InsertDBSecurityTest(retirejs); err != nil {
 			return err

--- a/server.go
+++ b/server.go
@@ -9,13 +9,12 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"strings"
 
-	"github.com/globocom/glbgelf"
 	"github.com/globocom/huskyci/analysis"
 	apiContext "github.com/globocom/huskyci/context"
 	db "github.com/globocom/huskyci/db/mongo"
 	docker "github.com/globocom/huskyci/dockers"
+	"github.com/globocom/huskyci/log"
 	"github.com/globocom/huskyci/types"
 	"github.com/labstack/echo"
 	"github.com/labstack/echo/middleware"
@@ -32,29 +31,14 @@ const projectName = "HuskyCI"
 
 func main() {
 
+	log.InitLog()
+	log.Info("main", "SERVER", 11)
+
 	configAndPrintVersion(version, commit, date)
-
-	isDev := true
-	if strings.EqualFold(os.Getenv("HUSKYCI_DEV"), "false") {
-		isDev = false
-	}
-
-	glbgelf.InitLogger(os.Getenv("HUSKYCI_GRAYLOG_ADDR"), os.Getenv("HUSKYCI_APP_NAME"), os.Getenv("HUSKYCI_TAGS"), isDev, os.Getenv("HUSKYCI_GRAYLOG_PROTO"))
-
-	if errLog := glbgelf.Logger.SendLog(map[string]interface{}{
-		"action": "main",
-		"info":   "SERVER"}, "INFO", "Starting Husky..."); errLog != nil {
-		fmt.Println("glbgelf error: ", errLog)
-	}
-
 	configAPI := apiContext.GetAPIConfig()
 
 	if err := checkHuskyRequirements(configAPI); err != nil {
-		if errLog := glbgelf.Logger.SendLog(map[string]interface{}{
-			"action": "main",
-			"info":   "SERVER"}, "ERROR", "Error starting Husky:", err); errLog != nil {
-			fmt.Println("glbgelf error: ", errLog)
-		}
+		log.Error("main", "SERVER", 1001, err)
 		os.Exit(1)
 	}
 
@@ -82,45 +66,25 @@ func checkHuskyRequirements(configAPI *apiContext.APIConfig) error {
 	if err := checkEnvVars(); err != nil {
 		return err
 	}
-
-	if errLog := glbgelf.Logger.SendLog(map[string]interface{}{
-		"action": "checkHuskyRequirements",
-		"info":   "SERVER"}, "INFO", "Environment Variables: OK!"); errLog != nil {
-		fmt.Println("glbgelf error: ", errLog)
-	}
+	log.Info("checkHuskyRequirements", "SERVER", 12)
 
 	// check if all docker hosts are up and running docker API.
 	if err := checkDockerHosts(configAPI); err != nil {
 		return err
 	}
-
-	if errLog := glbgelf.Logger.SendLog(map[string]interface{}{
-		"action": "checkHuskyRequirements",
-		"info":   "SERVER"}, "INFO", "Docker API Hosts: OK!"); errLog != nil {
-		fmt.Println("glbgelf error: ", errLog)
-	}
+	log.Info("checkHuskyRequirements", "SERVER", 13)
 
 	// check if MongoDB is acessible and credentials received are working.
 	if err := checkMongoDB(); err != nil {
 		return err
 	}
-
-	if errLog := glbgelf.Logger.SendLog(map[string]interface{}{
-		"action": "checkHuskyRequirements",
-		"info":   "SERVER"}, "INFO", "MongoDB: OK!"); errLog != nil {
-		fmt.Println("glbgelf error: ", errLog)
-	}
+	log.Info("checkHuskyRequirements", "SERVER", 14)
 
 	// check if default securityTests are set into MongoDB.
 	if err := checkDefaultSecurityTests(configAPI); err != nil {
 		return err
 	}
-
-	if errLog := glbgelf.Logger.SendLog(map[string]interface{}{
-		"action": "checkHuskyRequirements",
-		"info":   "SERVER"}, "INFO", "Default security tests set: OK!"); errLog != nil {
-		fmt.Println("glbgelf error: ", errLog)
-	}
+	log.Info("checkHuskyRequirements", "SERVER", 15)
 
 	return nil
 }
@@ -157,7 +121,7 @@ func checkEnvVars() error {
 	}
 
 	if allEnvIsSet == false {
-		finalError := fmt.Sprintf("check environment variables: %s", errorString)
+		finalError := fmt.Sprintf("Check environment variables: %s", errorString)
 		return errors.New(finalError)
 	}
 
@@ -169,14 +133,10 @@ func checkDockerHosts(configAPI *apiContext.APIConfig) error {
 }
 
 func checkMongoDB() error {
-
-	err := db.Connect()
-
-	if err != nil {
-		mongoError := fmt.Sprintf("check mongoDB: %s", err)
+	if err := db.Connect(); err != nil {
+		mongoError := fmt.Sprintf("Check MongoDB: %s", err)
 		return errors.New(mongoError)
 	}
-
 	return nil
 }
 
@@ -185,11 +145,7 @@ func checkDefaultSecurityTests(configAPI *apiContext.APIConfig) error {
 	enry, err := analysis.FindOneDBSecurityTest(enryQuery)
 	if err == mgo.ErrNotFound {
 		// As Enry securityTest is not set into MongoDB, HuskyCI will insert it.
-		if errLog := glbgelf.Logger.SendLog(map[string]interface{}{
-			"action": "checkDefaultSecurityTests",
-			"info":   "SERVER"}, "ERROR", "Enry securityTest not found!"); errLog != nil {
-			fmt.Println("glbgelf error: ", errLog)
-		}
+		log.Warning("checkDefaultSecurityTests", "SERVER", 201)
 		enry = *configAPI.EnrySecurityTest
 		if err := analysis.InsertDBSecurityTest(enry); err != nil {
 			return err
@@ -202,11 +158,7 @@ func checkDefaultSecurityTests(configAPI *apiContext.APIConfig) error {
 	gosec, err := analysis.FindOneDBSecurityTest(gosecQuery)
 	if err == mgo.ErrNotFound {
 		// As Gosec securityTest is not set into MongoDB, HuskyCI will insert it.
-		if errLog := glbgelf.Logger.SendLog(map[string]interface{}{
-			"action": "checkDefaultSecurityTests",
-			"info":   "SERVER"}, "ERROR", "Gosec securityTest not found!"); errLog != nil {
-			fmt.Println("glbgelf error: ", errLog)
-		}
+		log.Warning("checkDefaultSecurityTests", "SERVER", 202)
 		gosec = *configAPI.GosecSecurityTest
 		if err := analysis.InsertDBSecurityTest(gosec); err != nil {
 			return err
@@ -219,11 +171,7 @@ func checkDefaultSecurityTests(configAPI *apiContext.APIConfig) error {
 	brakeman, err := analysis.FindOneDBSecurityTest(brakemanQuery)
 	if err == mgo.ErrNotFound {
 		// As Brakeman securityTest is not set into MongoDB, HuskyCI will insert it.
-		if errLog := glbgelf.Logger.SendLog(map[string]interface{}{
-			"action": "checkDefaultSecurityTests",
-			"info":   "SERVER"}, "ERROR", "Brakeman securityTest not found!"); errLog != nil {
-			fmt.Println("glbgelf error: ", errLog)
-		}
+		log.Warning("checkDefaultSecurityTests", "SERVER", 203)
 		brakeman = *configAPI.BrakemanSecurityTest
 		if err := analysis.InsertDBSecurityTest(brakeman); err != nil {
 			return err
@@ -236,11 +184,7 @@ func checkDefaultSecurityTests(configAPI *apiContext.APIConfig) error {
 	bandit, err := analysis.FindOneDBSecurityTest(banditQuery)
 	if err == mgo.ErrNotFound {
 		// As Bandit securityTest is not set into MongoDB, HuskyCI will insert it.
-		if errLog := glbgelf.Logger.SendLog(map[string]interface{}{
-			"action": "checkDefaultSecurityTests",
-			"info":   "SERVER"}, "ERROR", "Bandit securityTest not found!"); errLog != nil {
-			fmt.Println("glbgelf error: ", errLog)
-		}
+		log.Warning("checkDefaultSecurityTests", "SERVER", 204)
 		bandit = *configAPI.BanditSecurityTest
 		if err := analysis.InsertDBSecurityTest(bandit); err != nil {
 			return err


### PR DESCRIPTION
## Closes #142 

#### Makefile :
* Fix `get-deps` into `get-test-deps`.

#### analysis/* :
* Some messages that were being returned to the API user as `c.JSON` is now being using `c.STRING`.
* Added log package into all files that were using glbgelf.
* Added a new validation into `StatusAnalysis` function to avoid malicious users abusing the API by injecting MongoDB queries into `RID` parameter.
