### PR TITLE
api|FEAT: Add kill containers logic

### DIFF
--- a/api/context/context.go
+++ b/api/context/context.go
@@ -33,13 +33,14 @@ type MongoConfig struct {
 
 // DockerHostsConfig represents Docker Hosts configuration.
 type DockerHostsConfig struct {
-	Address         string
-	DockerAPIPort   int
-	Certificate     string
-	PathCertificate string
-	Key             string
-	Host            string
-	TLSVerify       int
+	Address              string
+	DockerAPIPort        int
+	Certificate          string
+	PathCertificate      string
+	Key                  string
+	Host                 string
+	TLSVerify            int
+	MaxContainersAllowed int
 }
 
 // GraylogConfig represents Graylog configuration.
@@ -200,13 +201,14 @@ func getDockerHostsConfig() *DockerHostsConfig {
 	dockerHostsPathCertificates := os.Getenv("HUSKYCI_DOCKERAPI_CERT_PATH")
 	dockerHostsKey := os.Getenv("HUSKYCI_DOCKERAPI_CERT_KEY")
 	return &DockerHostsConfig{
-		Address:         dockerHostsAddresses[0],
-		DockerAPIPort:   dockerAPIPort,
-		Certificate:     dockerHostsCertificate,
-		PathCertificate: dockerHostsPathCertificates,
-		Key:             dockerHostsKey,
-		Host:            fmt.Sprintf("%s:%d", dockerHostsAddresses[0], dockerAPIPort),
-		TLSVerify:       getDockerAPITLSVerify(),
+		Address:              dockerHostsAddresses[0],
+		DockerAPIPort:        dockerAPIPort,
+		Certificate:          dockerHostsCertificate,
+		PathCertificate:      dockerHostsPathCertificates,
+		Key:                  dockerHostsKey,
+		Host:                 fmt.Sprintf("%s:%d", dockerHostsAddresses[0], dockerAPIPort),
+		TLSVerify:            getDockerAPITLSVerify(),
+		MaxContainersAllowed: getMaxContainersAllowed(),
 	}
 }
 
@@ -235,4 +237,12 @@ func getSecurityTestConfig(securityTestName string) *types.SecurityTest {
 		Default:          viper.GetBool(fmt.Sprintf("%s.default", securityTestName)),
 		TimeOutInSeconds: viper.GetInt(fmt.Sprintf("%s.timeOutInSeconds", securityTestName)),
 	}
+}
+
+func getMaxContainersAllowed() int {
+	maxContainersAllowed, err := strconv.Atoi(os.Getenv("HUSKYCI_DOCKERAPI_MAX_CONTAINERS_BEFORE_CLEANING"))
+	if err != nil {
+		return 50
+	}
+	return maxContainersAllowed
 }

--- a/api/log/messagecodes.go
+++ b/api/log/messagecodes.go
@@ -101,6 +101,11 @@ var MsgCode = map[int]string{
 	3018: "Unexpected securityTest.Name: ",
 	3019: "Could not set DOCKER_CERT_PATH enviroment variable: ",
 	3020: "Could not set DOCKER_TLS_VERIFY enviroment variable: ",
+	3021: "Could not list current active containers: ",
+	3022: "Could not stop a container via d.client: ",
+	3023: "Could not remove a container via d.client: ",
+	3024: "Could not call die containers: ",
+	3025: "Could not update listed containers: ",
 
 	// Util package errors
 	4001: "Could not read certificate file: ",

--- a/api/util/api/api-util.go
+++ b/api/util/api/api-util.go
@@ -71,6 +71,7 @@ func checkEnvVars() error {
 		// "HUSKYCI_DOCKERAPI_CERT_CA", (optional)
 		// "HUSKYCI_DOCKERAPI_PORT", (optional)
 		// "HUSKYCI_DOCKERAPI_TLS_VERIFY", (optional)
+		// "HUSKYCI_DOCKERAPI_MAX_CONTAINERS_BEFORE_CLEANING", (optional)
 
 		// huskyCI API:
 		// "HUSKYCI_API_PORT", (optional)


### PR DESCRIPTION
This PR aims to kill all containers created by huskyCI after a given amount. The changes are listed below: 

#### api/dockers/api.go
- `StopContainers()` stops an active container;
- `RemoveContainers()` removes a container;
- `ListContainers()` returns a list of Docker type elements, each containing a CID and a Docker client pointer;
- `DieContainers()` stops and removes all containers returned by `ListContainers()`.

#### api/analysis/dockerrun.go
- `listedContainers` contains the current number of started containers since `make install` or last `DieContainers()`;
- Add step 6 in `DockerRun()` function, checking if it's already time to kill all containers;
- `updateAndCheckContainerList()` increments `listedContainers` variable and, if it's bigger or equal than `MaxContainersAllowed`, then kill all containers.

#### api/context/context.go
- Add `MaxContainersAllowed` to `DockerHostConfig`;
- `getMaxContainersAllowed()` returns max value from env var or, if it's not been set, returns it's default value (50 by now).

#### api/log/messagecodes.go
- Add new error log messages.


