### PR TITLE
Fix timedout bug by adding a missing return statement

### DIFF
--- a/api/analysis/analysis.go
+++ b/api/analysis/analysis.go
@@ -165,6 +165,7 @@ func MonitorAnalysis(analysis *types.Analysis) {
 				if err != nil {
 					// already being logged
 				}
+				return
 			} // cenario 3: retry after retryTick seconds!
 		}
 	}


### PR DESCRIPTION
## Closes #193

As a return statement was not being used, `case <-timeout:` was always being called. 