### PR TITLE
Add HTTPS functionality to client and util package

### DIFF
--- a/api/analysis/dockerrun.go
+++ b/api/analysis/dockerrun.go
@@ -5,13 +5,12 @@
 package analysis
 
 import (
-	"os"
-	"strings"
 	"time"
 
 	docker "github.com/globocom/huskyci/api/dockers"
 	"github.com/globocom/huskyci/api/log"
 	"github.com/globocom/huskyci/api/types"
+	"github.com/globocom/huskyci/util"
 	"gopkg.in/mgo.v2/bson"
 )
 
@@ -19,7 +18,7 @@ import (
 func DockerRun(RID string, analysis *types.Analysis, securityTest types.SecurityTest) {
 
 	newContainer := types.Container{SecurityTest: securityTest}
-	securityTest.Cmd = handlePrivateSSHKey(securityTest.Cmd)
+	securityTest.Cmd = util.HandlePrivateSSHKey(securityTest.Cmd)
 
 	d, err := docker.NewDocker()
 	if err != nil {
@@ -198,11 +197,6 @@ func dockerRunRegisterError(d *docker.Docker, analysis *types.Analysis) error {
 		return err
 	}
 	return nil
-}
-
-func handlePrivateSSHKey(rawString string) string {
-	cmdReplaced := strings.Replace(rawString, "GIT_PRIVATE_SSH_KEY", os.Getenv("GIT_PRIVATE_SSH_KEY"), -1)
-	return cmdReplaced
 }
 
 func dockerPullImage(d *docker.Docker, image string) error {

--- a/api/log/messagecodes.go
+++ b/api/log/messagecodes.go
@@ -82,8 +82,6 @@ var MsgCode = map[int]string{
 	// Docker API errors
 	3001: "Could not set DOCKER_HOST enviroment variable.",
 	3002: "Could not start a new Docker API client: ",
-	3003: "Could not read/parse private/public key pair: ",
-	3004: "Could not read carootFile: ",
 	3005: "Could not create a new container via d.client: ",
 	3006: "Could not get containers' logs: ",
 	3007: "Could not read containers' STDOUT: ",
@@ -98,4 +96,8 @@ var MsgCode = map[int]string{
 	3016: "Could not wait container via HuskyCI: ",
 	3017: "Could not read container output via HuskyCI: ",
 	3018: "Unexpected securityTest.Name: ",
+
+	// Util package errors
+	4001: "Could not read certificate file: ",
+	4002: "Could not append ceritificates: ",
 }

--- a/api/server.go
+++ b/api/server.go
@@ -16,6 +16,7 @@ import (
 	docker "github.com/globocom/huskyci/api/dockers"
 	"github.com/globocom/huskyci/api/log"
 	"github.com/globocom/huskyci/api/types"
+	"github.com/globocom/huskyci/util"
 	"github.com/labstack/echo"
 	"github.com/labstack/echo/middleware"
 	mgo "gopkg.in/mgo.v2"
@@ -57,7 +58,7 @@ func main() {
 	echoInstance.POST("/repository", analysis.CreateNewRepository)
 
 	huskyAPIport := fmt.Sprintf(":%d", configAPI.HuskyAPIPort)
-	echoInstance.Logger.Fatal(echoInstance.Start(huskyAPIport))
+	echoInstance.Logger.Fatal(echoInstance.StartTLS(huskyAPIport, util.CertFile, util.KeyFile))
 }
 
 func checkHuskyRequirements(configAPI *apiContext.APIConfig) error {

--- a/deployments/scripts/create-certs.sh
+++ b/deployments/scripts/create-certs.sh
@@ -84,6 +84,10 @@ function checkCAFilesExist {
     fi
 }
 
+function createTLSCert {
+    openssl req -x509 -newkey rsa:4096 -keyout $TARGETDIR/api-tls-key.pem -out $TARGETDIR/api-tls-cert.pem -days 365 -nodes -subj '/CN=localhost'
+}
+
 function createServerCert {
     checkCAFilesExist
 
@@ -132,6 +136,8 @@ elif [[ $MODE = "server" ]]; then
     createServerCert
 elif [[ $MODE = "client" ]]; then
     createClientCert
+elif [[ $MODE = "tls" ]]; then
+    createTLSCert
 else
     usage
 fi

--- a/deployments/scripts/generate-env-pass.sh
+++ b/deployments/scripts/generate-env-pass.sh
@@ -6,7 +6,7 @@
 # huskyCI client default vars
 HUSKYCI_REPO_URL="https://github.com/globocom/huskyci.git"
 HUSKYCI_REPO_BRANCH="master"
-HUSKYCI_API="http://localhost:8888"
+HUSKYCI_API="https://localhost:8888"
 
 # Generating "random" passwords
 CERT_PASSPHRASE_TMP="certPass$RANDOM$RANDOM"
@@ -24,8 +24,8 @@ echo "export MONGO_DATABASE_PASSWORD=\"$MONGO_DATABASE_PASSWORD_TMP\"" >> .env
 
 # Adding default envs vars to run client
 echo "export HUSKYCI_REPO_URL=\"$HUSKYCI_REPO_URL\"" >> .env
-echo "export HUSKYCI_REPO_URL=\"$HUSKYCI_REPO_BRANCH\"" >> .env
-echo "export HUSKYCI_REPO_URL=\"$HUSKYCI_API\"" >> .env
+echo "export HUSKYCI_REPO_BRANCH=\"$HUSKYCI_REPO_BRANCH\"" >> .env
+echo "export HUSKYCI_API=\"$HUSKYCI_API\"" >> .env
 
 # Preparing script to create mongoDB default user
 cat << EOF > deployments/mongo-init.js

--- a/deployments/scripts/run-create-certs.sh
+++ b/deployments/scripts/run-create-certs.sh
@@ -8,4 +8,4 @@ rm -rf deployments/certs/*
 ./deployments/scripts/create-certs.sh -m ca -pw $CERT_PASSPHRASE -t deployments/certs -e 900
 ./deployments/scripts/create-certs.sh -m server -h dockerapi -pw $CERT_PASSPHRASE -t deployments/certs -e 365
 ./deployments/scripts/create-certs.sh -m client -h huskyapi -pw $CERT_PASSPHRASE -t deployments/certs -e 365
-./deployments/scripts/create-certs.sh -m tls -h dockerapi -pw $CERT_PASSPHRASE -t deployments/certs -e 365
+./deployments/scripts/create-certs.sh -m tls -h dockerapi -pw $CERT_PASSPHRASE -t api -e 365

--- a/deployments/scripts/run-create-certs.sh
+++ b/deployments/scripts/run-create-certs.sh
@@ -8,3 +8,4 @@ rm -rf deployments/certs/*
 ./deployments/scripts/create-certs.sh -m ca -pw $CERT_PASSPHRASE -t deployments/certs -e 900
 ./deployments/scripts/create-certs.sh -m server -h dockerapi -pw $CERT_PASSPHRASE -t deployments/certs -e 365
 ./deployments/scripts/create-certs.sh -m client -h huskyapi -pw $CERT_PASSPHRASE -t deployments/certs -e 365
+./deployments/scripts/create-certs.sh -m tls -h dockerapi -pw $CERT_PASSPHRASE -t deployments/certs -e 365

--- a/util/util.go
+++ b/util/util.go
@@ -1,0 +1,67 @@
+package util
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/globocom/huskyci/api/log"
+)
+
+const (
+	// CertFile contains the address for the API's TLS certificate.
+	CertFile = "api/api-tls-cert.pem"
+	// KeyFile contains the address for the API's TLS certificate key file.
+	KeyFile = "api/api-tls-key.pem"
+)
+
+// NewClientTLS returns an http client with certificate authentication.
+func NewClientTLS() (*http.Client, error) {
+
+	// Tries to find system's certificate pool
+	caCertPool, _ := x509.SystemCertPool() // #nosec - SystemCertPool tries to get local cert pool, if it fails, a new cer pool is created
+	if caCertPool == nil {
+		caCertPool = x509.NewCertPool()
+	}
+
+	cert, err := ioutil.ReadFile(CertFile)
+	if err != nil {
+		log.Error("NewClientTLS", "UTIL", 4001, err)
+	}
+	if ok := caCertPool.AppendCertsFromPEM(cert); !ok {
+		log.Error("NewClientTLS", "UTIL", 4002, err)
+	}
+
+	tlsConfig := &tls.Config{
+		RootCAs: caCertPool,
+	}
+	tlsConfig.BuildNameToCertificate()
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				MinVersion:               tls.VersionTLS11,
+				MaxVersion:               tls.VersionTLS12,
+				PreferServerCipherSuites: true,
+				InsecureSkipVerify:       false,
+				RootCAs:                  caCertPool,
+			},
+		},
+	}
+	return client, nil
+}
+
+// HandleCmd will extract %GIT_REPO% and %GIT_BRANCH% from cmd and replace it with the proper repository URL.
+func HandleCmd(repositoryURL, repositoryBranch, cmd string) string {
+	replace1 := strings.Replace(cmd, "%GIT_REPO%", repositoryURL, -1)
+	replace2 := strings.Replace(replace1, "%GIT_BRANCH%", repositoryBranch, -1)
+	return replace2
+}
+
+// HandlePrivateSSHKey will extract %GIT_PRIVATE_SSH_KEY% from cmd and replace it with the proper private SSH key.
+func HandlePrivateSSHKey(rawString string) string {
+	cmdReplaced := strings.Replace(rawString, "GIT_PRIVATE_SSH_KEY", os.Getenv("GIT_PRIVATE_SSH_KEY"), -1)
+	return cmdReplaced
+}


### PR DESCRIPTION
## Closes #163 

* api/log/messagecodes.go: Created a new error category to reference the new `util` package.
* api/server.go: Changed how the API starts to support HTTPS connections.
* client/analysis/analysis.go: Changed how the requests are being made to support HTTPS functionality.
* deployments/scripts/create-certs.sh: Added a new function to generate the certificates needed to a TLS connection.
* deployments/scripts/generate-env-pass.sh: Fixed typo in environment variables.
* deployments/scripts/run-create-certs.sh: Added a a new line to create the certificates needed for HTTPS.

## Closes #150 

* api/analysis/dockerrun.go: Added the `handlePrivateSSHKey()` function to the `util` package.
* api/dockers/api.go: Added `NewClientTLS()` function to the `util` package.
* util/util.go: New file designed to handle useful functions across huskyCI.
