### PR TITLE
Handle when Safety fails to run and adjust it's output to be more verbose

### DIFF
--- a/api/config.yaml
+++ b/api/config.yaml
@@ -141,11 +141,14 @@ safety:
     if [ $? -eq 0 ]; then
       cd code
       if [ -f requirements.txt ]; then
-        cat requirements.txt | grep '=' | grep -v '#' 1> safety_huskyci_analysis_requirements.txt
+        cat requirements.txt | grep '=' | grep -v '#' 1> safety_huskyci_analysis_requirements_raw.txt
+        sed -i -e 's/>=/==/g; s/<=/==/g' safety_huskyci_analysis_requirements_raw.txt
+        cat safety_huskyci_analysis_requirements_raw.txt | cut -f1 -d "," > safety_huskyci_analysis_requirements.txt
         safety check -r safety_huskyci_analysis_requirements.txt --json > safety_huskyci_analysis_output.json 2> /tmp/errorRunning
-        if [ -f /tmp/errorRunning ]; then
-          if grep -q "unpinned requirement" "/tmp/errorRunning"; then
-            cat /tmp/errorRunning
+        safety check -r safety_huskyci_analysis_requirements_raw.txt --json > /dev/null 2> /tmp/warning
+        if [ -f /tmp/warning ]; then
+          if grep -q "unpinned requirement" "/tmp/warning"; then
+            cat /tmp/warning
           fi
           chmod +x /script.sh
           /script.sh safety_huskyci_analysis_output.json

--- a/api/config.yaml
+++ b/api/config.yaml
@@ -141,9 +141,16 @@ safety:
     if [ $? -eq 0 ]; then
       cd code
       if [ -f requirements.txt ]; then
-        safety check -r requirements.txt --json > safety_huskyci_analysis_output.json 2> /tmp/errorUnpinnedReq
-        /script.sh safety_huskyci_analysis_output.json
-        cat output.json
+        cat requirements.txt | grep '=' | grep -v '#' 1> safety_huskyci_analysis_requirements.txt
+        safety check -r safety_huskyci_analysis_requirements.txt --json > safety_huskyci_analysis_output.json 2> /tmp/errorRunning
+        if [ $? -eq 0 ]; then
+          chmod +x /script.sh
+          /script.sh safety_huskyci_analysis_output.json
+          cat output.json
+        else
+          echo "ERROR_RUNNING_SAFETY"
+          cat /tmp/errorRunning 
+        fi
       else
         echo "ERROR_REQ_NOT_FOUND"  
       fi

--- a/api/config.yaml
+++ b/api/config.yaml
@@ -143,7 +143,10 @@ safety:
       if [ -f requirements.txt ]; then
         cat requirements.txt | grep '=' | grep -v '#' 1> safety_huskyci_analysis_requirements.txt
         safety check -r safety_huskyci_analysis_requirements.txt --json > safety_huskyci_analysis_output.json 2> /tmp/errorRunning
-        if [ $? -eq 0 ]; then
+        if [ -f /tmp/errorRunning ]; then
+          if grep -q "unpinned requirement" "/tmp/errorRunning"; then
+            cat /tmp/errorRunning
+          fi
           chmod +x /script.sh
           /script.sh safety_huskyci_analysis_output.json
           cat output.json

--- a/client/analysis/output.go
+++ b/client/analysis/output.go
@@ -227,6 +227,19 @@ func prepareSafetyOutput(mongoDBcontainerOutput string, mongoDBcontainerInfo str
 		return
 	}
 
+	if mongoDBcontainerInfo == "Internal error running Safety." {
+		safetyVuln := types.HuskyCIVulnerability{}
+		safetyVuln.Language = "Python"
+		safetyVuln.SecurityTool = "Safety"
+		safetyVuln.Severity = "info"
+		safetyVuln.Details = "Internal error running Safety."
+		types.FoundInfo = true
+
+		pythonResults.SafetyOutput = append(pythonResults.SafetyOutput, safetyVuln)
+
+		return
+	}
+
 	// Safety returns warnings and the json output in the same string, which need to be split
 	var cOutputSanitized string
 	safetyOutput := types.SafetyOutput{}

