### PR TITLE
deployments|FIX: Change single for double quotes

### DIFF
--- a/deployments/scripts/generate-env.sh
+++ b/deployments/scripts/generate-env.sh
@@ -10,7 +10,7 @@ HUSKYCI_CLIENT_API_ADDR="http://localhost:8888"
 HUSKYCI_CLIENT_API_USE_HTTPS="false"
 
 # Adding default envs vars to run be used by make run-client
-echo 'export HUSKYCI_CLIENT_REPO_URL=\"$HUSKYCI_CLIENT_REPO_URL\"' > .env
-echo 'export HUSKYCI_CLIENT_REPO_BRANCH=\"$HUSKYCI_CLIENT_REPO_BRANCH\"' >> .env
-echo 'export HUSKYCI_CLIENT_API_ADDR=\"$HUSKYCI_CLIENT_API_ADDR\"' >> .env
-echo 'export HUSKYCI_CLIENT_API_USE_HTTPS=\"$HUSKYCI_CLIENT_API_USE_HTTPS\"' >> .env
+echo "export HUSKYCI_CLIENT_REPO_URL=\"$HUSKYCI_CLIENT_REPO_URL\"" > .env
+echo "export HUSKYCI_CLIENT_REPO_BRANCH=\"$HUSKYCI_CLIENT_REPO_BRANCH\"" >> .env
+echo "export HUSKYCI_CLIENT_API_ADDR=\"$HUSKYCI_CLIENT_API_ADDR\"" >> .env
+echo "export HUSKYCI_CLIENT_API_USE_HTTPS=\"$HUSKYCI_CLIENT_API_USE_HTTPS\"" >> .env


### PR DESCRIPTION
Single quotes were putting the variables names inside the variables without replacing them with values.