### PR TITLE
Fix Safety bug when "requirements.txt" isn't found

### DIFF
--- a/api/config.yaml
+++ b/api/config.yaml
@@ -126,8 +126,7 @@ safety:
     git clone -b %GIT_BRANCH% --single-branch %GIT_REPO% code --quiet 2> /tmp/errorGitCloneSafety
     if [ $? -eq 0 ]; then
       cd code
-      cat *requirements* | grep '=' | grep -v '#' > safety_huskyci_analysis_requirements.txt 2> /tmp/errorGetRequirements
-      if [ $? -eq 0 ]; then
+      if [ $(cat requirements.txt | grep '=' | grep -v '#' 1> safety_huskyci_analysis_requirements.txt 2> /tmp/errorFindRequirements) ]; then
         safety check -r safety_analysis_requirements.txt --json > safety_huskyci_analysis_output.json 2> /tmp/errorUnpinnedReq
         chmod +x /script.sh
         /script.sh /code/safety_analysis_output.json

--- a/client/analysis/output.go
+++ b/client/analysis/output.go
@@ -322,8 +322,8 @@ func PrintSafetyOutput(mongoDBcontainerOutput string, mongoDBcontainerInfo strin
 		return
 	}
 
-	if mongoDBcontainerOutput == "Requirements not found or this project uses latest dependencies." {
-		fmt.Printf("[HUSKYCI][*] Requirements not found or this project uses latest dependencies.\n")
+	if mongoDBcontainerInfo == "Requirements not found or this project uses latest dependencies." {
+		fmt.Printf("[HUSKYCI][*] requirements.txt not found or this project uses latest dependencies.\n")
 		fmt.Printf("[HUSKYCI][*] Safety :|\n\n")
 		return
 	}


### PR DESCRIPTION
## Closes issue #232 

This PR aims to fix a bug where Safety would not exit if a `requirements` file wasn't found.

In order for a Python project to be properly analyzed by Safety now it must have a `requirements.txt` file.

* `api/config.yaml`: Change `requirements` search to be inside the `if` statement to prevent error from showing in cOutput.

* `client/analysis/output.go`: Safety now checks cInfo to verify if `requirements.txt` file wasn't found.