### PR TITLE
Fix CreateContainerName function in util package

### DIFF
--- a/api/util/util.go
+++ b/api/util/util.go
@@ -90,35 +90,44 @@ func CreateContainerName(repositoryURL, repositoryBranch, image string) string {
 	if repositoryURL == "" || repositoryBranch == "" || image == "" {
 		return ""
 	}
+
+	//Trim '/' and '.git' from end of string
 	cleanURL := strings.TrimSuffix(repositoryURL, "/")
 	cleanURL = strings.TrimSuffix(cleanURL, ".git")
 
+	//Get index of the begining of repository name and image name strings
 	repoNameStartIndex := strings.LastIndex(cleanURL, "/")
 	imageNameStartIndex := strings.LastIndex(image, "/")
 
-	if repoNameStartIndex == -1 || imageNameStartIndex == -1 {
-		//Not a valid git repository or image
+	//Check if index is valid
+	if repoNameStartIndex == -1 || len(cleanURL) < repoNameStartIndex+1 || imageNameStartIndex == -1 || len(cleanURL) < imageNameStartIndex+1 {
 		return ""
 	}
 
+	//Get substrings starting from each index
 	repositoryName := cleanURL[repoNameStartIndex+1:]
 	imageName := image[imageNameStartIndex+1:]
 
+	//Trim repository name and '/'
 	repositoryOwner := strings.TrimSuffix(cleanURL, repositoryName)
 	repositoryOwner = strings.TrimSuffix(repositoryOwner, "/")
 
+	//Get index of the beggining of repository owner string
+	// --Repository has format: "https://github.com/some-user/my-repo.git/"
 	repoOwnerStartIndex1 := strings.LastIndex(repositoryOwner, "/")
+	// --Repository has format: "github@github.com:some-user/my-repo.git/"
 	repoOwnerStartIndex2 := strings.LastIndex(repositoryOwner, ":")
 
-	if repoOwnerStartIndex1 != -1 {
+	//Check if index is valid
+	if repoOwnerStartIndex1 != -1 && len(repositoryOwner) >= repoOwnerStartIndex1+1 {
 		repositoryOwner = repositoryOwner[repoOwnerStartIndex1+1:]
-	} else if repoOwnerStartIndex2 != -1 {
+	} else if repoOwnerStartIndex2 != -1 && len(repositoryOwner) >= repoOwnerStartIndex2+1 {
 		repositoryOwner = repositoryOwner[repoOwnerStartIndex2+1:]
 	} else {
-		//Not a valid repository owner
 		return ""
 	}
 
+	//Join all strings
 	s := []string{repositoryOwner, repositoryName, repositoryBranch, imageName}
 	containerName := strings.Join(s, "_")
 

--- a/api/util/util.go
+++ b/api/util/util.go
@@ -87,13 +87,40 @@ func RemoveDuplicates(s []string) []string {
 //  - Input: {repositoryURL: https://github.com/globocom/huskyCI.git, repositoryBranch: "master", imageName: "huskyci/enry"}
 //  - Output: globocom_huskyCI_master_enry
 func CreateContainerName(repositoryURL, repositoryBranch, image string) string {
-	if repositoryURL != "" && repositoryBranch != "" && image != "" {
-		imageSlices := strings.Split(image, "/")
-		imageName := imageSlices[len(imageSlices)-1]
-		url := strings.TrimSuffix(repositoryURL, ".git")
-		urlSlices := strings.Split(url, "/")[3:]
-		myStrings := []string{strings.Join(urlSlices, "_"), repositoryBranch, imageName}
-		return strings.Join(myStrings, "_")
+	if repositoryURL == "" || repositoryBranch == "" || image == "" {
+		return ""
 	}
-	return ""
+	cleanURL := strings.TrimSuffix(repositoryURL, "/")
+	cleanURL = strings.TrimSuffix(cleanURL, ".git")
+
+	repoNameStartIndex := strings.LastIndex(cleanURL, "/")
+	imageNameStartIndex := strings.LastIndex(image, "/")
+
+	if repoNameStartIndex == -1 || imageNameStartIndex == -1 {
+		//Not a valid git repository or image
+		return ""
+	}
+
+	repositoryName := cleanURL[repoNameStartIndex+1:]
+	imageName := image[imageNameStartIndex+1:]
+
+	repositoryOwner := strings.TrimSuffix(cleanURL, repositoryName)
+	repositoryOwner = strings.TrimSuffix(repositoryOwner, "/")
+
+	repoOwnerStartIndex1 := strings.LastIndex(repositoryOwner, "/")
+	repoOwnerStartIndex2 := strings.LastIndex(repositoryOwner, ":")
+
+	if repoOwnerStartIndex1 != -1 {
+		repositoryOwner = repositoryOwner[repoOwnerStartIndex1+1:]
+	} else if repoOwnerStartIndex2 != -1 {
+		repositoryOwner = repositoryOwner[repoOwnerStartIndex2+1:]
+	} else {
+		//Not a valid repository owner
+		return ""
+	}
+
+	s := []string{repositoryOwner, repositoryName, repositoryBranch, imageName}
+	containerName := strings.Join(s, "_")
+
+	return containerName
 }

--- a/api/util/util_test.go
+++ b/api/util/util_test.go
@@ -142,31 +142,34 @@ Line4`
 	})
 
 	Describe("CreateContainerName", func() {
-		inputURL := "https://github.com/globocom/secDevLabs.git"
-		inputBranch := "myBranch"
-		inputImage := "secdevLabs/bandit"
-		expected := "globocom_secDevLabs_myBranch_bandit"
+		inputURLType1 := "https://github.com/some-user/my-repo.git"
+		inputURLType2 := "github@github.com:some-user/my-repo.git/"
+		inputURLType3 := "git://github.com/some-user/my-repo.git"
+		inputBranch := "my-branch"
+		inputImage := "my-repo/bandit"
+		expected := "some-user_my-repo_my-branch_bandit"
 
 		Context("When inputURL, imputBranch and inputImage are not empty", func() {
-			It("Should return a container name based on these params", func() {
-				Expect(util.CreateContainerName(inputURL, inputBranch, inputImage)).To(Equal(expected))
+			It("Should return a container name from URL type 1", func() {
+				Expect(util.CreateContainerName(inputURLType1, inputBranch, inputImage)).To(Equal(expected))
+			})
+			It("Should return a container name from URL type 2", func() {
+				Expect(util.CreateContainerName(inputURLType2, inputBranch, inputImage)).To(Equal(expected))
+			})
+			It("Should return a container name from URL type 3", func() {
+				Expect(util.CreateContainerName(inputURLType3, inputBranch, inputImage)).To(Equal(expected))
+			})
+			It("Should return an empty string if inputURL is not valid", func() {
+				Expect(util.CreateContainerName("not-a-git-repo", inputBranch, inputImage)).To(Equal(""))
+			})
+			It("Should return an empty string if inputImage is not valid", func() {
+				Expect(util.CreateContainerName(inputURLType1, inputBranch, "random:string")).To(Equal(""))
 			})
 		})
-		Context("When inputURL is empty", func() {
+		Context("When inputURL, inputBranch or inputBranch are empty", func() {
 			It("Should return empty string and docker will generate a default name", func() {
 				Expect(util.CreateContainerName("", inputBranch, inputImage)).To(Equal(""))
 			})
 		})
-		Context("When inputBranch is empty", func() {
-			It("Should return empty string and docker will generate a default name", func() {
-				Expect(util.CreateContainerName(inputURL, "", inputImage)).To(Equal(""))
-			})
-		})
-		Context("When inputImage is empty", func() {
-			It("Should return empty string and docker will generate a default name", func() {
-				Expect(util.CreateContainerName(inputURL, inputBranch, "")).To(Equal(""))
-			})
-		})
 	})
-
 })

--- a/api/util/util_test.go
+++ b/api/util/util_test.go
@@ -142,9 +142,9 @@ Line4`
 	})
 
 	Describe("CreateContainerName", func() {
-		inputURLType1 := "https://github.com/some-user/my-repo.git"
+		inputURLType1 := "https://github.com/some-user/my-repo.git/"
 		inputURLType2 := "github@github.com:some-user/my-repo.git/"
-		inputURLType3 := "git://github.com/some-user/my-repo.git"
+		inputURLType3 := "git://github.com/some-user/my-repo.git/"
 		inputBranch := "my-branch"
 		inputImage := "my-repo/bandit"
 		expected := "some-user_my-repo_my-branch_bandit"


### PR DESCRIPTION
Fix error from `CreateContainerName()` in `util` package, that was panicking when an unexpected format of git repository URL was passed. 

Now it supports:
```https://github.com/some-user/my-repo.git/```
```github@github.com:some-user/my-repo.git```
```git://github.com/some-user/my-repo.git```
and returns an empty string (docker will create a default name for the container) when one of the parameters don't have the expected formats.