### PR TITLE
Add JSON output option to huskyCI client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,10 @@ pull-images:
 run-client: build-client
 	./"$(HUSKYCICLIENTBIN)"
 
+## Runs huskyci-client with JSON output
+run-client-json: build-client
+	./"$(HUSKYCICLIENTBIN)" JSON
+
 ## Run huskyci-client compiling it in Linux arch
 run-client-linux: build-client-linux
 	./"$(HUSKYCICLIENTBIN)"

--- a/client/analysis/analysis.go
+++ b/client/analysis/analysis.go
@@ -124,5 +124,7 @@ func PrintResults(formatOutput string) error {
 		printhuskyCIOutput()
 	}
 
+	printSummary()
+
 	return nil
 }

--- a/client/analysis/analysis.go
+++ b/client/analysis/analysis.go
@@ -124,7 +124,7 @@ func PrintResults(formatOutput string) error {
 		printhuskyCIOutput()
 	}
 
-	printSummary()
+	calculateSummary()
 
 	return nil
 }

--- a/client/analysis/analysis.go
+++ b/client/analysis/analysis.go
@@ -105,26 +105,27 @@ func MonitorAnalysis(RID string) (types.Analysis, error) {
 	}
 }
 
-// AnalyzeResult analyzes the result received from HuskyCI API.
-func AnalyzeResult(analysisResult types.Analysis) {
+// PrepareResults analyzes the result received from HuskyCI API.
+func PrepareResults(analysisResult types.Analysis) {
 	fmt.Println()
 	for _, container := range analysisResult.Containers {
-		CheckMongoDBContainerOutput(container)
+		prepareSecurityTestResult(container)
 	}
 }
 
 // PrintResults prints huskyCI output either in JSON or the standard output.
 func PrintResults(formatOutput string) error {
+
+	prepareAllSummary()
+
 	if formatOutput == "JSON" {
 		err := printJSONOutput()
 		if err != nil {
 			return err
 		}
 	} else {
-		printhuskyCIOutput()
+		printSTDOUTOutput()
 	}
-
-	calculateSummary()
 
 	return nil
 }

--- a/client/analysis/analysis.go
+++ b/client/analysis/analysis.go
@@ -100,7 +100,9 @@ func MonitorAnalysis(RID string) (types.Analysis, error) {
 			if analysis.Status == "finished" {
 				return analysis, nil
 			}
-			fmt.Println("[HUSKYCI][!] Hold on! HuskyCI is still running...")
+			if !types.IsJSONoutput {
+				fmt.Println("[HUSKYCI][!] Hold on! huskyCI is still running...")
+			}
 		}
 	}
 }
