### PR TITLE
Adjust huskyCI to contemplate RetireJS new output format

### DIFF
--- a/api/analysis/retirejs.go
+++ b/api/analysis/retirejs.go
@@ -90,7 +90,7 @@ func RetirejsStartAnalysis(CID string, cOutput string) {
 	}
 
 	// step 1.1: Sets the container output to "No issues found" if RetirejsIssues returns an empty slice
-	if len(retirejsOutput.RetirejsResult) == 0 {
+	if len(retirejsOutput) == 0 {
 		updateContainerAnalysisQuery := bson.M{
 			"$set": bson.M{
 				"containers.$.cResult": "passed",
@@ -107,7 +107,7 @@ func RetirejsStartAnalysis(CID string, cOutput string) {
 	// step 2: find Vulnerabilities that have severity "medium" or "high".
 	cResult = "passed"
 	for _, output := range retirejsOutput {
-		for _, result := range output.Results {
+		for _, result := range output.RetirejsResult {
 			for _, vulnerability := range result.Vulnerabilities {
 				if vulnerability.Severity == "high" || vulnerability.Severity == "medium" {
 				cResult = "failed"
@@ -132,4 +132,5 @@ func RetirejsStartAnalysis(CID string, cOutput string) {
 		log.Error("RetirejsStartAnalysis", "RETIREJS", 2007, err)
 		return
 	}
+}
 }

--- a/api/config.yaml
+++ b/api/config.yaml
@@ -99,24 +99,19 @@ retirejs:
     git clone -b %GIT_BRANCH% --single-branch %GIT_REPO% code --quiet 2> /tmp/errorGitCloneRetirejs
     if [ $? -eq 0 ]; then
       cd code
-      if [ $(ls yarn.lock 2>/dev/null) ]; then
+      if [ -f yarn.lock ]; then
         yarn install >/dev/null 2>&1
-        ableToRun='true'
-      elif [ $(ls src/yarn.lock >/dev/null 2>&1) ]; then
+        retire -n --outputformat json --exitwith 0
+      elif [ -f src/yarn.lock ]; then
         cd src/
         yarn install >/dev/null 2>&1
-        ableToRun='true'
-      elif [ $(ls package.json >/dev/null 2>&1) ] || [ $(ls package-lock.json >/dev/null 2>&1) ]; then
+        retire -n --outputformat json --exitwith 0
+      elif [ -f package.json ] || [ -f package-lock.json ]; then
         npm install >/dev/null 2>&1
-        ableToRun='true'
-      elif [ $(ls src/package.json >/dev/null 2>&1) ] || [ $(ls src/package-lock.json >/dev/null 2>&1) ]; then
+        retire -n --outputformat json --exitwith 0
+      elif [ -f src/package.json ] || [ -f src/package-lock.json ]; then
         cd src/
         npm install >/dev/null 2>&1
-        ableToRun='true'
-      else
-        ableToRun='false'
-      fi
-      if [ $ableToRun == 'true' ]; then
         retire -n --outputformat json --exitwith 0
       else
         echo 'ERROR_RUNNING_RETIREJS'

--- a/api/config.yaml
+++ b/api/config.yaml
@@ -101,18 +101,22 @@ retirejs:
       cd code
       if [ -f yarn.lock ]; then
         yarn install >/dev/null 2>&1
-        retire -n --outputformat json --exitwith 0
+        retire -n --outputformat json --outputpath /tmp/results.json --exitwith 0 2>/dev/null
+        cat /tmp/results.json
       elif [ -f src/yarn.lock ]; then
         cd src/
         yarn install >/dev/null 2>&1
-        retire -n --outputformat json --exitwith 0
+        retire -n --outputformat json --outputpath /tmp/results.json --exitwith 0 2>/dev/null
+        cat /tmp/results.json
       elif [ -f package.json ] || [ -f package-lock.json ]; then
         npm install >/dev/null 2>&1
-        retire -n --outputformat json --exitwith 0
+        retire -n --outputformat json --outputpath /tmp/results.json --exitwith 0 2>/dev/null
+        cat /tmp/results.json 
       elif [ -f src/package.json ] || [ -f src/package-lock.json ]; then
         cd src/
         npm install >/dev/null 2>&1
-        retire -n --outputformat json --exitwith 0
+        retire -n --outputformat json --outputpath /tmp/results.json --exitwith 0 2>/dev/null
+        cat /tmp/results.json 
       else
         echo 'ERROR_RUNNING_RETIREJS'
       fi

--- a/client/analysis/output.go
+++ b/client/analysis/output.go
@@ -179,65 +179,68 @@ func PrintRetirejsOutput(mongoDBcontainerOutput string, mongoDBcontainerInfo str
 	}
 
 	if strings.Contains(mongoDBcontainerInfo, "ERROR_RUNNING_RETIREJS") {
-		fmt.Printf("[HUSKYCI][*] It looks like your project doesn't have package.json or yarn.lock. huskyCI was not able to run RetireJS properly.\n\n")
+		fmt.Printf("[HUSKYCI][*] It looks like your project doesn't have package.json or yarn.lock. huskyCI was not able to run RetireJS properly.\n")
 		fmt.Printf("[HUSKYCI][*] RetireJS :|\n\n")
 		return
 	}
 
 	foundVuln := false
 	foundInfo := false
-	retirejsOutput := types.RetirejsOutput{}
+	retirejsOutput := []types.ResultsStruct{}
 	err := json.Unmarshal([]byte(mongoDBcontainerOutput), &retirejsOutput)
 	if err != nil {
-		fmt.Println("[HUSKYCI][ERROR] Could not Unmarshal retirejsOutput!", mongoDBcontainerOutput)
+		fmt.Println("[HUSKYCI][ERROR] Could not Unmarshal retirejsOutput!", err)
 		os.Exit(1)
 	}
 
-	for _, issue := range retirejsOutput.RetirejsIssues {
-		for _, result := range issue.RetirejsResults {
-			for _, vulnerability := range result.RetirejsVulnerabilities {
+	for _, output := range retirejsOutput {
+		for _, result := range output.Results {
+			for _, vulnerability := range result.Vulnerabilities {
 				if vulnerability.Severity == "high" {
 					foundVuln = true
 					color.Red("[HUSKYCI][!] Severity: %s", vulnerability.Severity)
-					color.Red("[HUSKYCI][!] Details: %s", vulnerability.Info)
-					color.Red("[HUSKYCI][!] File: %s", issue.File)
 					color.Red("[HUSKYCI][!] Component: %s", result.Component)
 					color.Red("[HUSKYCI][!] Version: %s", result.Version)
-					color.Red("[HUSKYCI][!] Vulnerable Below: %s", vulnerability.Below)
+					for _, info := range vulnerability.Info {
+						color.Red("[HUSKYCI][!] Info: %s", info)
+					}
+					color.Red("[HUSKYCI][!] Identifiers: %s", vulnerability.Identifiers.Summary)
 					fmt.Println()
 				}
 			}
 		}
 	}
 
-	for _, issue := range retirejsOutput.RetirejsIssues {
-		for _, result := range issue.RetirejsResults {
-			for _, vulnerability := range result.RetirejsVulnerabilities {
+	for _, output := range retirejsOutput {
+		for _, result := range output.Results {
+			for _, vulnerability := range result.Vulnerabilities {
 				if vulnerability.Severity == "medium" {
 					foundVuln = true
 					color.Yellow("[HUSKYCI][!] Severity: %s", vulnerability.Severity)
-					color.Yellow("[HUSKYCI][!] Details: %s", vulnerability.Info)
-					color.Yellow("[HUSKYCI][!] File: %s", issue.File)
 					color.Yellow("[HUSKYCI][!] Component: %s", result.Component)
 					color.Yellow("[HUSKYCI][!] Version: %s", result.Version)
-					color.Yellow("[HUSKYCI][!] Vulnerable Below: %s", vulnerability.Below)
+					for _, info := range vulnerability.Info {
+						color.Yellow("[HUSKYCI][!] Info: %s", info)
+					}
+					color.Yellow("[HUSKYCI][!] Identifiers: %s", vulnerability.Identifiers.Summary)
 					fmt.Println()
 				}
 			}
 		}
 	}
 
-	for _, issue := range retirejsOutput.RetirejsIssues {
-		for _, result := range issue.RetirejsResults {
-			for _, vulnerability := range result.RetirejsVulnerabilities {
+	for _, output := range retirejsOutput {
+		for _, result := range output.Results {
+			for _, vulnerability := range result.Vulnerabilities {
 				if vulnerability.Severity == "low" {
-					foundInfo = true
+					foundVuln = true
 					color.Blue("[HUSKYCI][!] Severity: %s", vulnerability.Severity)
-					color.Blue("[HUSKYCI][!] Details: %s", vulnerability.Info)
-					color.Blue("[HUSKYCI][!] File: %s", issue.File)
 					color.Blue("[HUSKYCI][!] Component: %s", result.Component)
 					color.Blue("[HUSKYCI][!] Version: %s", result.Version)
-					color.Blue("[HUSKYCI][!] Vulnerable Below: %s", vulnerability.Below)
+					for _, info := range vulnerability.Info {
+						color.Blue("[HUSKYCI][!] Info: %s", info)
+					}
+					color.Blue("[HUSKYCI][!] Identifiers: %s", vulnerability.Identifiers.Summary)
 					fmt.Println()
 				}
 			}

--- a/client/types/retirejs.go
+++ b/client/types/retirejs.go
@@ -4,40 +4,27 @@
 
 package types
 
-import "encoding/json"
-
-//RetirejsOutput is the struct that holds issues, messages and errors found on a Retire scan.
-type RetirejsOutput struct {
-	RetirejsIssues []RetirejsIssue `json:"data"`
-	Messages       json.RawMessage `json:"messages"`
-	Errors         json.RawMessage `json:"errors"`
+//ResultsStruct is a struct that holds the array of results scanned.
+type ResultsStruct struct {
+	Results []RetirejsResult	`json:"results"`
 }
 
-//RetirejsIssue is a struct that holds the results that were scanned and the file they came from.
-type RetirejsIssue struct {
-	File            string           `json:"file"`
-	RetirejsResults []RetirejsResult `json:"results"`
-}
-
-//RetirejsResult is a struct that holds the vulnerabilities found on a component being used by the code being analysed.
+//RetirejsResult is a struct that holds each scanned result.
 type RetirejsResult struct {
-	Version                 string                  `json:"version"`
-	Component               string                  `json:"component"`
-	Detection               string                  `json:"detection"`
-	RetirejsVulnerabilities []RetirejsVulnerability `json:"vulnerabilities"`
+	Component       string                    `json:"component"`
+	Version         string                    `json:"version"`
+	Level           int                       `json:"level"`
+	Vulnerabilities []RetireJSVulnerabilities `json:"vulnerabilities"`
 }
 
-//RetirejsVulnerability is a struct that holds info on what vulnerabilies were found.
-type RetirejsVulnerability struct {
-	Info                []string           `json:"info"`
-	Below               string             `json:"below"`
-	Severity            string             `json:"severity"`
-	RetirejsIdentifiers RetirejsIdentifier `json:"identifiers"`
+//RetireJSVulnerabilities is a struct that holds the vulnerabilities found on a scan.
+type RetireJSVulnerabilities struct {
+	Info        []string        					`json:"info"`
+	Severity    string                             	`json:"severity"`
+	Identifiers RetireJSVulnerabilityIdentifiers 	`json:"identifiers"`
 }
 
-//RetirejsIdentifier is a struct that holds details on the vulnerabilities found.
-type RetirejsIdentifier struct {
-	IssueFound string   `json:"issue"`
-	Summary    string   `json:"summary"`
-	CVE        []string `json:"CVE"`
+//RetireJSVulnerabilityIdentifiers is a struct that holds identifiying information on a vulnerability found.
+type RetireJSVulnerabilityIdentifiers struct {
+	Summary string	`json:"summary"`
 }


### PR DESCRIPTION
## Closes #258 

This PR aims to modify huskyCI's RetireJS struct format to suit the new output of RetireJS.

* `client/analysis/output.go` : Fix how huskyCI prints the RetireJS result after parsing it's JSON.
*  `client/types/retirejs.go` : Fix huskyCI's RetireJS struct to fit the new format output by the tool.

* `api/analysis/retirejs.go` : Fix how huskyCI API deals with the new output of RetireJS.
* `api/config.yaml` : Fixed the issue where huskyCI wasn't able to find the proper JavaScript/NodeJS package install files of a project.