### PR TITLE
Fix huskyCI exiting before all containers have finished

### DIFF
--- a/api/analysis/enry.go
+++ b/api/analysis/enry.go
@@ -113,6 +113,16 @@ func EnryStartAnalysis(CID string, cOutput string, RID string) {
 		return
 	}
 
+	updateContainerAnalysisQuery := bson.M{
+		"$set": bson.M{
+			"containers.$.cInfo": "Finished successfully.",
+		},
+	}
+	err = db.UpdateOneDBAnalysisContainer(analysisQuery, updateContainerAnalysisQuery)
+	if err != nil {
+		log.Error("EnryStartAnalysis", "ENRY", 2007, err)
+	}
+
 	// step 5: start all new securityTests.
 	for _, securityTest := range newLanguageSecurityTests {
 		// avoiding a loop here with this if condition.

--- a/api/db/huskydb.go
+++ b/api/db/huskydb.go
@@ -132,7 +132,6 @@ func InsertDBRepository(repository types.Repository) error {
 		URL:           repository.URL,
 		Branch:        repository.Branch,
 		SecurityTests: securityTestList,
-		VM:            repository.VM,
 		CreatedAt:     repository.CreatedAt,
 		DeletedAt:     repository.DeletedAt,
 		Languages:     repository.Languages,

--- a/api/log/messagecodes.go
+++ b/api/log/messagecodes.go
@@ -75,6 +75,7 @@ var MsgCode = map[int]string{
 
 	// Docker API info
 	31: "Waiting pull image...",
+	32: "Container started successfully: ",
 
 	// Docker API warning
 	301: "",

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -17,7 +17,6 @@ type Repository struct {
 	Branch           string         `bson:"repositoryBranch" json:"repositoryBranch"`
 	SecurityTests    []SecurityTest `bson:"securityTests" json:"securityTests"`
 	SecurityTestName []string       `bson:"securityTestName,omitempty" json:"securityTestName"`
-	VM               string         `bson:"VM" json:"vm"`
 	CreatedAt        time.Time      `bson:"createdAt" json:"createdAt"`
 	DeletedAt        time.Time      `bson:"deletedAt" json:"deletedAt"`
 	Languages        []Language     `bson:"languages" json:"languages"`
@@ -49,7 +48,6 @@ type Analysis struct {
 // Container is the struct that stores all data from a container run.
 type Container struct {
 	CID          string       `bson:"CID" json:"CID"`
-	VM           string       `bson:"VM" json:"VM"`
 	SecurityTest SecurityTest `bson:"securityTest" json:"securityTest"`
 	CStatus      string       `bson:"cStatus" json:"cStatus"`
 	COuput       string       `bson:"cOutput" json:"cOutput"`

--- a/client/analysis/output.go
+++ b/client/analysis/output.go
@@ -21,15 +21,15 @@ func CheckMongoDBContainerOutput(container types.Container) {
 	switch container.SecurityTest.Name {
 	case "enry":
 	case "gosec":
-		PrintGosecOutput(container.COutput)
+		PrintGosecOutput(container.COutput, container.CInfo)
 	case "bandit":
-		PrintBanditOutput(container.COutput)
+		PrintBanditOutput(container.COutput, container.CInfo)
 	case "retirejs":
-		PrintRetirejsOutput(container.COutput)
+		PrintRetirejsOutput(container.COutput, container.CInfo)
 	case "brakeman":
-		PrintBrakemanOutput(container.COutput)
+		PrintBrakemanOutput(container.COutput, container.CInfo)
 	case "safety":
-		PrintSafetyOutput(container.COutput)
+		PrintSafetyOutput(container.COutput, container.CInfo)
 	default:
 		fmt.Println("[HUSKYCI][ERROR] securityTest name not recognized:", container.SecurityTest.Name)
 		os.Exit(1)
@@ -37,9 +37,9 @@ func CheckMongoDBContainerOutput(container types.Container) {
 }
 
 // PrintGosecOutput will print the Gosec output.
-func PrintGosecOutput(mongoDBcontainerOutput string) {
+func PrintGosecOutput(mongoDBcontainerOutput string, mongoDBcontainerInfo string) {
 
-	if mongoDBcontainerOutput == "No issues found." {
+	if mongoDBcontainerInfo == "No issues found." {
 		color.Green("[HUSKYCI][*] Gosec :)\n\n")
 		return
 	}
@@ -104,9 +104,9 @@ func PrintGosecOutput(mongoDBcontainerOutput string) {
 }
 
 // PrintBanditOutput will print Bandit output.
-func PrintBanditOutput(mongoDBcontainerOutput string) {
+func PrintBanditOutput(mongoDBcontainerOutput string, mongoDBcontainerInfo string) {
 
-	if mongoDBcontainerOutput == "No issues found." {
+	if mongoDBcontainerInfo == "No issues found." {
 		color.Green("[HUSKYCI][*] Bandit :)\n\n")
 		return
 	}
@@ -171,9 +171,9 @@ func PrintBanditOutput(mongoDBcontainerOutput string) {
 }
 
 // PrintRetirejsOutput will print Retirejs output.
-func PrintRetirejsOutput(mongoDBcontainerOutput string) {
+func PrintRetirejsOutput(mongoDBcontainerOutput string, mongoDBcontainerInfo string) {
 
-	if mongoDBcontainerOutput == "No issues found." {
+	if mongoDBcontainerInfo == "No issues found." {
 		color.Green("[HUSKYCI][*] RetireJS :)\n\n")
 		return
 	}
@@ -250,8 +250,8 @@ func PrintRetirejsOutput(mongoDBcontainerOutput string) {
 }
 
 // PrintBrakemanOutput will print Brakeman output.
-func PrintBrakemanOutput(mongoDBcontainerOutput string) {
-	if mongoDBcontainerOutput == "No issues found." {
+func PrintBrakemanOutput(mongoDBcontainerOutput string, mongoDBcontainerInfo string) {
+	if mongoDBcontainerInfo == "No issues found." {
 		color.Green("[HUSKYCI][*] Brakeman :)\n\n")
 		return
 	}
@@ -315,9 +315,9 @@ func PrintBrakemanOutput(mongoDBcontainerOutput string) {
 }
 
 // PrintSafetyOutput will print Safety output.
-func PrintSafetyOutput(mongoDBcontainerOutput string) {
+func PrintSafetyOutput(mongoDBcontainerOutput string, mongoDBcontainerInfo string) {
 
-	if mongoDBcontainerOutput == "No issues found." {
+	if mongoDBcontainerInfo == "No issues found." {
 		color.Green("[HUSKYCI][*] Safety :)\n\n")
 		return
 	}

--- a/client/types/types.go
+++ b/client/types/types.go
@@ -41,7 +41,6 @@ type Analysis struct {
 // Container is the struct that stores all data from a container run.
 type Container struct {
 	CID          string       `bson:"CID" json:"CID"`
-	VM           string       `bson:"VM" json:"VM"`
 	SecurityTest SecurityTest `bson:"securityTest" json:"securityTest"`
 	CStatus      string       `bson:"cStatus" json:"cStatus"`
 	COutput      string       `bson:"cOutput" json:"cOutput"`


### PR DESCRIPTION
## Closes #201 

This PR aims to solve the issue of `enry` setting the status of the analysis as finished before all containers have actually finished.

* `api/analysis/analysis.go` : Created a new variable, `securityTestDoneCounter` to assure that all security tests found by `Enry` would actually run before the client close the connection.

* `api/analysis/dockerrun.go` : Implemented a max retry loop to try to start a container.

* `api/analysis/enry.go` : `Enry` container now writes `Finished Successfully.` in the new field `cInfo`, if it finished successfully.

* `api/db/huskydb.go` : Removed `VM` field.

* `api/log/messagecodes.go` : Added a new info message code.

* `api/types/types.go` : Removed `VM` field.

* `client/analysis/output.go` : All containers now have a `cInfo` field, where additional info about an analysis will be displayed.

* `client/types/types.go` : Removed `VM` field.