### PR TITLE
Fix a bug in config.yml indentation

### DIFF
--- a/api/config.yaml
+++ b/api/config.yaml
@@ -104,13 +104,12 @@ retirejs:
     else
       echo "ERROR_CLONING"
       cat /tmp/errorGitCloneRetirejs
-    fi
-    
+    fi    
   language: JavaScript
   default: true
   timeOutInSeconds: 360
 
-  safety:
+safety:
   name: safety
   image: huskyci/safety
   cmd: |+


### PR DESCRIPTION
When deploying huskyCI, `retireJS` securityTest was not being started in MongoDB. 

After reviewing `config.yml`, I have noticed that an indentation error was causing this bug. 

This PR fix this.