@@ -117,7 +119,7 @@ func PrintResults(formatOutput string) error {
 
 	prepareAllSummary()
 
-	if formatOutput == "JSON" {
+	if types.IsJSONoutput {
 		err := printJSONOutput()
 		if err != nil {
 			return err

--- a/client/analysis/analysis.go
+++ b/client/analysis/analysis.go
@@ -111,4 +111,6 @@ func AnalyzeResult(analysisResult types.Analysis) {
 	for _, container := range analysisResult.Containers {
 		CheckMongoDBContainerOutput(container)
 	}
+
+	// Call print json output or on screen function here
 }

--- a/client/analysis/analysis.go
+++ b/client/analysis/analysis.go
@@ -106,11 +106,20 @@ func MonitorAnalysis(RID string) (types.Analysis, error) {
 }
 
 // AnalyzeResult analyzes the result received from HuskyCI API.
-func AnalyzeResult(analysisResult types.Analysis) {
+func AnalyzeResult(analysisResult types.Analysis, cmdInput string) error {
 	fmt.Println()
 	for _, container := range analysisResult.Containers {
 		CheckMongoDBContainerOutput(container)
 	}
 
-	// Call print json output or on screen function here
+	if cmdInput == "JSON" {
+		err := PrintJSONOutput()
+		if err != nil {
+			return err
+		}
+	} else {
+		PrinthuskyCIOutput()
+	}
+
+	return nil
 }

--- a/client/analysis/analysis.go
+++ b/client/analysis/analysis.go
@@ -107,7 +107,6 @@ func MonitorAnalysis(RID string) (types.Analysis, error) {
 
 // PrepareResults analyzes the result received from HuskyCI API.
 func PrepareResults(analysisResult types.Analysis) {
-	fmt.Println()
 	for _, container := range analysisResult.Containers {
 		prepareSecurityTestResult(container)
 	}

--- a/client/analysis/analysis.go
+++ b/client/analysis/analysis.go
@@ -106,19 +106,22 @@ func MonitorAnalysis(RID string) (types.Analysis, error) {
 }
 
 // AnalyzeResult analyzes the result received from HuskyCI API.
-func AnalyzeResult(analysisResult types.Analysis, cmdInput string) error {
+func AnalyzeResult(analysisResult types.Analysis) {
 	fmt.Println()
 	for _, container := range analysisResult.Containers {
 		CheckMongoDBContainerOutput(container)
 	}
+}
 
-	if cmdInput == "JSON" {
-		err := PrintJSONOutput()
+// PrintResults prints huskyCI output either in JSON or the standard output.
+func PrintResults(formatOutput string) error {
+	if formatOutput == "JSON" {
+		err := printJSONOutput()
 		if err != nil {
 			return err
 		}
 	} else {
-		PrinthuskyCIOutput()
+		printhuskyCIOutput()
 	}
 
 	return nil

--- a/client/analysis/output.go
+++ b/client/analysis/output.go
@@ -63,7 +63,8 @@ func PrepareGosecOutput(mongoDBcontainerOutput string, mongoDBcontainerInfo stri
 
 	for _, issue := range gosecOutput.GosecIssues {
 		gosecVuln := types.HuskyCIVulnerability{}
-		gosecVuln.SecurityTool = "gosec"
+		gosecVuln.Language = "Go"
+		gosecVuln.SecurityTool = "GoSec"
 		gosecVuln.Severity = issue.Severity
 		gosecVuln.Confidence = issue.Confidence
 		gosecVuln.Details = issue.Details
@@ -97,7 +98,8 @@ func PrepareBanditOutput(mongoDBcontainerOutput string, mongoDBcontainerInfo str
 
 	for _, issue := range banditOutput.Results {
 		banditVuln := types.HuskyCIVulnerability{}
-		banditVuln.SecurityTool = "bandit"
+		banditVuln.Language = "Python"
+		banditVuln.SecurityTool = "Bandit"
 		banditVuln.Severity = issue.IssueSeverity
 		banditVuln.Confidence = issue.IssueConfidence
 		banditVuln.Details = issue.IssueText
@@ -124,7 +126,8 @@ func PrepareRetirejsOutput(mongoDBcontainerOutput string, mongoDBcontainerInfo s
 
 	if strings.Contains(mongoDBcontainerInfo, "ERROR_RUNNING_RETIREJS") {
 		retirejsVuln := types.HuskyCIVulnerability{}
-		retirejsVuln.SecurityTool = "retirejs"
+		retirejsVuln.Language = "JavaScript"
+		retirejsVuln.SecurityTool = "RetireJS"
 		retirejsVuln.Severity = "info"
 		retirejsVuln.Confidence = "high"
 		retirejsVuln.Details = "It looks like your project doesn't have package.json or yarn.lock. huskyCI was not able to run RetireJS properly."
@@ -146,7 +149,8 @@ func PrepareRetirejsOutput(mongoDBcontainerOutput string, mongoDBcontainerInfo s
 		for _, result := range output.Results {
 			for _, vulnerability := range result.Vulnerabilities {
 				retirejsVuln := types.HuskyCIVulnerability{}
-				retirejsVuln.SecurityTool = "retirejs"
+				retirejsVuln.Language = "JavaScript"
+				retirejsVuln.SecurityTool = "RetireJS"
 				retirejsVuln.Severity = vulnerability.Severity
 				retirejsVuln.Code = result.Component
 				retirejsVuln.Version = result.Version
@@ -187,7 +191,8 @@ func PrepareBrakemanOutput(mongoDBcontainerOutput string, mongoDBcontainerInfo s
 
 	for _, warning := range brakemanOutput.Warnings {
 		brakemanVuln := types.HuskyCIVulnerability{}
-		brakemanVuln.SecurityTool = "brakeman"
+		brakemanVuln.Language = "Ruby"
+		brakemanVuln.SecurityTool = "Brakeman"
 		brakemanVuln.Confidence = warning.Confidence
 		brakemanVuln.Details = warning.Details + warning.Message
 		brakemanVuln.File = warning.File
@@ -214,7 +219,8 @@ func PrepareSafetyOutput(mongoDBcontainerOutput string, mongoDBcontainerInfo str
 
 	if mongoDBcontainerInfo == "Requirements not found or this project uses latest dependencies." {
 		safetyVuln := types.HuskyCIVulnerability{}
-		safetyVuln.SecurityTool = "safety"
+		safetyVuln.Language = "Python"
+		safetyVuln.SecurityTool = "Safety"
 		safetyVuln.Severity = "info"
 		safetyVuln.Details = "requirements.txt not found or this project uses latest dependencies"
 
@@ -251,7 +257,8 @@ func PrepareSafetyOutput(mongoDBcontainerOutput string, mongoDBcontainerInfo str
 		}
 		for _, warning := range outputWarnings {
 			safetyVuln := types.HuskyCIVulnerability{}
-			safetyVuln.SecurityTool = "safety"
+			safetyVuln.Language = "Python"
+			safetyVuln.SecurityTool = "Safety"
 			safetyVuln.Severity = "warning"
 			safetyVuln.Details = warning
 
@@ -265,7 +272,8 @@ func PrepareSafetyOutput(mongoDBcontainerOutput string, mongoDBcontainerInfo str
 
 	for _, issue := range safetyOutput.SafetyIssues {
 		safetyVuln := types.HuskyCIVulnerability{}
-		safetyVuln.SecurityTool = "safety"
+		safetyVuln.Language = "Python"
+		safetyVuln.SecurityTool = "Safety"
 		safetyVuln.Severity = "high"
 		safetyVuln.Details = issue.Comment
 		safetyVuln.Code = issue.Version
@@ -290,6 +298,8 @@ func printJSONOutput() error {
 // PrinthuskyCIOutput prints the analysis output in huskyCI's format
 func printhuskyCIOutput() {
 	for _, issue := range outputJSON.GoResults.GosecOutput {
+		fmt.Printf("[HUSKYCI][!] Language: %s\n", issue.Language)
+		fmt.Printf("[HUSKYCI][!] Tool: %s\n", issue.SecurityTool)
 		fmt.Printf("[HUSKYCI][!] Severity: %s\n", issue.Severity)
 		fmt.Printf("[HUSKYCI][!] Confidence: %s\n", issue.Confidence)
 		fmt.Printf("[HUSKYCI][!] Details: %s\n", issue.Details)
@@ -300,6 +310,8 @@ func printhuskyCIOutput() {
 	}
 
 	for _, issue := range outputJSON.PythonResults.BanditOutput {
+		fmt.Printf("[HUSKYCI][!] Language: %s\n", issue.Language)
+		fmt.Printf("[HUSKYCI][!] Tool: %s\n", issue.SecurityTool)
 		fmt.Printf("[HUSKYCI][!] Severity: %s\n", issue.Severity)
 		fmt.Printf("[HUSKYCI][!] Confidence: %s\n", issue.Confidence)
 		fmt.Printf("[HUSKYCI][!] Details: %s\n", issue.Details)
@@ -310,14 +322,18 @@ func printhuskyCIOutput() {
 	}
 
 	for _, issue := range outputJSON.PythonResults.SafetyOutput {
+		fmt.Printf("[HUSKYCI][!] Language: %s\n", issue.Language)
+		fmt.Printf("[HUSKYCI][!] Tool: %s\n", issue.SecurityTool)
 		fmt.Printf("[HUSKYCI][!] Severity: %s\n", issue.Severity)
 		fmt.Printf("[HUSKYCI][!] Details: %s\n", issue.Details)
-		fmt.Printf("[HUSKYCI][!] Code:\n%s\n", issue.Code)
-		fmt.Printf("[HUSKYCI][!] Vulnerable Below:\n%s\n", issue.VunerableBelow)
+		fmt.Printf("[HUSKYCI][!] Code: %s\n", issue.Code)
+		fmt.Printf("[HUSKYCI][!] Vulnerable Below: %s\n", issue.VunerableBelow)
 		fmt.Println()
 	}
 
 	for _, issue := range outputJSON.RubyResults.BrakemanOutput {
+		fmt.Printf("[HUSKYCI][!] Language: %s\n", issue.Language)
+		fmt.Printf("[HUSKYCI][!] Tool: %s\n", issue.SecurityTool)
 		fmt.Printf("[HUSKYCI][!] Confidence: %s\n", issue.Confidence)
 		fmt.Printf("[HUSKYCI][!] Details: %s\n", issue.Details)
 		fmt.Printf("[HUSKYCI][!] File: %s\n", issue.File)
@@ -328,6 +344,8 @@ func printhuskyCIOutput() {
 	}
 
 	for _, issue := range outputJSON.JavaScriptResults.RetirejsResult {
+		fmt.Printf("[HUSKYCI][!] Language: %s\n", issue.Language)
+		fmt.Printf("[HUSKYCI][!] Tool: %s\n", issue.SecurityTool)
 		fmt.Printf("[HUSKYCI][!] Severity: %s\n", issue.Severity)
 		fmt.Printf("[HUSKYCI][!] Code: %s\n", issue.Code)
 		fmt.Printf("[HUSKYCI][!] Version: %s\n", issue.Version)

--- a/client/analysis/output.go
+++ b/client/analysis/output.go
@@ -328,8 +328,10 @@ func printhuskyCIOutput() {
 		fmt.Printf("[HUSKYCI][!] Tool: %s\n", issue.SecurityTool)
 		fmt.Printf("[HUSKYCI][!] Severity: %s\n", issue.Severity)
 		fmt.Printf("[HUSKYCI][!] Details: %s\n", issue.Details)
-		fmt.Printf("[HUSKYCI][!] Code: %s\n", issue.Code)
-		fmt.Printf("[HUSKYCI][!] Vulnerable Below: %s\n", issue.VunerableBelow)
+		if issue.Details != "requirements.txt not found or this project uses latest dependencies" {
+			fmt.Printf("[HUSKYCI][!] Code: %s\n", issue.Code)
+			fmt.Printf("[HUSKYCI][!] Vulnerable Below: %s\n", issue.VunerableBelow)
+		}
 		fmt.Println()
 	}
 

--- a/client/analysis/output.go
+++ b/client/analysis/output.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/fatih/color"
 	"github.com/globocom/huskyCI/client/types"
 	"github.com/globocom/huskyCI/client/util"
 )
@@ -146,6 +147,8 @@ func PrepareRetirejsOutput(mongoDBcontainerOutput string, mongoDBcontainerInfo s
 				retirejsVuln := types.HuskyCIVulnerability{}
 				retirejsVuln.SecurityTool = "retirejs"
 				retirejsVuln.Severity = vulnerability.Severity
+				retirejsVuln.Code = result.Component
+				retirejsVuln.Version = result.Version
 				for _, info := range vulnerability.Info {
 					retirejsVuln.Details = retirejsVuln.Details + info
 				}
@@ -264,4 +267,132 @@ func PrepareSafetyOutput(mongoDBcontainerOutput string, mongoDBcontainerInfo str
 	}
 
 	types.FoundVuln = true
+}
+
+// PrintJSONOutput prints the analysis output in a JSON format
+func PrintJSONOutput() error {
+	jsonReady, err := json.Marshal(outputJSON)
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(jsonReady))
+	return nil
+}
+
+// PrinthuskyCIOutput prints the analysis output in huskyCI's format
+func PrinthuskyCIOutput() {
+	for _, issue := range outputJSON.GoResults.GosecOutput {
+		if (issue.Severity == "HIGH") && (issue.Confidence == "HIGH") {
+			color.Red("[HUSKYCI][!] Severity: %s", issue.Severity)
+			color.Red("[HUSKYCI][!] Confidence: %s", issue.Confidence)
+			color.Red("[HUSKYCI][!] Details: %s", issue.Details)
+			color.Red("[HUSKYCI][!] File: %s", issue.File)
+			color.Red("[HUSKYCI][!] Line: %s", issue.Line)
+			color.Red("[HUSKYCI][!] Code: %s", issue.Code)
+			fmt.Println()
+		} else if (issue.Severity == "MEDIUM") && (issue.Confidence == "HIGH") {
+			color.Yellow("[HUSKYCI][!] Severity: %s", issue.Severity)
+			color.Yellow("[HUSKYCI][!] Confidence: %s", issue.Confidence)
+			color.Yellow("[HUSKYCI][!] Details: %s", issue.Details)
+			color.Yellow("[HUSKYCI][!] File: %s", issue.File)
+			color.Yellow("[HUSKYCI][!] Line: %s", issue.Line)
+			color.Yellow("[HUSKYCI][!] Code: %s", issue.Code)
+			fmt.Println()
+		} else if issue.Severity == "LOW" {
+			color.Blue("[HUSKYCI][!] Severity: %s", issue.Severity)
+			color.Blue("[HUSKYCI][!] Confidence: %s", issue.Confidence)
+			color.Blue("[HUSKYCI][!] Details: %s", issue.Details)
+			color.Blue("[HUSKYCI][!] File: %s", issue.File)
+			color.Blue("[HUSKYCI][!] Line: %s", issue.Line)
+			color.Blue("[HUSKYCI][!] Code: %s", issue.Code)
+			fmt.Println()
+		}
+	}
+
+	for _, issue := range outputJSON.PythonResults.BanditOutput {
+		if (issue.Severity == "HIGH") && (issue.Confidence == "HIGH") {
+			color.Red("[HUSKYCI][!] Severity: %s", issue.Severity)
+			color.Red("[HUSKYCI][!] Confidence: %s", issue.Confidence)
+			color.Red("[HUSKYCI][!] Details: %s", issue.Details)
+			color.Red("[HUSKYCI][!] File: %s", issue.File)
+			color.Red("[HUSKYCI][!] Line: %s", issue.Line)
+			color.Red("[HUSKYCI][!] Code:\n%s", issue.Code)
+			fmt.Println()
+		} else if (issue.Severity == "MEDIUM") && (issue.Confidence == "HIGH") {
+			color.Yellow("[HUSKYCI][!] Severity: %s", issue.Severity)
+			color.Yellow("[HUSKYCI][!] Confidence: %s", issue.Confidence)
+			color.Yellow("[HUSKYCI][!] Details: %s", issue.Details)
+			color.Yellow("[HUSKYCI][!] File: %s", issue.File)
+			color.Yellow("[HUSKYCI][!] Line: %s", issue.Line)
+			color.Yellow("[HUSKYCI][!] Code:\n%s", issue.Code)
+			fmt.Println()
+		} else if issue.Severity == "LOW" {
+			color.Blue("[HUSKYCI][!] Severity: %s", issue.Severity)
+			color.Blue("[HUSKYCI][!] Confidence: %s", issue.Confidence)
+			color.Blue("[HUSKYCI][!] Details: %s", issue.Details)
+			color.Blue("[HUSKYCI][!] File: %s", issue.File)
+			color.Blue("[HUSKYCI][!] Line: %s", issue.Line)
+			color.Blue("[HUSKYCI][!] Code:\n%s", issue.Code)
+			fmt.Println()
+		}
+	}
+
+	for _, issue := range outputJSON.PythonResults.SafetyOutput {
+		color.Red("[HUSKYCI][!] Severity: %s", issue.Severity)
+		color.Red("[HUSKYCI][!] Details: %s", issue.Details)
+		color.Red("[HUSKYCI][!] Code:\n%s", issue.Code)
+		color.Red("[HUSKYCI][!] Vulnerable Below:\n%s", issue.VunerableBelow)
+		fmt.Println()
+	}
+
+	for _, issue := range outputJSON.RubyResults.BrakemanOutput {
+		if issue.Confidence == "High" {
+			color.Red("[HUSKYCI][!] Confidence: %s", issue.Confidence)
+			color.Red("[HUSKYCI][!] Details: %s", issue.Details)
+			color.Red("[HUSKYCI][!] File: %s", issue.File)
+			color.Red("[HUSKYCI][!] Line: %s", issue.Line)
+			color.Red("[HUSKYCI][!] Code: %s", issue.Code)
+			color.Red("[HUSKYCI][!] Type: %s", issue.Type)
+			fmt.Println()
+		} else if issue.Confidence == "MEDIUM" {
+			color.Yellow("[HUSKYCI][!] Confidence: %s", issue.Confidence)
+			color.Yellow("[HUSKYCI][!] Details: %s", issue.Details)
+			color.Yellow("[HUSKYCI][!] File: %s", issue.File)
+			color.Yellow("[HUSKYCI][!] Line: %s", issue.Line)
+			color.Yellow("[HUSKYCI][!] Code: %s", issue.Code)
+			color.Yellow("[HUSKYCI][!] Type: %s", issue.Type)
+			fmt.Println()
+		} else if issue.Confidence == "LOW" {
+			color.Blue("[HUSKYCI][!] Confidence: %s", issue.Confidence)
+			color.Blue("[HUSKYCI][!] Details: %s", issue.Details)
+			color.Blue("[HUSKYCI][!] File: %s", issue.File)
+			color.Blue("[HUSKYCI][!] Line: %s", issue.Line)
+			color.Blue("[HUSKYCI][!] Code: %s", issue.Code)
+			color.Blue("[HUSKYCI][!] Type: %s", issue.Type)
+			fmt.Println()
+		}
+	}
+
+	for _, issue := range outputJSON.JavaScriptResults.RetirejsResult {
+		if issue.Severity == "high" {
+			color.Red("[HUSKYCI][!] Severity: %s", issue.Severity)
+			color.Red("[HUSKYCI][!] Code: %s", issue.Code)
+			color.Red("[HUSKYCI][!] Version: %s", issue.Version)
+			color.Red("[HUSKYCI][!] Details: %s", issue.Details)
+			fmt.Println()
+		} else if issue.Severity == "medium" {
+			color.Yellow("[HUSKYCI][!] Severity: %s", issue.Severity)
+			color.Yellow("[HUSKYCI][!] Code: %s", issue.Code)
+			color.Yellow("[HUSKYCI][!] Version: %s", issue.Version)
+			color.Yellow("[HUSKYCI][!] Details: %s", issue.Details)
+			fmt.Println()
+		} else if issue.Severity == "low" {
+			color.Blue("[HUSKYCI][!] Severity: %s", issue.Severity)
+			color.Blue("[HUSKYCI][!] Code: %s", issue.Code)
+			color.Blue("[HUSKYCI][!] Version: %s", issue.Version)
+			color.Blue("[HUSKYCI][!] Details: %s", issue.Details)
+			fmt.Println()
+		}
+
+	}
 }

--- a/client/analysis/output.go
+++ b/client/analysis/output.go
@@ -21,25 +21,25 @@ var pythonResults types.PythonResults
 var javaScriptResults types.JavaScriptResults
 var rubyResults types.RubyResults
 
-// CheckMongoDBContainerOutput will validate the output of a given container.
-func CheckMongoDBContainerOutput(container types.Container) {
+// prepareSecurityTestResult preares the output of a given securityTest.
+func prepareSecurityTestResult(container types.Container) {
 
 	switch container.SecurityTest.Name {
 	case "enry":
 	case "gosec":
-		PrepareGosecOutput(container.COutput, container.CInfo)
+		prepareGosecOutput(container.COutput, container.CInfo)
 		outputJSON.GoResults = goResults
 	case "bandit":
-		PrepareBanditOutput(container.COutput, container.CInfo)
+		prepareBanditOutput(container.COutput, container.CInfo)
 		outputJSON.PythonResults.BanditOutput = pythonResults.BanditOutput
 	case "retirejs":
-		PrepareRetirejsOutput(container.COutput, container.CInfo)
+		prepareRetirejsOutput(container.COutput, container.CInfo)
 		outputJSON.JavaScriptResults.RetirejsResult = javaScriptResults.RetirejsResult
 	case "brakeman":
-		PrepareBrakemanOutput(container.COutput, container.CInfo)
+		prepareBrakemanOutput(container.COutput, container.CInfo)
 		outputJSON.RubyResults.BrakemanOutput = rubyResults.BrakemanOutput
 	case "safety":
-		PrepareSafetyOutput(container.COutput, container.CInfo)
+		prepareSafetyOutput(container.COutput, container.CInfo)
 		outputJSON.PythonResults.SafetyOutput = pythonResults.SafetyOutput
 	default:
 		fmt.Println("[HUSKYCI][ERROR] securityTest name not recognized:", container.SecurityTest.Name)
@@ -47,8 +47,8 @@ func CheckMongoDBContainerOutput(container types.Container) {
 	}
 }
 
-// PrepareGosecOutput will prepare Gosec output.
-func PrepareGosecOutput(mongoDBcontainerOutput string, mongoDBcontainerInfo string) {
+// prepareGosecOutput will prepare Gosec output.
+func prepareGosecOutput(mongoDBcontainerOutput string, mongoDBcontainerInfo string) {
 
 	if mongoDBcontainerInfo == "No issues found." {
 		return
@@ -82,8 +82,8 @@ func PrepareGosecOutput(mongoDBcontainerOutput string, mongoDBcontainerInfo stri
 	}
 }
 
-// PrepareBanditOutput will prepare Bandit output.
-func PrepareBanditOutput(mongoDBcontainerOutput string, mongoDBcontainerInfo string) {
+// prepareBanditOutput will prepare Bandit output.
+func prepareBanditOutput(mongoDBcontainerOutput string, mongoDBcontainerInfo string) {
 
 	if mongoDBcontainerInfo == "No issues found." {
 		return
@@ -117,8 +117,8 @@ func PrepareBanditOutput(mongoDBcontainerOutput string, mongoDBcontainerInfo str
 	}
 }
 
-// PrepareRetirejsOutput will prepare Retirejs output.
-func PrepareRetirejsOutput(mongoDBcontainerOutput string, mongoDBcontainerInfo string) {
+// prepareRetirejsOutput will prepare Retirejs output.
+func prepareRetirejsOutput(mongoDBcontainerOutput string, mongoDBcontainerInfo string) {
 
 	if mongoDBcontainerInfo == "No issues found." {
 		return
@@ -175,8 +175,8 @@ func PrepareRetirejsOutput(mongoDBcontainerOutput string, mongoDBcontainerInfo s
 	}
 }
 
-// PrepareBrakemanOutput will prepare Brakeman output.
-func PrepareBrakemanOutput(mongoDBcontainerOutput string, mongoDBcontainerInfo string) {
+// prepareBrakemanOutput will prepare Brakeman output.
+func prepareBrakemanOutput(mongoDBcontainerOutput string, mongoDBcontainerInfo string) {
 
 	if mongoDBcontainerInfo == "No issues found." {
 		return
@@ -212,8 +212,8 @@ func PrepareBrakemanOutput(mongoDBcontainerOutput string, mongoDBcontainerInfo s
 	}
 }
 
-// PrepareSafetyOutput will prepare Safety output.
-func PrepareSafetyOutput(mongoDBcontainerOutput string, mongoDBcontainerInfo string) {
+// prepareSafetyOutput will prepare Safety output.
+func prepareSafetyOutput(mongoDBcontainerOutput string, mongoDBcontainerInfo string) {
 
 	if mongoDBcontainerInfo == "No issues found." {
 		return
@@ -286,9 +286,8 @@ func PrepareSafetyOutput(mongoDBcontainerOutput string, mongoDBcontainerInfo str
 	}
 }
 
-// PrintJSONOutput prints the analysis output in a JSON format
+// printJSONOutput prints the analysis output in a JSON format
 func printJSONOutput() error {
-	calculateSummary()
 	jsonReady := []byte{}
 	var err error
 	if jsonReady, err = json.Marshal(outputJSON); err != nil {
@@ -298,9 +297,9 @@ func printJSONOutput() error {
 	return nil
 }
 
-// PrinthuskyCIOutput prints the analysis output in huskyCI's format
-func printhuskyCIOutput() {
-	calculateSummary()
+// printSTDOUTOutput prints the analysis output in STDOUT using printfs
+func printSTDOUTOutput() {
+
 	for _, issue := range outputJSON.GoResults.GosecOutput {
 		fmt.Printf("[HUSKYCI][!] Language: %s\n", issue.Language)
 		fmt.Printf("[HUSKYCI][!] Tool: %s\n", issue.SecurityTool)
@@ -310,13 +309,6 @@ func printhuskyCIOutput() {
 		fmt.Printf("[HUSKYCI][!] File: %s\n", issue.File)
 		fmt.Printf("[HUSKYCI][!] Line: %s\n", issue.Line)
 		fmt.Printf("[HUSKYCI][!] Code: %s\n", issue.Code)
-		fmt.Println()
-	}
-	if outputJSON.Summary.GosecSummary.FoundVuln {
-		fmt.Printf("[HUSKYCI][SUMMARY] Go -> GoSec\n")
-		fmt.Printf("[HUSKYCI][SUMMARY] High: %d\n", outputJSON.Summary.GosecSummary.HighVuln)
-		fmt.Printf("[HUSKYCI][SUMMARY] Medium: %d\n", outputJSON.Summary.GosecSummary.MediumVuln)
-		fmt.Printf("[HUSKYCI][SUMMARY] Low: %d\n", outputJSON.Summary.GosecSummary.LowVuln)
 		fmt.Println()
 	}
 
@@ -331,13 +323,6 @@ func printhuskyCIOutput() {
 		fmt.Printf("[HUSKYCI][!] Code:\n%s\n", issue.Code)
 		fmt.Println()
 	}
-	if outputJSON.Summary.BanditSummary.FoundVuln {
-		fmt.Printf("[HUSKYCI][SUMMARY] Python -> Bandit\n")
-		fmt.Printf("[HUSKYCI][SUMMARY] High: %d\n", outputJSON.Summary.BanditSummary.HighVuln)
-		fmt.Printf("[HUSKYCI][SUMMARY] Medium: %d\n", outputJSON.Summary.BanditSummary.MediumVuln)
-		fmt.Printf("[HUSKYCI][SUMMARY] Low: %d\n", outputJSON.Summary.BanditSummary.LowVuln)
-		fmt.Println()
-	}
 
 	for _, issue := range outputJSON.PythonResults.SafetyOutput {
 		fmt.Printf("[HUSKYCI][!] Language: %s\n", issue.Language)
@@ -348,12 +333,6 @@ func printhuskyCIOutput() {
 			fmt.Printf("[HUSKYCI][!] Code: %s\n", issue.Code)
 			fmt.Printf("[HUSKYCI][!] Vulnerable Below: %s\n", issue.VunerableBelow)
 		}
-		fmt.Println()
-	}
-	if outputJSON.Summary.SafetySummary.FoundVuln {
-		fmt.Printf("[HUSKYCI][SUMMARY] Python -> Safety\n")
-		fmt.Printf("[HUSKYCI][SUMMARY] High: %d\n", outputJSON.Summary.BanditSummary.HighVuln)
-		fmt.Printf("[HUSKYCI][SUMMARY] Low: %d\n", outputJSON.Summary.BanditSummary.LowVuln)
 		fmt.Println()
 	}
 
@@ -368,13 +347,6 @@ func printhuskyCIOutput() {
 		fmt.Printf("[HUSKYCI][!] Type: %s\n", issue.Type)
 		fmt.Println()
 	}
-	if outputJSON.Summary.BrakemanSummary.FoundVuln {
-		fmt.Printf("[HUSKYCI][SUMMARY] Ruby -> Brakeman\n")
-		fmt.Printf("[HUSKYCI][SUMMARY] High: %d\n", outputJSON.Summary.BrakemanSummary.HighVuln)
-		fmt.Printf("[HUSKYCI][SUMMARY] Medium: %d\n", outputJSON.Summary.BrakemanSummary.MediumVuln)
-		fmt.Printf("[HUSKYCI][SUMMARY] Low: %d\n", outputJSON.Summary.BrakemanSummary.LowVuln)
-		fmt.Println()
-	}
 
 	for _, issue := range outputJSON.JavaScriptResults.RetirejsResult {
 		fmt.Printf("[HUSKYCI][!] Language: %s\n", issue.Language)
@@ -385,30 +357,19 @@ func printhuskyCIOutput() {
 		fmt.Printf("[HUSKYCI][!] Details: %s\n", issue.Details)
 		fmt.Println()
 	}
-	if outputJSON.Summary.RetirejsSummary.FoundVuln {
-		fmt.Printf("[HUSKYCI][SUMMARY] JavaScript -> RetireJS\n")
-		fmt.Printf("[HUSKYCI][SUMMARY] High: %d\n", outputJSON.Summary.RetirejsSummary.HighVuln)
-		fmt.Printf("[HUSKYCI][SUMMARY] Medium: %d\n", outputJSON.Summary.RetirejsSummary.MediumVuln)
-		fmt.Printf("[HUSKYCI][SUMMARY] Low: %d\n", outputJSON.Summary.RetirejsSummary.LowVuln)
-		fmt.Println()
-	}
 
-	fmt.Printf("[HUSKYCI][SUMMARY] Total\n")
-	fmt.Printf("[HUSKYCI][SUMMARY] High: %d\n", outputJSON.Summary.TotalSummary.HighVuln)
-	fmt.Printf("[HUSKYCI][SUMMARY] Medium: %d\n", outputJSON.Summary.TotalSummary.MediumVuln)
-	fmt.Printf("[HUSKYCI][SUMMARY] Low: %d\n", outputJSON.Summary.TotalSummary.LowVuln)
-	fmt.Println()
+	printAllSummary()
 }
 
-// calculateSummary calculates how many low, medium and high vulnerabilites were found.
-func calculateSummary() {
+// prepareAllSummary prepares how many low, medium and high vulnerabilites were found.
+func prepareAllSummary() {
 	var totalLow, totalMedium, totalHigh int
 
 	// GoSec summary
 	for _, issue := range outputJSON.GoResults.GosecOutput {
 		switch issue.Severity {
 		case "LOW":
-			outputJSON.Summary.GosecSummary.FoundVuln = true
+			outputJSON.Summary.GosecSummary.FoundInfo = true
 			outputJSON.Summary.GosecSummary.LowVuln++
 		case "MEDIUM":
 			outputJSON.Summary.GosecSummary.FoundVuln = true
@@ -423,7 +384,7 @@ func calculateSummary() {
 	for _, issue := range outputJSON.PythonResults.BanditOutput {
 		switch issue.Severity {
 		case "LOW":
-			outputJSON.Summary.BanditSummary.FoundVuln = true
+			outputJSON.Summary.BanditSummary.FoundInfo = true
 			outputJSON.Summary.BanditSummary.LowVuln++
 		case "MEDIUM":
 			outputJSON.Summary.BanditSummary.FoundVuln = true
@@ -438,10 +399,10 @@ func calculateSummary() {
 	for _, issue := range outputJSON.PythonResults.SafetyOutput {
 		switch issue.Severity {
 		case "info":
-			outputJSON.Summary.SafetySummary.FoundVuln = true
+			outputJSON.Summary.SafetySummary.FoundInfo = true
 			outputJSON.Summary.SafetySummary.LowVuln++
 		case "warning":
-			outputJSON.Summary.SafetySummary.FoundVuln = true
+			outputJSON.Summary.SafetySummary.FoundInfo = true
 			outputJSON.Summary.SafetySummary.LowVuln++
 		case "high":
 			outputJSON.Summary.SafetySummary.FoundVuln = true
@@ -468,7 +429,7 @@ func calculateSummary() {
 	for _, issue := range outputJSON.JavaScriptResults.RetirejsResult {
 		switch issue.Severity {
 		case "low":
-			outputJSON.Summary.RetirejsSummary.FoundVuln = true
+			outputJSON.Summary.RetirejsSummary.FoundInfo = true
 			outputJSON.Summary.RetirejsSummary.LowVuln++
 		case "medium":
 			outputJSON.Summary.RetirejsSummary.FoundVuln = true
@@ -479,15 +440,71 @@ func calculateSummary() {
 		}
 	}
 
+	// Total summary
 	if outputJSON.Summary.GosecSummary.FoundVuln || outputJSON.Summary.BanditSummary.FoundVuln || outputJSON.Summary.SafetySummary.FoundVuln || outputJSON.Summary.BrakemanSummary.FoundVuln || outputJSON.Summary.RetirejsSummary.FoundVuln {
-		totalLow = outputJSON.Summary.RetirejsSummary.LowVuln + outputJSON.Summary.BrakemanSummary.LowVuln + outputJSON.Summary.SafetySummary.LowVuln + outputJSON.Summary.BanditSummary.LowVuln + outputJSON.Summary.GosecSummary.LowVuln
-		totalMedium = outputJSON.Summary.RetirejsSummary.MediumVuln + outputJSON.Summary.BrakemanSummary.MediumVuln + outputJSON.Summary.SafetySummary.MediumVuln + outputJSON.Summary.BanditSummary.MediumVuln + outputJSON.Summary.GosecSummary.MediumVuln
-		totalHigh = outputJSON.Summary.RetirejsSummary.HighVuln + outputJSON.Summary.BrakemanSummary.HighVuln + outputJSON.Summary.SafetySummary.HighVuln + outputJSON.Summary.BanditSummary.HighVuln + outputJSON.Summary.GosecSummary.HighVuln
-
 		outputJSON.Summary.TotalSummary.FoundVuln = true
-		outputJSON.Summary.TotalSummary.HighVuln = totalHigh
-		outputJSON.Summary.TotalSummary.MediumVuln = totalMedium
-		outputJSON.Summary.TotalSummary.LowVuln = totalLow
+	} else if outputJSON.Summary.GosecSummary.FoundInfo || outputJSON.Summary.BanditSummary.FoundInfo || outputJSON.Summary.SafetySummary.FoundInfo || outputJSON.Summary.BrakemanSummary.FoundInfo || outputJSON.Summary.RetirejsSummary.FoundInfo {
+		outputJSON.Summary.TotalSummary.FoundInfo = true
+	}
+
+	totalLow = outputJSON.Summary.RetirejsSummary.LowVuln + outputJSON.Summary.BrakemanSummary.LowVuln + outputJSON.Summary.SafetySummary.LowVuln + outputJSON.Summary.BanditSummary.LowVuln + outputJSON.Summary.GosecSummary.LowVuln
+	totalMedium = outputJSON.Summary.RetirejsSummary.MediumVuln + outputJSON.Summary.BrakemanSummary.MediumVuln + outputJSON.Summary.SafetySummary.MediumVuln + outputJSON.Summary.BanditSummary.MediumVuln + outputJSON.Summary.GosecSummary.MediumVuln
+	totalHigh = outputJSON.Summary.RetirejsSummary.HighVuln + outputJSON.Summary.BrakemanSummary.HighVuln + outputJSON.Summary.SafetySummary.HighVuln + outputJSON.Summary.BanditSummary.HighVuln + outputJSON.Summary.GosecSummary.HighVuln
+
+	outputJSON.Summary.TotalSummary.HighVuln = totalHigh
+	outputJSON.Summary.TotalSummary.MediumVuln = totalMedium
+	outputJSON.Summary.TotalSummary.LowVuln = totalLow
+
+}
+
+func printAllSummary() {
+
+	if outputJSON.Summary.GosecSummary.FoundVuln || outputJSON.Summary.GosecSummary.FoundInfo {
+		fmt.Printf("[HUSKYCI][SUMMARY] Go -> GoSec\n")
+		fmt.Printf("[HUSKYCI][SUMMARY] High: %d\n", outputJSON.Summary.GosecSummary.HighVuln)
+		fmt.Printf("[HUSKYCI][SUMMARY] Medium: %d\n", outputJSON.Summary.GosecSummary.MediumVuln)
+		fmt.Printf("[HUSKYCI][SUMMARY] Low: %d\n", outputJSON.Summary.GosecSummary.LowVuln)
+		fmt.Println()
+	}
+
+	if outputJSON.Summary.BanditSummary.FoundVuln || outputJSON.Summary.BanditSummary.FoundInfo {
+		fmt.Printf("[HUSKYCI][SUMMARY] Python -> Bandit\n")
+		fmt.Printf("[HUSKYCI][SUMMARY] High: %d\n", outputJSON.Summary.BanditSummary.HighVuln)
+		fmt.Printf("[HUSKYCI][SUMMARY] Medium: %d\n", outputJSON.Summary.BanditSummary.MediumVuln)
+		fmt.Printf("[HUSKYCI][SUMMARY] Low: %d\n", outputJSON.Summary.BanditSummary.LowVuln)
+		fmt.Println()
+	}
+
+	if outputJSON.Summary.SafetySummary.FoundVuln || outputJSON.Summary.SafetySummary.FoundInfo {
+		fmt.Printf("[HUSKYCI][SUMMARY] Python -> Safety\n")
+		fmt.Printf("[HUSKYCI][SUMMARY] High: %d\n", outputJSON.Summary.BanditSummary.HighVuln)
+		fmt.Printf("[HUSKYCI][SUMMARY] Medium: %d\n", outputJSON.Summary.BanditSummary.MediumVuln)
+		fmt.Printf("[HUSKYCI][SUMMARY] Low: %d\n", outputJSON.Summary.BanditSummary.LowVuln)
+		fmt.Println()
+	}
+
+	if outputJSON.Summary.BrakemanSummary.FoundVuln || outputJSON.Summary.BrakemanSummary.FoundInfo {
+		fmt.Printf("[HUSKYCI][SUMMARY] Ruby -> Brakeman\n")
+		fmt.Printf("[HUSKYCI][SUMMARY] High: %d\n", outputJSON.Summary.BrakemanSummary.HighVuln)
+		fmt.Printf("[HUSKYCI][SUMMARY] Medium: %d\n", outputJSON.Summary.BrakemanSummary.MediumVuln)
+		fmt.Printf("[HUSKYCI][SUMMARY] Low: %d\n", outputJSON.Summary.BrakemanSummary.LowVuln)
+		fmt.Println()
+	}
+
+	if outputJSON.Summary.RetirejsSummary.FoundVuln || outputJSON.Summary.RetirejsSummary.FoundInfo {
+		fmt.Printf("[HUSKYCI][SUMMARY] JavaScript -> RetireJS\n")
+		fmt.Printf("[HUSKYCI][SUMMARY] High: %d\n", outputJSON.Summary.RetirejsSummary.HighVuln)
+		fmt.Printf("[HUSKYCI][SUMMARY] Medium: %d\n", outputJSON.Summary.RetirejsSummary.MediumVuln)
+		fmt.Printf("[HUSKYCI][SUMMARY] Low: %d\n", outputJSON.Summary.RetirejsSummary.LowVuln)
+		fmt.Println()
+	}
+
+	if outputJSON.Summary.TotalSummary.FoundVuln || outputJSON.Summary.TotalSummary.FoundInfo {
+		fmt.Printf("[HUSKYCI][SUMMARY] Total\n")
+		fmt.Printf("[HUSKYCI][SUMMARY] High: %d\n", outputJSON.Summary.TotalSummary.HighVuln)
+		fmt.Printf("[HUSKYCI][SUMMARY] Medium: %d\n", outputJSON.Summary.TotalSummary.MediumVuln)
+		fmt.Printf("[HUSKYCI][SUMMARY] Low: %d\n", outputJSON.Summary.TotalSummary.LowVuln)
+		fmt.Println()
 	}
 
 }

--- a/client/analysis/output.go
+++ b/client/analysis/output.go
@@ -203,8 +203,10 @@ func PrepareBrakemanOutput(mongoDBcontainerOutput string, mongoDBcontainerInfo s
 		rubyResults.BrakemanOutput = append(rubyResults.BrakemanOutput, brakemanVuln)
 
 		if brakemanVuln.Confidence == "High" || brakemanVuln.Confidence == "Medium" {
+			brakemanVuln.Severity = "High"
 			types.FoundVuln = true
 		} else {
+			brakemanVuln.Severity = "Low"
 			types.FoundInfo = true
 		}
 	}
@@ -352,4 +354,137 @@ func printhuskyCIOutput() {
 		fmt.Printf("[HUSKYCI][!] Details: %s\n", issue.Details)
 		fmt.Println()
 	}
+}
+
+func printSummary() {
+
+	var gosecFound, banditFound, safetyFound, brakemanFound, retirejsFound bool
+	var gosecLow, gosecMedium, gosecHigh int
+	var banditLow, banditMedium, banditHigh int
+	var safetyLow, safetyMedium, safetyHigh int
+	var brakemanLow, brakemanMedium, brakemanHigh int
+	var retirejsLow, retirejsMedium, retirejsHigh int
+	var totalHigh, totalMedium, totalLow int
+
+	// GoSec summary
+	for _, issue := range outputJSON.GoResults.GosecOutput {
+		switch issue.Severity {
+		case "LOW":
+			gosecFound = true
+			gosecLow++
+		case "MEDIUM":
+			gosecFound = true
+			gosecMedium++
+		case "HIGH":
+			gosecFound = true
+			gosecHigh++
+		}
+	}
+	if gosecFound {
+		fmt.Printf("[HUSKYCI][SUMMARY] Go -> GoSec\n")
+		fmt.Printf("[HUSKYCI][SUMMARY] High: %d\n", gosecHigh)
+		fmt.Printf("[HUSKYCI][SUMMARY] Medium: %d\n", gosecMedium)
+		fmt.Printf("[HUSKYCI][SUMMARY] Low: %d\n", gosecLow)
+		fmt.Println()
+	}
+
+	// Bandit summary
+	for _, issue := range outputJSON.PythonResults.BanditOutput {
+		switch issue.Severity {
+		case "LOW":
+			banditFound = true
+			banditLow++
+		case "MEDIUM":
+			banditFound = true
+			banditMedium++
+		case "HIGH":
+			banditFound = true
+			banditHigh++
+		}
+	}
+	if banditFound {
+		fmt.Printf("[HUSKYCI][SUMMARY] Python -> Bandit\n")
+		fmt.Printf("[HUSKYCI][SUMMARY] High: %d\n", banditHigh)
+		fmt.Printf("[HUSKYCI][SUMMARY] Medium: %d\n", banditMedium)
+		fmt.Printf("[HUSKYCI][SUMMARY] Low: %d\n", banditLow)
+		fmt.Println()
+	}
+
+	// Safety summary
+	for _, issue := range outputJSON.PythonResults.SafetyOutput {
+		switch issue.Severity {
+		case "info":
+			safetyFound = true
+			safetyLow++
+		case "warning":
+			safetyFound = true
+			safetyLow++
+		case "high":
+			safetyFound = true
+			safetyHigh++
+		}
+	}
+	if safetyFound {
+		fmt.Printf("[HUSKYCI][SUMMARY] Python -> Safety\n")
+		fmt.Printf("[HUSKYCI][SUMMARY] High: %d\n", safetyHigh)
+		fmt.Printf("[HUSKYCI][SUMMARY] Medium: %d\n", safetyMedium)
+		fmt.Printf("[HUSKYCI][SUMMARY] Low: %d\n", safetyLow)
+		fmt.Println()
+	}
+
+	// Brakeman summary
+	for _, issue := range outputJSON.RubyResults.BrakemanOutput {
+		switch issue.Severity {
+		case "Low":
+			brakemanFound = true
+			brakemanLow++
+		case "Medium":
+			brakemanFound = true
+			brakemanMedium++
+		case "High":
+			brakemanFound = true
+			brakemanHigh++
+		}
+	}
+	if brakemanFound {
+		fmt.Printf("[HUSKYCI][SUMMARY] Ruby -> Brakeman\n")
+		fmt.Printf("[HUSKYCI][SUMMARY] High: %d\n", brakemanHigh)
+		fmt.Printf("[HUSKYCI][SUMMARY] Medium: %d\n", brakemanMedium)
+		fmt.Printf("[HUSKYCI][SUMMARY] Low: %d\n", brakemanLow)
+		fmt.Println()
+	}
+
+	// RetireJS summary
+	for _, issue := range outputJSON.JavaScriptResults.RetirejsResult {
+		switch issue.Severity {
+		case "low":
+			retirejsFound = true
+			retirejsLow++
+		case "medium":
+			retirejsFound = true
+			retirejsMedium++
+		case "high":
+			retirejsFound = true
+			retirejsHigh++
+		}
+	}
+	if retirejsFound {
+		fmt.Printf("[HUSKYCI][SUMMARY] JavaScript -> RetireJS\n")
+		fmt.Printf("[HUSKYCI][SUMMARY] High: %d\n", retirejsHigh)
+		fmt.Printf("[HUSKYCI][SUMMARY] Medium: %d\n", retirejsMedium)
+		fmt.Printf("[HUSKYCI][SUMMARY] Low: %d\n", retirejsLow)
+		fmt.Println()
+	}
+
+	if gosecFound || banditFound || safetyFound || brakemanFound || retirejsFound {
+		totalLow = gosecLow + banditLow + safetyLow + brakemanLow + retirejsLow
+		totalMedium = gosecMedium + banditMedium + safetyMedium + brakemanMedium + retirejsMedium
+		totalHigh = gosecHigh + banditHigh + safetyHigh + brakemanHigh + brakemanHigh
+		fmt.Printf("[HUSKYCI][SUMMARY] Total\n")
+		fmt.Printf("[HUSKYCI][SUMMARY] High: %d\n", totalHigh)
+		fmt.Printf("[HUSKYCI][SUMMARY] Medium: %d\n", totalMedium)
+		fmt.Printf("[HUSKYCI][SUMMARY] Low: %d\n", totalLow)
+		fmt.Println()
+	}
+
 }

--- a/client/analysis/output.go
+++ b/client/analysis/output.go
@@ -137,7 +137,6 @@ func prepareRetirejsOutput(mongoDBcontainerOutput string, mongoDBcontainerInfo s
 		return
 	}
 
-	foundVuln := false
 	retirejsOutput := []types.ResultsStruct{}
 	err := json.Unmarshal([]byte(mongoDBcontainerOutput), &retirejsOutput)
 	if err != nil {
@@ -168,10 +167,6 @@ func prepareRetirejsOutput(mongoDBcontainerOutput string, mongoDBcontainerInfo s
 				}
 			}
 		}
-	}
-
-	if foundVuln {
-		types.FoundVuln = true
 	}
 }
 
@@ -477,9 +472,9 @@ func printAllSummary() {
 
 	if outputJSON.Summary.SafetySummary.FoundVuln || outputJSON.Summary.SafetySummary.FoundInfo {
 		fmt.Printf("[HUSKYCI][SUMMARY] Python -> Safety\n")
-		fmt.Printf("[HUSKYCI][SUMMARY] High: %d\n", outputJSON.Summary.BanditSummary.HighVuln)
-		fmt.Printf("[HUSKYCI][SUMMARY] Medium: %d\n", outputJSON.Summary.BanditSummary.MediumVuln)
-		fmt.Printf("[HUSKYCI][SUMMARY] Low: %d\n", outputJSON.Summary.BanditSummary.LowVuln)
+		fmt.Printf("[HUSKYCI][SUMMARY] High: %d\n", outputJSON.Summary.SafetySummary.HighVuln)
+		fmt.Printf("[HUSKYCI][SUMMARY] Medium: %d\n", outputJSON.Summary.SafetySummary.MediumVuln)
+		fmt.Printf("[HUSKYCI][SUMMARY] Low: %d\n", outputJSON.Summary.SafetySummary.LowVuln)
 		fmt.Println()
 	}
 

--- a/client/cmd/main.go
+++ b/client/cmd/main.go
@@ -23,15 +23,14 @@ func main() {
 		os.Exit(1)
 	}
 	config.SetConfigs()
-	fmt.Println(fmt.Sprintf("[HUSKYCI][*] %s -> %s", config.RepositoryBranch, config.RepositoryURL))
 
 	// step 1: start analysis and get its RID.
+	fmt.Println(fmt.Sprintf("[HUSKYCI][*] %s -> %s", config.RepositoryBranch, config.RepositoryURL))
 	RID, err := analysis.StartAnalysis()
 	if err != nil {
 		fmt.Println("[HUSKYCI][ERROR] Sending request to huskyCI:", err)
 		os.Exit(1)
 	}
-
 	fmt.Println("[HUSKYCI][*] huskyCI analysis started!", RID)
 
 	// step 2: keep querying huskyCI API to check if a given analysis has already finished.
@@ -56,21 +55,25 @@ func main() {
 	}
 
 	// step 5: block developer CI if vulnerabilities were found
-	if types.FoundVuln == true {
-		if len(os.Args) < 1 {
-			fmt.Printf("[HUSKYCI][*] Some high issues were found :(\n")
-			os.Exit(1)
+	if types.FoundVuln == false && types.FoundInfo == false {
+		if len(os.Args) <= 1 {
+			fmt.Printf("[HUSKYCI][*] Nice! No issues were found :)\n")
 		}
-		os.Exit(1)
-	}
-
-	if types.FoundInfo == true && len(os.Args) < 1 {
-		fmt.Printf("[HUSKYCI][*] Some low/info issues were found :|\n")
 		os.Exit(0)
 	}
 
-	if len(os.Args) < 1 {
-		fmt.Printf("[HUSKYCI][*] Nice! No issues were found :)\n")
+	if types.FoundVuln == false && types.FoundInfo == true {
+		if len(os.Args) <= 1 {
+			fmt.Printf("[HUSKYCI][*] Some LOW/INFO issues were found :|\n")
+		}
+		os.Exit(0)
 	}
-	os.Exit(0)
+
+	if types.FoundVuln == true {
+		if len(os.Args) <= 1 {
+			fmt.Printf("[HUSKYCI][*] Some HIGH/MEDIUM issues were found :(\n")
+		}
+	}
+
+	os.Exit(1)
 }

--- a/client/cmd/main.go
+++ b/client/cmd/main.go
@@ -16,22 +16,35 @@ import (
 func main() {
 
 	types.FoundVuln = false
+	types.IsJSONoutput = false
+
+	if len(os.Args) > 1 {
+		if os.Args[1] == "JSON" {
+			types.IsJSONoutput = true
+		}
+	}
 
 	// step 0: check and set huskyci-client configuration
 	if err := config.CheckEnvVars(); err != nil {
-		fmt.Println("[HUSKYCI][ERROR] Check environment variables:", err)
+		if !types.IsJSONoutput {
+			fmt.Println("[HUSKYCI][ERROR] Check environment variables:", err)
+		}
 		os.Exit(1)
 	}
 	config.SetConfigs()
 
 	// step 1: start analysis and get its RID.
-	fmt.Println(fmt.Sprintf("[HUSKYCI][*] %s -> %s", config.RepositoryBranch, config.RepositoryURL))
+	if !types.IsJSONoutput {
+		fmt.Println(fmt.Sprintf("[HUSKYCI][*] %s -> %s", config.RepositoryBranch, config.RepositoryURL))
+	}
 	RID, err := analysis.StartAnalysis()
 	if err != nil {
 		fmt.Println("[HUSKYCI][ERROR] Sending request to huskyCI:", err)
 		os.Exit(1)
 	}
-	fmt.Println("[HUSKYCI][*] huskyCI analysis started!", RID)
+	if !types.IsJSONoutput {
+		fmt.Println("[HUSKYCI][*] huskyCI analysis started!", RID)
+	}
 
 	// step 2: keep querying huskyCI API to check if a given analysis has already finished.
 	huskyAnalysis, err := analysis.MonitorAnalysis(RID)
@@ -56,21 +69,21 @@ func main() {
 
 	// step 5: block developer CI if vulnerabilities were found
 	if types.FoundVuln == false && types.FoundInfo == false {
-		if len(os.Args) <= 1 {
+		if !types.IsJSONoutput {
 			fmt.Printf("[HUSKYCI][*] Nice! No issues were found :)\n")
 		}
 		os.Exit(0)
 	}
 
 	if types.FoundVuln == false && types.FoundInfo == true {
-		if len(os.Args) <= 1 {
+		if !types.IsJSONoutput {
 			fmt.Printf("[HUSKYCI][*] Some LOW/INFO issues were found :|\n")
 		}
 		os.Exit(0)
 	}
 
 	if types.FoundVuln == true {
-		if len(os.Args) <= 1 {
+		if !types.IsJSONoutput {
 			fmt.Printf("[HUSKYCI][*] Some HIGH/MEDIUM issues were found :(\n")
 		}
 	}

--- a/client/cmd/main.go
+++ b/client/cmd/main.go
@@ -41,21 +41,24 @@ func main() {
 		os.Exit(1)
 	}
 
-	// step 3: analyze result and return to CI the final result.
+	// step 3: analyze result
+	analysis.AnalyzeResult(huskyAnalysis)
+
+	// step 4: print output
+	formatOutput := ""
 	if len(os.Args) > 1 {
-		err = analysis.AnalyzeResult(huskyAnalysis, os.Args[1])
-	} else {
-		err = analysis.AnalyzeResult(huskyAnalysis, "")
+		formatOutput = "JSON"
 	}
+	err = analysis.PrintResults(formatOutput)
 	if err != nil {
 		fmt.Println("[HUSKYCI][ERROR] Printing output:", err)
 		os.Exit(1)
 	}
 
+	// step 5: block developer CI if vulnerabilities were found
 	if types.FoundVuln == true {
 		os.Exit(1)
 	}
 
 	os.Exit(0)
-
 }

--- a/client/cmd/main.go
+++ b/client/cmd/main.go
@@ -66,7 +66,9 @@ func main() {
 		os.Exit(0)
 	}
 
-	fmt.Printf("[HUSKYCI][*] Nice! No issues Found :)\n")
-	fmt.Println()
+	if len(os.Args) < 1 {
+		fmt.Printf("[HUSKYCI][*] Nice! No issues Found :)\n")
+		fmt.Println()
+	}
 	os.Exit(0)
 }

--- a/client/cmd/main.go
+++ b/client/cmd/main.go
@@ -42,7 +42,15 @@ func main() {
 	}
 
 	// step 3: analyze result and return to CI the final result.
-	analysis.AnalyzeResult(huskyAnalysis)
+	if len(os.Args) > 1 {
+		err = analysis.AnalyzeResult(huskyAnalysis, os.Args[1])
+	} else {
+		err = analysis.AnalyzeResult(huskyAnalysis, "")
+	}
+	if err != nil {
+		fmt.Println("[HUSKYCI][ERROR] Printing output:", err)
+		os.Exit(1)
+	}
 
 	if types.FoundVuln == true {
 		os.Exit(1)

--- a/client/cmd/main.go
+++ b/client/cmd/main.go
@@ -25,26 +25,26 @@ func main() {
 	config.SetConfigs()
 	fmt.Println(fmt.Sprintf("[HUSKYCI][*] %s -> %s", config.RepositoryBranch, config.RepositoryURL))
 
-	// step 1: start analysis and get a RID.
+	// step 1: start analysis and get its RID.
 	RID, err := analysis.StartAnalysis()
 	if err != nil {
-		fmt.Println("[HUSKYCI][ERROR] Sending request to HuskyCI:", err)
+		fmt.Println("[HUSKYCI][ERROR] Sending request to huskyCI:", err)
 		os.Exit(1)
 	}
 
 	fmt.Println("[HUSKYCI][*] huskyCI analysis started!", RID)
 
-	// step 2: keep querying husky API to check if a given analysis has already finished.
+	// step 2: keep querying huskyCI API to check if a given analysis has already finished.
 	huskyAnalysis, err := analysis.MonitorAnalysis(RID)
 	if err != nil {
 		fmt.Println(fmt.Sprintf("[HUSKYCI][ERROR] Monitoring analysis %s: %s", RID, err))
 		os.Exit(1)
 	}
 
-	// step 3: analyze result
-	analysis.AnalyzeResult(huskyAnalysis)
+	// step 3: prepares huskyCI results into structs
+	analysis.PrepareResults(huskyAnalysis)
 
-	// step 4: print output
+	// step 4: print output based on os.Args(1) parameter received
 	formatOutput := ""
 	if len(os.Args) > 1 {
 		formatOutput = "JSON"
@@ -57,18 +57,20 @@ func main() {
 
 	// step 5: block developer CI if vulnerabilities were found
 	if types.FoundVuln == true {
+		if len(os.Args) < 1 {
+			fmt.Printf("[HUSKYCI][*] Some high issues were found :(\n")
+			os.Exit(1)
+		}
 		os.Exit(1)
 	}
 
-	if types.FoundInfo == true {
+	if types.FoundInfo == true && len(os.Args) < 1 {
 		fmt.Printf("[HUSKYCI][*] Some low/info issues were found :|\n")
-		fmt.Println()
 		os.Exit(0)
 	}
 
 	if len(os.Args) < 1 {
-		fmt.Printf("[HUSKYCI][*] Nice! No issues Found :)\n")
-		fmt.Println()
+		fmt.Printf("[HUSKYCI][*] Nice! No issues were found :)\n")
 	}
 	os.Exit(0)
 }

--- a/client/cmd/main.go
+++ b/client/cmd/main.go
@@ -32,7 +32,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	fmt.Println("[HUSKYCI][*] HuskyCI analysis started!", RID)
+	fmt.Println("[HUSKYCI][*] huskyCI analysis started!", RID)
 
 	// step 2: keep querying husky API to check if a given analysis has already finished.
 	huskyAnalysis, err := analysis.MonitorAnalysis(RID)
@@ -60,5 +60,13 @@ func main() {
 		os.Exit(1)
 	}
 
+	if types.FoundInfo == true {
+		fmt.Printf("[HUSKYCI][*] Some low/info issues were found :|\n")
+		fmt.Println()
+		os.Exit(0)
+	}
+
+	fmt.Printf("[HUSKYCI][*] Nice! No issues Found :)\n")
+	fmt.Println()
 	os.Exit(0)
 }

--- a/client/types/types.go
+++ b/client/types/types.go
@@ -59,6 +59,7 @@ type SecurityTest struct {
 
 // HuskyCIVulnerability is the struct that stores vulnerability information.
 type HuskyCIVulnerability struct {
+	Language       string `json:"language"`
 	SecurityTool   string `json:"securitytool,omitempty"`
 	Severity       string `json:"severity,omitempty"`
 	Confidence     string `json:"confidence,omitempty"`

--- a/client/types/types.go
+++ b/client/types/types.go
@@ -56,43 +56,43 @@ type SecurityTest struct {
 
 // HuskyCIVulnerability is the struct that stores vulnerability information.
 type HuskyCIVulnerability struct {
-	SecurityTool   string `json:"securitytool"`
-	Severity       string `json:"severity"`
-	Confidence     string `json:"confidence"`
-	File           string `json:"file"`
-	Line           string `json:"line"`
-	Code           string `json:"code"`
-	Details        string `json:"details"`
-	Type           string `json:"type"`
-	VunerableBelow string `json:"vulnerablebelow"`
-	Version        string `json:"version"`
+	SecurityTool   string `json:"securitytool,omitempty"`
+	Severity       string `json:"severity,omitempty"`
+	Confidence     string `json:"confidence,omitempty"`
+	File           string `json:"file,omitempty"`
+	Line           string `json:"line,omitempty"`
+	Code           string `json:"code,omitempty"`
+	Details        string `json:"details,omitempty"`
+	Type           string `json:"type,omitempty"`
+	VunerableBelow string `json:"vulnerablebelow,omitempty"`
+	Version        string `json:"version,omitempty"`
 }
 
 // JSONOutput is a truct that represents huskyCI output in a JSON format.
 type JSONOutput struct {
-	GoResults         GoResults         `json:"golang"`
-	PythonResults     PythonResults     `json:"python"`
-	JavaScriptResults JavaScriptResults `json:"javascript"`
-	RubyResults       RubyResults       `json:"ruby"`
+	GoResults         GoResults         `json:"goresults,omitempty"`
+	PythonResults     PythonResults     `json:"pythonresults,omitempty"`
+	JavaScriptResults JavaScriptResults `json:"javascriptresults,omitempty"`
+	RubyResults       RubyResults       `json:"rubyresults,omitempty"`
 }
 
 // GoResults represents all Golang security tests results.
 type GoResults struct {
-	GosecOutput []HuskyCIVulnerability
+	GosecOutput []HuskyCIVulnerability `json:"gosecoutput,omitempty"`
 }
 
 // PythonResults represents all Python security tests results.
 type PythonResults struct {
-	BanditOutput []HuskyCIVulnerability
-	SafetyOutput []HuskyCIVulnerability
+	BanditOutput []HuskyCIVulnerability `json:"banditoutput,omitempty"`
+	SafetyOutput []HuskyCIVulnerability `json:"safetyoutput,omitempty"`
 }
 
 // JavaScriptResults represents all JavaScript security tests results.
 type JavaScriptResults struct {
-	RetirejsResult []HuskyCIVulnerability
+	RetirejsResult []HuskyCIVulnerability `json:"retirejsoutput,omitempty"`
 }
 
 // RubyResults represents all Ruby security tests results.
 type RubyResults struct {
-	BrakemanOutput []HuskyCIVulnerability
+	BrakemanOutput []HuskyCIVulnerability `json:"brakemanoutput,omitempty"`
 }

--- a/client/types/types.go
+++ b/client/types/types.go
@@ -53,3 +53,45 @@ type SecurityTest struct {
 	Default          bool          `bson:"default" json:"default"`
 	TimeOutInSeconds int           `bson:"timeOutSeconds" json:"timeOutSeconds"`
 }
+
+// HuskyCIVulnerability is the struct that stores vulnerability information.
+type HuskyCIVulnerability struct {
+	SecurityTool   string
+	Severity       string
+	Confidence     string
+	File           string
+	Line           string
+	Code           string
+	Details        string
+	Type           string
+	VunerableBelow string
+}
+
+// JSONOutput is a truct that represents huskyCI output in a JSON format.
+type JSONOutput struct {
+	GoResults         GoResults         `json:"golang"`
+	PythonResults     PythonResults     `json:"python"`
+	JavaScriptResults JavaScriptResults `json:"javascript"`
+	RubyResults       RubyResults       `json:"ruby"`
+}
+
+// GoResults represents all Golang security tests results.
+type GoResults struct {
+	GosecOutput []HuskyCIVulnerability
+}
+
+// PythonResults represents all Python security tests results.
+type PythonResults struct {
+	BanditOutput []HuskyCIVulnerability
+	SafetyOutput []HuskyCIVulnerability
+}
+
+// JavaScriptResults represents all JavaScript security tests results.
+type JavaScriptResults struct {
+	RetirejsResult []HuskyCIVulnerability
+}
+
+// RubyResults represents all Ruby security tests results.
+type RubyResults struct {
+	BrakemanOutput []HuskyCIVulnerability
+}

--- a/client/types/types.go
+++ b/client/types/types.go
@@ -13,6 +13,9 @@ import (
 // FoundVuln is the boolean that will be checked to return an os.exit(0) or os.exit(1)
 var FoundVuln bool
 
+// FoundInfo is the boolean that will be checked to verify if only low/info severity vulnerabilites were found.
+var FoundInfo bool
+
 // JSONPayload is a struct that represents the JSON payload needed to make a HuskyCI API request.
 type JSONPayload struct {
 	RepositoryURL    string `json:"repositoryURL"`

--- a/client/types/types.go
+++ b/client/types/types.go
@@ -115,6 +115,7 @@ type Summary struct {
 // HuskyCISummary is the struct that holds summary information.
 type HuskyCISummary struct {
 	FoundVuln  bool `json:"foundvuln,omitempty"`
+	FoundInfo  bool `json:"foundinfo,omitempty"`
 	LowVuln    int  `json:"lowvuln,omitempty"`
 	MediumVuln int  `json:"mediumvuln,omitempty"`
 	HighVuln   int  `json:"highvuln,omitempty"`

--- a/client/types/types.go
+++ b/client/types/types.go
@@ -59,7 +59,7 @@ type SecurityTest struct {
 
 // HuskyCIVulnerability is the struct that stores vulnerability information.
 type HuskyCIVulnerability struct {
-	Language       string `json:"language"`
+	Language       string `json:"language,omitempty"`
 	SecurityTool   string `json:"securitytool,omitempty"`
 	Severity       string `json:"severity,omitempty"`
 	Confidence     string `json:"confidence,omitempty"`

--- a/client/types/types.go
+++ b/client/types/types.go
@@ -78,6 +78,7 @@ type JSONOutput struct {
 	PythonResults     PythonResults     `json:"pythonresults,omitempty"`
 	JavaScriptResults JavaScriptResults `json:"javascriptresults,omitempty"`
 	RubyResults       RubyResults       `json:"rubyresults,omitempty"`
+	Summary           Summary           `json:"summary,omitempty"`
 }
 
 // GoResults represents all Golang security tests results.
@@ -99,4 +100,22 @@ type JavaScriptResults struct {
 // RubyResults represents all Ruby security tests results.
 type RubyResults struct {
 	BrakemanOutput []HuskyCIVulnerability `json:"brakemanoutput,omitempty"`
+}
+
+// Summary holds a summary of the information on all security tests.
+type Summary struct {
+	GosecSummary    HuskyCISummary `json:"gosecsummary,omitempty"`
+	BanditSummary   HuskyCISummary `json:"banditsummary,omitempty"`
+	SafetySummary   HuskyCISummary `json:"safetysummary,omitempty"`
+	RetirejsSummary HuskyCISummary `json:"retirejssummary,omitempty"`
+	BrakemanSummary HuskyCISummary `json:"brakemansummary,omitempty"`
+	TotalSummary    HuskyCISummary `json:"totalsummary,omitempty"`
+}
+
+// HuskyCISummary is the struct that holds summary information.
+type HuskyCISummary struct {
+	FoundVuln  bool `json:"foundvuln,omitempty"`
+	LowVuln    int  `json:"lowvuln,omitempty"`
+	MediumVuln int  `json:"mediumvuln,omitempty"`
+	HighVuln   int  `json:"highvuln,omitempty"`
 }

--- a/client/types/types.go
+++ b/client/types/types.go
@@ -16,6 +16,9 @@ var FoundVuln bool
 // FoundInfo is the boolean that will be checked to verify if only low/info severity vulnerabilites were found.
 var FoundInfo bool
 
+// IsJSONoutput is the boolean that will be checked to verity if the output is expected to be printed in a JSON format
+var IsJSONoutput bool
+
 // JSONPayload is a struct that represents the JSON payload needed to make a HuskyCI API request.
 type JSONPayload struct {
 	RepositoryURL    string `json:"repositoryURL"`

--- a/client/types/types.go
+++ b/client/types/types.go
@@ -56,15 +56,16 @@ type SecurityTest struct {
 
 // HuskyCIVulnerability is the struct that stores vulnerability information.
 type HuskyCIVulnerability struct {
-	SecurityTool   string
-	Severity       string
-	Confidence     string
-	File           string
-	Line           string
-	Code           string
-	Details        string
-	Type           string
-	VunerableBelow string
+	SecurityTool   string `json:"securitytool"`
+	Severity       string `json:"severity"`
+	Confidence     string `json:"confidence"`
+	File           string `json:"file"`
+	Line           string `json:"line"`
+	Code           string `json:"code"`
+	Details        string `json:"details"`
+	Type           string `json:"type"`
+	VunerableBelow string `json:"vulnerablebelow"`
+	Version        string `json:"version"`
 }
 
 // JSONOutput is a truct that represents huskyCI output in a JSON format.


### PR DESCRIPTION
## Closes #200 

This PR aims to add an option into huskyCI's output to enable the tool to output results both on STDOUT or in a JSON format.

#### `Makefile`: 
* Added new option to print huskyCI's output as a JSON.

#### `client/analysis/analysis.go` and `client/cmd/main.go`: 
* Added `PrintResults` function
* Added a new logic to print huskyCI's output as JSON or STDOUT. 

#### `client/types/types.go`: 
* Created a new struct type, `HuskyCIVUlnereability`, to hold all the information related to a vulnerability
* Created alongside new structs to better separate languages and security tests.

#### `client/analysis/output.go`: 
* Added new logic to prepare the structs and later print them. 
* STDOUT output now includes a summary of the findings. 
* Some functions' name was also refactored.

If this PR is merged, this is a JSON output example of analysis: 
![image](https://user-images.githubusercontent.com/8943477/60611772-7df2c800-9d9d-11e9-886b-e5aaa0367fc4.png)

And the new STDOUT output example of analysis: 
![image](https://user-images.githubusercontent.com/8943477/60611955-fa85a680-9d9d-11e9-9f3e-e89928127ab5.png)

## Todo

Add Summary results in JSON output.