### PR TITLE
Add the option to use TLS as a feature flag

### DIFF
--- a/api/context/config.go
+++ b/api/context/config.go
@@ -40,6 +40,7 @@ type APIConfig struct {
 	MongoDBConfig        *MongoConfig
 	DockerHostsConfig    *DockerHostsConfig
 	HuskyAPIPort         int
+	UseTLS               bool
 	EnrySecurityTest     *types.SecurityTest
 	GosecSecurityTest    *types.SecurityTest
 	BanditSecurityTest   *types.SecurityTest
@@ -66,6 +67,7 @@ func GetAPIConfig() *APIConfig {
 			MongoDBConfig:        getMongoConfig(),
 			DockerHostsConfig:    getDockerHostsConfig(),
 			HuskyAPIPort:         getAPIHostPort(),
+			UseTLS:               getUseTLS(),
 			EnrySecurityTest:     getEnryConfig(),
 			GosecSecurityTest:    getGosecConfig(),
 			BanditSecurityTest:   getBanditConfig(),
@@ -142,6 +144,15 @@ func getAPIHostPort() int {
 		apiPort = 8888
 	}
 	return apiPort
+}
+
+// getUseTLS returns TRUE or FALSE retrieved from an environment variable.
+func getUseTLS() bool {
+	option := os.Getenv("HUSKY_API_ENABLE_HTTPS")
+	if option == "true" || option == "1" || option == "TRUE" {
+		return true
+	}
+	return false
 }
 
 // getMongoTimeout returns MongoDB timeout retrieved form an environment variable.

--- a/api/server.go
+++ b/api/server.go
@@ -58,7 +58,12 @@ func main() {
 	echoInstance.POST("/repository", analysis.CreateNewRepository)
 
 	huskyAPIport := fmt.Sprintf(":%d", configAPI.HuskyAPIPort)
-	echoInstance.Logger.Fatal(echoInstance.StartTLS(huskyAPIport, util.CertFile, util.KeyFile))
+
+	if !configAPI.UseTLS {
+		echoInstance.Logger.Fatal(echoInstance.Start(huskyAPIport))
+	} else {
+		echoInstance.Logger.Fatal(echoInstance.StartTLS(huskyAPIport, util.CertFile, util.KeyFile))
+	}
 }
 
 func checkHuskyRequirements(configAPI *apiContext.APIConfig) error {

--- a/client/analysis/analysis.go
+++ b/client/analysis/analysis.go
@@ -30,11 +30,12 @@ func StartAnalysis() (string, error) {
 		return "", err
 	}
 	huskyStartAnalysisURL := config.HuskyAPI + "/husky"
-	httpsClient, err := util.NewClientTLS()
+
+	httpClient, err := util.NewClient(config.HuskyUseTLS)
 	if err != nil {
 		return "", err
 	}
-	resp, err := httpsClient.Post(huskyStartAnalysisURL, "application/json", bytes.NewBuffer(marshalPayload))
+	resp, err := httpClient.Post(huskyStartAnalysisURL, "application/json", bytes.NewBuffer(marshalPayload))
 	if err != nil {
 		return "", err
 	}
@@ -57,12 +58,12 @@ func GetAnalysis(RID string) (types.Analysis, error) {
 
 	analysis := types.Analysis{}
 
-	httpsClient, err := util.NewClientTLS()
+	httpClient, err := util.NewClient(config.HuskyUseTLS)
 	if err != nil {
 		return analysis, err
 	}
 
-	resp, err := httpsClient.Get(config.HuskyAPI + "/husky/" + RID)
+	resp, err := httpClient.Get(config.HuskyAPI + "/husky/" + RID)
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -19,11 +19,15 @@ var HuskyAPI string
 // RepositoryBranch stores the repository branch of the project to be analyzed.
 var RepositoryBranch string
 
+// HuskyUseTLS stores if huskyCI is to use an HTTPS connection.
+var HuskyUseTLS bool
+
 // SetConfigs sets all configuration needed to start the client.
 func SetConfigs() {
 	RepositoryURL = os.Getenv(`HUSKYCI_REPO_URL`)
 	RepositoryBranch = os.Getenv(`HUSKYCI_REPO_BRANCH`)
 	HuskyAPI = os.Getenv(`HUSKYCI_API`)
+	HuskyUseTLS = getUseTLS()
 }
 
 // CheckEnvVars checks if all environment vars are set.
@@ -53,4 +57,13 @@ func CheckEnvVars() error {
 		return errors.New(finalError)
 	}
 	return nil
+}
+
+// getUseTLS returns TRUE or FALSE retrieved from an environment variable.
+func getUseTLS() bool {
+	option := os.Getenv("HUSKY_CLIENT_ENABLE_HTTPS")
+	if option == "true" || option == "1" || option == "TRUE" {
+		return true
+	}
+	return false
 }

--- a/deployments/scripts/generate-env-pass.sh
+++ b/deployments/scripts/generate-env-pass.sh
@@ -6,7 +6,9 @@
 # huskyCI client default vars
 HUSKYCI_REPO_URL="https://github.com/globocom/huskyci.git"
 HUSKYCI_REPO_BRANCH="master"
-HUSKYCI_API="https://localhost:8888"
+HUSKYCI_API="http://localhost:8888"
+HUSKY_API_ENABLE_HTTPS="false"     # If HTTPS is enabled, HUSKYCI_API must also be of an HTTPS URL
+HUSKY_CLIENT_ENABLE_HTTPS="false"
 
 # Generating "random" passwords
 CERT_PASSPHRASE_TMP="certPass$RANDOM$RANDOM"
@@ -16,6 +18,7 @@ MONGO_DATABASE_PASSWORD_TMP="huskyPass$RANDOM$RANDOM"
 # Writing passwords into dockers.env file to be used by docker compose
 echo "MONGO_DATABASE_USERNAME=$MONGO_DATABASE_USERNAME_TMP" > deployments/dockers.env
 echo "MONGO_DATABASE_PASSWORD=$MONGO_DATABASE_PASSWORD_TMP" >> deployments/dockers.env
+echo "HUSKY_API_ENABLE_HTTPS=$HUSKY_API_ENABLE_HTTPS" >> deployments/dockers.env
 
 # Writing passwords into .env to be used by run_create_cert.sh and to send to STDOUT
 echo "export CERT_PASSPHRASE=\"$CERT_PASSPHRASE_TMP\"" > .env
@@ -26,6 +29,7 @@ echo "export MONGO_DATABASE_PASSWORD=\"$MONGO_DATABASE_PASSWORD_TMP\"" >> .env
 echo "export HUSKYCI_REPO_URL=\"$HUSKYCI_REPO_URL\"" >> .env
 echo "export HUSKYCI_REPO_BRANCH=\"$HUSKYCI_REPO_BRANCH\"" >> .env
 echo "export HUSKYCI_API=\"$HUSKYCI_API\"" >> .env
+echo "export HUSKY_CLIENT_ENABLE_HTTPS=\"$HUSKY_CLIENT_ENABLE_HTTPS\"" >> .env
 
 # Preparing script to create mongoDB default user
 cat << EOF > deployments/mongo-init.js

--- a/util/util.go
+++ b/util/util.go
@@ -18,38 +18,43 @@ const (
 	KeyFile = "api/api-tls-key.pem"
 )
 
-// NewClientTLS returns an http client with certificate authentication.
-func NewClientTLS() (*http.Client, error) {
+// NewClient returns an http client.
+func NewClient(httpsEnable bool) (*http.Client, error) {
 
-	// Tries to find system's certificate pool
-	caCertPool, _ := x509.SystemCertPool() // #nosec - SystemCertPool tries to get local cert pool, if it fails, a new cer pool is created
-	if caCertPool == nil {
-		caCertPool = x509.NewCertPool()
-	}
+	if httpsEnable {
+		// Tries to find system's certificate pool
+		caCertPool, _ := x509.SystemCertPool() // #nosec - SystemCertPool tries to get local cert pool, if it fails, a new cer pool is created
+		if caCertPool == nil {
+			caCertPool = x509.NewCertPool()
+		}
 
-	cert, err := ioutil.ReadFile(CertFile)
-	if err != nil {
-		log.Error("NewClientTLS", "UTIL", 4001, err)
-	}
-	if ok := caCertPool.AppendCertsFromPEM(cert); !ok {
-		log.Error("NewClientTLS", "UTIL", 4002, err)
-	}
+		cert, err := ioutil.ReadFile(CertFile)
+		if err != nil {
+			log.Error("NewClientTLS", "UTIL", 4001, err)
+		}
+		if ok := caCertPool.AppendCertsFromPEM(cert); !ok {
+			log.Error("NewClientTLS", "UTIL", 4002, err)
+		}
 
-	tlsConfig := &tls.Config{
-		RootCAs: caCertPool,
-	}
-	tlsConfig.BuildNameToCertificate()
-	client := &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				MinVersion:               tls.VersionTLS11,
-				MaxVersion:               tls.VersionTLS12,
-				PreferServerCipherSuites: true,
-				InsecureSkipVerify:       false,
-				RootCAs:                  caCertPool,
+		tlsConfig := &tls.Config{
+			RootCAs: caCertPool,
+		}
+		tlsConfig.BuildNameToCertificate()
+		client := &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					MinVersion:               tls.VersionTLS11,
+					MaxVersion:               tls.VersionTLS12,
+					PreferServerCipherSuites: true,
+					InsecureSkipVerify:       false,
+					RootCAs:                  caCertPool,
+				},
 			},
-		},
+		}
+		return client, nil
 	}
+
+	client := &http.Client{}
 	return client, nil
 }
 


### PR DESCRIPTION
This PR aims to add the option to use TLS as a feature flag.
## API
* api/server.go: Add verifier to check if TLS flag is set up. If it's not, API starts as HTTP only.
* api/context/config.go: Add new `UseTLS` variable to `APIConfig` struct.

## Client
* client/analysis/analysis.go: Change `NewClientTLS()` function to `NewClient()` to support both HTTP and HTTPS methods in Client.

## Deployments
* deployments/scripts/generate-env-pass.sh: Add new TLS environment variables to the generator script.
* util/util.go: Changed the `NewClientTLS()` function to `NewClient()` to support both HTTP and HTTPS methods.