### PR TITLE
Add ginkgo tests for routes package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,8 @@ get-test-deps:
 	$(GO) get -u github.com/golang/dep/cmd/dep
 	$(GO) get -u golang.org/x/lint/golint
 	$(GO) get -u github.com/securego/gosec/cmd/gosec
+	$(GO) get -u github.com/onsi/ginkgo/ginkgo
+	$(GO) get -u github.com/onsi/gomega/...
 
 ## Prints help message
 help:
@@ -107,5 +109,9 @@ pull-images:
 run-client: build-client
 	./"$(HUSKYCICLIENTBIN)"
 
+## Runs ginkgo
+ginkgo:
+	ginkgo -r -keepGoing 
+	
 ## Perfoms all make tests
-test: get-test-deps lint check-sec
+test: get-test-deps lint check-sec ginkgo

--- a/api/context/context.go
+++ b/api/context/context.go
@@ -79,12 +79,17 @@ func GetAPIConfig() *APIConfig {
 		fmt.Println("Error reading Viper config: ", err)
 		os.Exit(1)
 	}
+	SetOnceConfig()
+	return APIConfiguration
+}
 
+// SetOnceConfig sets APIConfiguration once
+func SetOnceConfig() {
 	onceConfig.Do(func() {
 		APIConfiguration = &APIConfig{
 			Port:                 getAPIPort(),
-			Version:              getAPIVersion(),
-			ReleaseDate:          getAPIReleaseDate(),
+			Version:              GetAPIVersion(),
+			ReleaseDate:          GetAPIReleaseDate(),
 			UseTLS:               getAPIUseTLS(),
 			GitPrivateSSHKey:     getGitPrivateSSHKey(),
 			GraylogConfig:        getGraylogConfig(),
@@ -98,7 +103,6 @@ func GetAPIConfig() *APIConfig {
 			SafetySecurityTest:   getSecurityTestConfig("safety"),
 		}
 	})
-	return APIConfiguration
 }
 
 func getAPIPort() int {
@@ -109,11 +113,13 @@ func getAPIPort() int {
 	return apiPort
 }
 
-func getAPIVersion() string {
+// GetAPIVersion returns current API version
+func GetAPIVersion() string {
 	return "0.2.0"
 }
 
-func getAPIReleaseDate() string {
+// GetAPIReleaseDate returns current API release date
+func GetAPIReleaseDate() string {
 	return "2019-04-11"
 }
 

--- a/api/routes/routes_suite_test.go
+++ b/api/routes/routes_suite_test.go
@@ -1,0 +1,13 @@
+package routes_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestRoutes(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Routes Suite")
+}

--- a/api/routes/version.go
+++ b/api/routes/version.go
@@ -10,9 +10,14 @@ import (
 //GetAPIVersion returns the API version
 func GetAPIVersion(c echo.Context) error {
 	configAPI := apiContext.APIConfiguration
+	return c.JSON(http.StatusOK, GetRequestResult(configAPI))
+}
+
+// GetRequestResult returns a map containing API's version and release date
+func GetRequestResult(configAPI *apiContext.APIConfig) map[string]string {
 	requestResult := map[string]string{
 		"version": configAPI.Version,
 		"date":    configAPI.ReleaseDate,
 	}
-	return c.JSON(http.StatusOK, requestResult)
+	return requestResult
 }

--- a/api/routes/version_test.go
+++ b/api/routes/version_test.go
@@ -1,0 +1,27 @@
+package routes_test
+
+import (
+	apiContext "github.com/globocom/huskyCI/api/context"
+	"github.com/globocom/huskyCI/api/routes"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("getRequestResult", func() {
+
+	expected := map[string]string{
+		"version": apiContext.GetAPIVersion(),
+		"date":    apiContext.GetAPIReleaseDate(),
+	}
+
+	apiContext.SetOnceConfig()
+	config := apiContext.APIConfiguration
+
+	Context("When version and date are requested", func() {
+		It("Should return a map with API version and date", func() {
+			Expect(routes.GetRequestResult(config)).To(Equal(expected))
+		})
+	})
+
+})


### PR DESCRIPTION
## Closes #114 

This PR implements the following changes:

#### api/routes/version.go:
* Function `GetRequestResult()` was created to isolate the logic of retrieving API version.

#### api/routes/context.go
* Function `SetOnceConfig()` was created to isolate the logic of setting API configuration.
* Functions `GetAPiVersion()` and `GetAPIReleaseDate()` are now public so that they can now be accessed from `version_test.go` file.

#### api/routes/version_test.go
* Added test for `GetRequestResult()` function.

#### api/routes/routes_suite_test.go
* Added ginkgo suite test for routes package.

#### Makefile
* Added ginkgo tests.