### PR TITLE
api|FIX: Fix env vars names in sh script

### DIFF
--- a/deployments/scripts/generate-env-pass.sh
+++ b/deployments/scripts/generate-env-pass.sh
@@ -4,10 +4,10 @@
 #
 
 # huskyCI client default environment variables
-HUSKYCI_REPO_URL="https://github.com/globocom/huskyCI.git"
-HUSKYCI_REPO_BRANCH="master"
-HUSKYCI_API="http://localhost:8888"
-HUSKY_CLIENT_ENABLE_HTTPS="false"
+HUSKYCI_CLIENT_REPO_URL="https://github.com/globocom/huskyCI.git"
+HUSKYCI_CLIENT_REPO_BRANCH="master"
+HUSKYCI_CLIENT_API_ADDR="http://localhost:8888"
+HUSKYCI_CLIENT_API_USE_HTTPS="false"
 
 # Generating "random" password for certificates
 CERT_PASSPHRASE_TMP="certPass$RANDOM$RANDOM"
@@ -16,7 +16,7 @@ CERT_PASSPHRASE_TMP="certPass$RANDOM$RANDOM"
 echo "export CERT_PASSPHRASE=\"$CERT_PASSPHRASE_TMP\"" > .env
 
 # Adding default envs vars to run be used by make run-client
-echo "export HUSKYCI_REPO_URL=\"$HUSKYCI_REPO_URL\"" >> .env
-echo "export HUSKYCI_REPO_BRANCH=\"$HUSKYCI_REPO_BRANCH\"" >> .env
-echo "export HUSKYCI_API=\"$HUSKYCI_API\"" >> .env
-echo "export HUSKY_CLIENT_ENABLE_HTTPS=\"$HUSKY_CLIENT_ENABLE_HTTPS\"" >> .env
+echo "export HUSKYCI_CLIENT_REPO_URL=\"$HUSKYCI_CLIENT_REPO_URL\"" >> .env
+echo "export HUSKYCI_CLIENT_REPO_BRANCH=\"$HUSKYCI_CLIENT_REPO_BRANCH\"" >> .env
+echo "export HUSKYCI_CLIENT_API_ADDR=\"$HUSKYCI_CLIENT_API_ADDR\"" >> .env
+echo "export HUSKYCI_CLIENT_API_USE_HTTPS=\"$HUSKYCI_CLIENT_API_USE_HTTPS\"" >> .env


### PR DESCRIPTION
This MR will update the env variables names in `generate-env-pass.sh` to their new names.