### PR TITLE
api|FEAT: Add custom container names

### DIFF
--- a/api/dockers/api.go
+++ b/api/dockers/api.go
@@ -73,12 +73,13 @@ func NewDocker() (*Docker, error) {
 // CreateContainer creates a new container
 func (d Docker) CreateContainer(analysis types.Analysis, image string, cmd string) (string, error) {
 	cmd = util.HandleCmd(analysis.URL, analysis.Branch, cmd)
+	containerName := util.CreateContainerName(analysis.URL, analysis.Branch, image)
 	ctx := goContext.Background()
 	resp, err := d.client.ContainerCreate(ctx, &container.Config{
 		Image: image,
 		Tty:   true,
 		Cmd:   []string{"/bin/sh", "-c", cmd},
-	}, nil, nil, "")
+	}, nil, nil, containerName)
 
 	if err != nil {
 		log.Error("CreateContainer", "DOCKERAPI", 3005, err)

--- a/api/util/util.go
+++ b/api/util/util.go
@@ -83,3 +83,16 @@ func RemoveDuplicates(s []string) []string {
 	}
 	return s[:i]
 }
+
+// CreateContainerName generates a name for a container based on project's URL and branch
+// Example:
+//  - Input: {repositoryURL: https://github.com/globocom/huskyCI.git, repositoryBranch: "master", imageName: "huskyci/enry"}
+//  - Output: globocom_huskyCI_master_enry
+func CreateContainerName(repositoryURL, repositoryBranch, image string) string {
+	imageSlices := strings.Split(image, "/")
+	imageName := imageSlices[len(imageSlices)-1]
+	url := strings.TrimSuffix(repositoryURL, ".git")
+	urlSlices := strings.Split(url, "/")[3:]
+	myStrings := []string{strings.Join(urlSlices, "_"), repositoryBranch, imageName}
+	return strings.Join(myStrings, "_")
+}


### PR DESCRIPTION
This PR adds the function `CreateContainerName()` to package `util`.
This function generates a name for a container based on:
1. Repository URL;
2. Repository Branch;
3. Image name (enry, gosec etc).