### PR TITLE
Fix container name conflicts

### DIFF
--- a/api/dockers/api.go
+++ b/api/dockers/api.go
@@ -73,13 +73,12 @@ func NewDocker() (*Docker, error) {
 // CreateContainer creates a new container
 func (d Docker) CreateContainer(analysis types.Analysis, image string, cmd string) (string, error) {
 	cmd = util.HandleCmd(analysis.URL, analysis.Branch, cmd)
-	containerName := util.CreateContainerName(analysis.URL, analysis.Branch, image)
 	ctx := goContext.Background()
 	resp, err := d.client.ContainerCreate(ctx, &container.Config{
 		Image: image,
 		Tty:   true,
 		Cmd:   []string{"/bin/sh", "-c", cmd},
-	}, nil, nil, containerName)
+	}, nil, nil, "")
 
 	if err != nil {
 		log.Error("CreateContainer", "DOCKERAPI", 3005, err)

--- a/api/util/util.go
+++ b/api/util/util.go
@@ -81,19 +81,3 @@ func RemoveDuplicates(s []string) []string {
 	}
 	return s[:i]
 }
-
-// CreateContainerName generates a name for a container based on project's URL and branch
-// Example:
-//  - Input: {repositoryURL: https://github.com/globocom/huskyCI.git, repositoryBranch: "master", imageName: "huskyci/enry"}
-//  - Output: globocom_huskyCI_master_enry
-func CreateContainerName(repositoryURL, repositoryBranch, image string) string {
-	if repositoryURL != "" && repositoryBranch != "" && image != "" {
-		imageSlices := strings.Split(image, "/")
-		imageName := imageSlices[len(imageSlices)-1]
-		url := strings.TrimSuffix(repositoryURL, ".git")
-		urlSlices := strings.Split(url, "/")[3:]
-		myStrings := []string{strings.Join(urlSlices, "_"), repositoryBranch, imageName}
-		return strings.Join(myStrings, "_")
-	}
-	return ""
-}

--- a/api/util/util_test.go
+++ b/api/util/util_test.go
@@ -24,17 +24,17 @@ var _ = Describe("Util", func() {
 		})
 		Context("When inputRepositoryURL is empty", func() {
 			It("Should return an empty string.", func() {
-				Expect(util.CreateContainerName("", inputRepositoryBranch, inputCMD)).To(Equal(""))
+				Expect(util.HandleCmd("", inputRepositoryBranch, inputCMD)).To(Equal(""))
 			})
 		})
 		Context("When inputRepositoryBranch is empty", func() {
 			It("Should return an empty string.", func() {
-				Expect(util.CreateContainerName(inputRepositoryURL, "", inputCMD)).To(Equal(""))
+				Expect(util.HandleCmd(inputRepositoryURL, "", inputCMD)).To(Equal(""))
 			})
 		})
 		Context("When inputCMD is empty", func() {
 			It("Should return an empty string.", func() {
-				Expect(util.CreateContainerName(inputRepositoryURL, inputRepositoryBranch, "")).To(Equal(""))
+				Expect(util.HandleCmd(inputRepositoryURL, inputRepositoryBranch, "")).To(Equal(""))
 			})
 		})
 	})
@@ -140,33 +140,4 @@ Line4`
 			})
 		})
 	})
-
-	Describe("CreateContainerName", func() {
-		inputURL := "https://github.com/globocom/secDevLabs.git"
-		inputBranch := "myBranch"
-		inputImage := "secdevLabs/bandit"
-		expected := "globocom_secDevLabs_myBranch_bandit"
-
-		Context("When inputURL, imputBranch and inputImage are not empty", func() {
-			It("Should return a container name based on these params", func() {
-				Expect(util.CreateContainerName(inputURL, inputBranch, inputImage)).To(Equal(expected))
-			})
-		})
-		Context("When inputURL is empty", func() {
-			It("Should return empty string and docker will generate a default name", func() {
-				Expect(util.CreateContainerName("", inputBranch, inputImage)).To(Equal(""))
-			})
-		})
-		Context("When inputBranch is empty", func() {
-			It("Should return empty string and docker will generate a default name", func() {
-				Expect(util.CreateContainerName(inputURL, "", inputImage)).To(Equal(""))
-			})
-		})
-		Context("When inputImage is empty", func() {
-			It("Should return empty string and docker will generate a default name", func() {
-				Expect(util.CreateContainerName(inputURL, inputBranch, "")).To(Equal(""))
-			})
-		})
-	})
-
 })


### PR DESCRIPTION
This PR aims to remove `CreateContainerName()` function and it's test, so huskyCI will no longer create containers with repository name and branches.

Also, some tests were testing the wrong functions. Changed some `CreateContainerName()` tests to `HandleCmd` as was intended.

After removing this function, security test containers will be created with docker standard names.