### PR TITLE
api|FIX: Add kill containers log

### DIFF
--- a/api/analysis/dockerrun.go
+++ b/api/analysis/dockerrun.go
@@ -265,6 +265,8 @@ func updateAndCheckContainerList(d *docker.Docker) error {
 	maxContainersAllowed := configAPI.DockerHostsConfig.MaxContainersAllowed
 	listedContainers++
 	if listedContainers >= maxContainersAllowed {
+		messageLog := fmt.Sprintf("Maximum allowed: %d -- Listed containers: %d", maxContainersAllowed, listedContainers)
+		log.Info("updateAndCheckContainerList", "DOCKERRUN", 33, messageLog)
 		err := d.DieContainers()
 		if err != nil {
 			log.Error("updateAndCheckContainerList", "DOCKERRUN", 3024, err)

--- a/api/log/messagecodes.go
+++ b/api/log/messagecodes.go
@@ -78,6 +78,7 @@ var MsgCode = map[int]string{
 	// Docker API info
 	31: "Waiting pull image...",
 	32: "Container started successfully: ",
+	33: "Max container count reached. huskyCI is about to kill containers. ",
 
 	// Docker API warning
 	301: "",


### PR DESCRIPTION
This PR adds a new log message to be printed when Api decides it's time to kill containers (when container limit is reached).