### PR TITLE
Remove init function from context file

### DIFF
--- a/api/context/context.go
+++ b/api/context/context.go
@@ -69,7 +69,9 @@ type APIConfig struct {
 	SafetySecurityTest   *types.SecurityTest
 }
 
-func init() {
+// GetAPIConfig returns the instance of an APIConfig.
+func GetAPIConfig() *APIConfig {
+
 	// load Viper using api/config.yml
 	viper.SetConfigName("config")
 	viper.AddConfigPath("api/")
@@ -77,11 +79,7 @@ func init() {
 		fmt.Println("Error reading Viper config: ", err)
 		os.Exit(1)
 	}
-	return
-}
 
-// GetAPIConfig returns the instance of an APIConfig.
-func GetAPIConfig() *APIConfig {
 	onceConfig.Do(func() {
 		APIConfiguration = &APIConfig{
 			Port:                 getAPIPort(),


### PR DESCRIPTION
## Closes #229

Due to the `init()` function present in `api/context.go`, it would be called automatically in both the `client` and the `API`, causing unexpected errors.

* api/context/context.go: Remove the `init()` function and move it's content to `GetAPIConfig()` in the same file.