### PR TITLE
Increase client tick time

### DIFF
--- a/client/analysis/analysis.go
+++ b/client/analysis/analysis.go
@@ -86,7 +86,7 @@ func MonitorAnalysis(RID string) (types.Analysis, error) {
 
 	analysis := types.Analysis{}
 	timeout := time.After(15 * time.Minute)
-	retryTick := time.Tick(20 * time.Second)
+	retryTick := time.Tick(60 * time.Second)
 
 	for {
 		select {


### PR DESCRIPTION
This PR aims to increase the time between each client request to the API to verify whether or not the analysis has ended. I've set the interval to 60 seconds.

* `client/analysis/analysis.go` : Changed time gap between requests to 60 seconds.