--- a/client/analysis/output.go
+++ b/client/analysis/output.go
@@ -245,7 +245,7 @@ func prepareSafetyOutput(mongoDBcontainerOutput string, mongoDBcontainerInfo str
 	safetyOutput := types.SafetyOutput{}
 	warningFound := strings.Contains(mongoDBcontainerOutput, "Warning: unpinned requirement ")
 	if !warningFound {
-		// only issue found
+		// only issues found
 		cOutputSanitized = util.SanitizeSafetyJSON(mongoDBcontainerOutput)
 		err := json.Unmarshal([]byte(cOutputSanitized), &safetyOutput)
 		if err != nil {
@@ -271,7 +271,7 @@ func prepareSafetyOutput(mongoDBcontainerOutput string, mongoDBcontainerInfo str
 			safetyVuln.Language = "Python"
 			safetyVuln.SecurityTool = "Safety"
 			safetyVuln.Severity = "warning"
-			safetyVuln.Details = warning
+			safetyVuln.Details = util.AdjustWarningMessage(warning)
 
 			pythonResults.SafetyOutput = append(pythonResults.SafetyOutput, safetyVuln)
 			types.FoundInfo = true
@@ -339,7 +339,7 @@ func printSTDOUTOutput() {
 		fmt.Printf("[HUSKYCI][!] Tool: %s\n", issue.SecurityTool)
 		fmt.Printf("[HUSKYCI][!] Severity: %s\n", issue.Severity)
 		fmt.Printf("[HUSKYCI][!] Details: %s\n", issue.Details)
-		if issue.Details != "requirements.txt not found" {
+		if issue.Details != "requirements.txt not found" && !strings.Contains(issue.Details, "Unpinned requirement ") {
 			fmt.Printf("[HUSKYCI][!] Code: %s\n", issue.Code)
 			fmt.Printf("[HUSKYCI][!] Vulnerable Below: %s\n", issue.VunerableBelow)
 		}

--- a/client/analysis/output.go
+++ b/client/analysis/output.go
@@ -287,7 +287,7 @@ func prepareSafetyOutput(mongoDBcontainerOutput string, mongoDBcontainerInfo str
 		safetyVuln.SecurityTool = "Safety"
 		safetyVuln.Severity = "high"
 		safetyVuln.Details = issue.Comment
-		safetyVuln.Code = issue.Version
+		safetyVuln.Code = issue.Dependency + " " + issue.Version
 		safetyVuln.VunerableBelow = issue.Below
 
 		pythonResults.SafetyOutput = append(pythonResults.SafetyOutput, safetyVuln)
@@ -338,11 +338,11 @@ func printSTDOUTOutput() {
 		fmt.Printf("[HUSKYCI][!] Language: %s\n", issue.Language)
 		fmt.Printf("[HUSKYCI][!] Tool: %s\n", issue.SecurityTool)
 		fmt.Printf("[HUSKYCI][!] Severity: %s\n", issue.Severity)
-		fmt.Printf("[HUSKYCI][!] Details: %s\n", issue.Details)
 		if issue.Details != "requirements.txt not found" && !strings.Contains(issue.Details, "Unpinned requirement ") {
 			fmt.Printf("[HUSKYCI][!] Code: %s\n", issue.Code)
 			fmt.Printf("[HUSKYCI][!] Vulnerable Below: %s\n", issue.VunerableBelow)
 		}
+		fmt.Printf("[HUSKYCI][!] Details: %s\n", issue.Details)
 	}
 
 	for _, issue := range outputJSON.RubyResults.BrakemanOutput {

--- a/client/util/util.go
+++ b/client/util/util.go
@@ -91,10 +91,10 @@ func SanitizeSafetyJSON(s string) string {
 func AdjustWarningMessage(warningRaw string) string {
 	warning := strings.Split(warningRaw, ":")
 	if len(warning) > 1 {
-		warning[1] = strings.Replace(warning[1], "safety_huskyci_analysis_requirements.txt", "'requirements.txt'", -1)
+		warning[1] = strings.Replace(warning[1], "safety_huskyci_analysis_requirements_raw.txt", "'requirements.txt'", -1)
 		warning[1] = strings.Replace(warning[1], " unpinned", "Unpinned", -1)
 
-		return warning[1]
+		return (warning[1] + " huskyCI can check it if you pin it in a format such as this: \"mypacket==3.2.9\" :D")
 	}
 
 	return warningRaw

--- a/client/util/util.go
+++ b/client/util/util.go
@@ -86,3 +86,16 @@ func SanitizeSafetyJSON(s string) string {
 	s2 := strings.Replace(s1, "\\\"", "\\\\\"", -1)
 	return s2
 }
+
+// AdjustWarningMessage returns the Safety Warning string that will be printed.
+func AdjustWarningMessage(warningRaw string) string {
+	warning := strings.Split(warningRaw, ":")
+	if len(warning) > 1 {
+		warning[1] = strings.Replace(warning[1], "safety_huskyci_analysis_requirements.txt", "'requirements.txt'", -1)
+		warning[1] = strings.Replace(warning[1], " unpinned", "Unpinned", -1)
+
+		return warning[1]
+	}
+
+	return warningRaw
+}


### PR DESCRIPTION
Thanks for reporting this error, @marcelometal! 

When Safety fails to run, as when a repository has lines different than the traditional packages, for example,`cOutput` and `cInfo` is not being properly updated. 

This PR will change Safety container commands to check this and add the corresponding logic into huskyCI API and Client.