### PR TITLE
Add support for RetireJS to install internal dependencies

### DIFF
--- a/api/analysis/analysis.go
+++ b/api/analysis/analysis.go
@@ -23,12 +23,13 @@ func StartAnalysis(RID string, repository types.Repository) {
 
 	// step 0: create a new analysis struct
 	newAnalysis := types.Analysis{
-		RID:        RID,
-		URL:        repository.URL,
-		Branch:     repository.Branch,
-		Status:     "running",
-		Containers: make([]types.Container, 0),
-		StartedAt:  time.Now(),
+		RID:            RID,
+		URL:            repository.URL,
+		Branch:         repository.Branch,
+		Status:         "running",
+		Containers:     make([]types.Container, 0),
+		StartedAt:      time.Now(),
+		InternalDepURL: repository.InternalDepURL,
 	}
 
 	// step 1: insert new analysis into MongoDB.

--- a/api/config.yaml
+++ b/api/config.yaml
@@ -96,9 +96,13 @@ retirejs:
     chmod 600 ~/.ssh/huskyci_id_rsa &&
     echo 'IdentityFile ~/.ssh/huskyci_id_rsa' >> /etc/ssh/ssh_config &&
     echo 'StrictHostKeyChecking no' >> /etc/ssh/ssh_config &&
+    useInternalDependencies=0
     git clone -b %GIT_BRANCH% --single-branch %GIT_REPO% code --quiet 2> /tmp/errorGitCloneRetirejs
     if [ $? -eq 0 ]; then
       cd code
+      if [ "%INTERNAL_DEP_URL%" != "" ]; then
+        useInternalDependencies=1
+      fi
       if [ -f yarn.lock ]; then
         yarn install >/dev/null 2>&1
         retire -n --outputformat json --outputpath /tmp/results.json --exitwith 0 2>/dev/null
@@ -109,11 +113,17 @@ retirejs:
         retire -n --outputformat json --outputpath /tmp/results.json --exitwith 0 2>/dev/null
         cat /tmp/results.json
       elif [ -f package.json ] || [ -f package-lock.json ]; then
+        if [ $useInternalDependencies == 1 ]; then
+          npm config set registry %INTERNAL_DEP_URL%
+        fi
         npm install >/dev/null 2>&1
         retire -n --outputformat json --outputpath /tmp/results.json --exitwith 0 2>/dev/null
         cat /tmp/results.json 
       elif [ -f src/package.json ] || [ -f src/package-lock.json ]; then
         cd src/
+        if [ $useInternalDependencies == 1 ]; then
+          npm config set registry %INTERNAL_DEP_URL%
+        fi
         npm install >/dev/null 2>&1
         retire -n --outputformat json --outputpath /tmp/results.json --exitwith 0 2>/dev/null
         cat /tmp/results.json 

--- a/api/db/huskydb.go
+++ b/api/db/huskydb.go
@@ -129,12 +129,13 @@ func InsertDBRepository(repository types.Repository) error {
 	}
 
 	newRepository := types.Repository{
-		URL:           repository.URL,
-		Branch:        repository.Branch,
-		SecurityTests: securityTestList,
-		CreatedAt:     repository.CreatedAt,
-		DeletedAt:     repository.DeletedAt,
-		Languages:     repository.Languages,
+		URL:            repository.URL,
+		Branch:         repository.Branch,
+		SecurityTests:  securityTestList,
+		CreatedAt:      repository.CreatedAt,
+		DeletedAt:      repository.DeletedAt,
+		Languages:      repository.Languages,
+		InternalDepURL: repository.InternalDepURL,
 	}
 
 	err = mongoHuskyCI.Conn.Insert(newRepository, mongoHuskyCI.RepositoryCollection)

--- a/api/dockers/api.go
+++ b/api/dockers/api.go
@@ -72,7 +72,7 @@ func NewDocker() (*Docker, error) {
 
 // CreateContainer creates a new container
 func (d Docker) CreateContainer(analysis types.Analysis, image string, cmd string) (string, error) {
-	cmd = util.HandleCmd(analysis.URL, analysis.Branch, cmd)
+	cmd = util.HandleCmd(analysis.URL, analysis.Branch, analysis.InternalDepURL, cmd)
 	ctx := goContext.Background()
 	resp, err := d.client.ContainerCreate(ctx, &container.Config{
 		Image: image,

--- a/api/log/messagecodes.go
+++ b/api/log/messagecodes.go
@@ -43,6 +43,7 @@ var MsgCode = map[int]string{
 	1018: "Could not Unmarshall the following safetyOutput: ",
 	1019: "Error loading viper: ",
 	1020: "Error searching for an analysis: ",
+	1021: "Received an invalid internal dependency URL",
 
 	// MongoDB infos
 	21: "Connecting to MongoDB.",

--- a/api/log/messagecodes.go
+++ b/api/log/messagecodes.go
@@ -43,7 +43,7 @@ var MsgCode = map[int]string{
 	1018: "Could not Unmarshall the following safetyOutput: ",
 	1019: "Error loading viper: ",
 	1020: "Error searching for an analysis: ",
-	1021: "Received an invalid internal dependency URL",
+	1021: "Received an invalid internal dependency URL: ",
 
 	// MongoDB infos
 	21: "Connecting to MongoDB.",

--- a/api/routes/analysis.go
+++ b/api/routes/analysis.go
@@ -90,17 +90,19 @@ func ReceiveRequest(c echo.Context) error {
 	}
 
 	// check-01-c: is this a valid dependency URL?
-	regexpInternalDepURL := `https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)`
-	valid, err = regexp.MatchString(regexpInternalDepURL, repository.InternalDepURL)
-	if err != nil {
-		log.Error("ReceiveRequest", "ANALYSIS", 1008, "Repository Branch regexp ", err)
-		reply := map[string]interface{}{"success": false, "error": "internal error"}
-		return c.JSON(http.StatusInternalServerError, reply)
-	}
-	if !valid {
-		log.Error("ReceiveRequest", "ANALYSIS", 1021, repository.Branch)
-		reply := map[string]interface{}{"success": false, "error": "invalid internal dependency URL"}
-		return c.JSON(http.StatusBadRequest, reply)
+	if repository.InternalDepURL != "" {
+		regexpInternalDepURL := `https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)`
+		valid, err = regexp.MatchString(regexpInternalDepURL, repository.InternalDepURL)
+		if err != nil {
+			log.Error("ReceiveRequest", "ANALYSIS", 1008, "Repository Branch regexp ", err)
+			reply := map[string]interface{}{"success": false, "error": "internal error"}
+			return c.JSON(http.StatusInternalServerError, reply)
+		}
+		if !valid {
+			log.Error("ReceiveRequest", "ANALYSIS", 1021, repository.Branch)
+			reply := map[string]interface{}{"success": false, "error": "invalid internal dependency URL"}
+			return c.JSON(http.StatusBadRequest, reply)
+		}
 	}
 
 	// check-02: is this repository in MongoDB?

--- a/api/routes/analysis.go
+++ b/api/routes/analysis.go
@@ -89,6 +89,20 @@ func ReceiveRequest(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, reply)
 	}
 
+	// check-01-c: is this a valid dependency URL?
+	regexpInternalDepURL := `https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)`
+	valid, err = regexp.MatchString(regexpInternalDepURL, repository.InternalDepURL)
+	if err != nil {
+		log.Error("ReceiveRequest", "ANALYSIS", 1008, "Repository Branch regexp ", err)
+		reply := map[string]interface{}{"success": false, "error": "internal error"}
+		return c.JSON(http.StatusInternalServerError, reply)
+	}
+	if !valid {
+		log.Error("ReceiveRequest", "ANALYSIS", 1021, repository.Branch)
+		reply := map[string]interface{}{"success": false, "error": "invalid internal dependency URL"}
+		return c.JSON(http.StatusBadRequest, reply)
+	}
+
 	// check-02: is this repository in MongoDB?
 	repositoryQuery := map[string]interface{}{"repositoryURL": repository.URL, "repositoryBranch": repository.Branch}
 	repositoryResult, err := db.FindOneDBRepository(repositoryQuery)

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -20,6 +20,7 @@ type Repository struct {
 	CreatedAt        time.Time      `bson:"createdAt" json:"createdAt"`
 	DeletedAt        time.Time      `bson:"deletedAt" json:"deletedAt"`
 	Languages        []Language     `bson:"languages" json:"languages"`
+	InternalDepURL   string         `bson:"internaldepURL" json:"internaldepURL"`
 }
 
 // SecurityTest is the struct that stores all data from the security tests to be executed.
@@ -35,16 +36,17 @@ type SecurityTest struct {
 
 // Analysis is the struct that stores all data from analysis performed.
 type Analysis struct {
-	ID            bson.ObjectId  `bson:"_id,omitempty"`
-	RID           string         `bson:"RID" json:"RID"`
-	URL           string         `bson:"repositoryURL" json:"repositoryURL"`
-	Branch        string         `bson:"repositoryBranch" json:"repositoryBranch"`
-	SecurityTests []SecurityTest `bson:"securityTests" json:"securityTests"`
-	Status        string         `bson:"status" json:"status"`
-	Result        string         `bson:"result" json:"result"`
-	Containers    []Container    `bson:"containers" json:"containers"`
-	StartedAt     time.Time      `bson:"startedAt" json:"startedAt"`
-	FinishedAt    time.Time      `bson:"finishedAt" json:"finishedAt"`
+	ID             bson.ObjectId  `bson:"_id,omitempty"`
+	RID            string         `bson:"RID" json:"RID"`
+	URL            string         `bson:"repositoryURL" json:"repositoryURL"`
+	Branch         string         `bson:"repositoryBranch" json:"repositoryBranch"`
+	SecurityTests  []SecurityTest `bson:"securityTests" json:"securityTests"`
+	Status         string         `bson:"status" json:"status"`
+	Result         string         `bson:"result" json:"result"`
+	Containers     []Container    `bson:"containers" json:"containers"`
+	StartedAt      time.Time      `bson:"startedAt" json:"startedAt"`
+	FinishedAt     time.Time      `bson:"finishedAt" json:"finishedAt"`
+	InternalDepURL string         `bson:"internaldepURL" json:"internaldepURL"`
 }
 
 // Container is the struct that stores all data from a container run.

--- a/api/util/util.go
+++ b/api/util/util.go
@@ -13,12 +13,13 @@ const (
 	KeyFile = "api/api-tls-key.pem"
 )
 
-// HandleCmd will extract %GIT_REPO% and %GIT_BRANCH% from cmd and replace it with the proper repository URL.
-func HandleCmd(repositoryURL, repositoryBranch, cmd string) string {
+// HandleCmd will extract %GIT_REPO%, %GIT_BRANCH% and %INTERNAL_DEP_URL% from cmd and replace it with the proper repository URL.
+func HandleCmd(repositoryURL, repositoryBranch, internalDepURL, cmd string) string {
 	if repositoryURL != "" && repositoryBranch != "" && cmd != "" {
 		replace1 := strings.Replace(cmd, "%GIT_REPO%", repositoryURL, -1)
 		replace2 := strings.Replace(replace1, "%GIT_BRANCH%", repositoryBranch, -1)
-		return replace2
+		replace3 := strings.Replace(replace2, "%INTERNAL_DEP_URL%", internalDepURL, -1)
+		return replace3
 	}
 	return ""
 }

--- a/api/util/util_test.go
+++ b/api/util/util_test.go
@@ -14,27 +14,34 @@ var _ = Describe("Util", func() {
 	Describe("HandleCmd", func() {
 		inputRepositoryURL := "https://github.com/globocom/secDevLabs.git"
 		inputRepositoryBranch := "myBranch"
-		inputCMD := "git clone -b %GIT_BRANCH% --single-branch %GIT_REPO% code --quiet 2> /tmp/errorGitCloneRetirejs"
-		expected := "git clone -b myBranch --single-branch https://github.com/globocom/secDevLabs.git code --quiet 2> /tmp/errorGitCloneRetirejs"
+		internalDepURL := "https://myinternalurl.com"
+		inputCMD := "git clone -b %GIT_BRANCH% --single-branch %GIT_REPO% code --quiet 2> /tmp/errorGitCloneRetirejs -- %INTERNAL_DEP_URL%"
+		expected := "git clone -b myBranch --single-branch https://github.com/globocom/secDevLabs.git code --quiet 2> /tmp/errorGitCloneRetirejs -- https://myinternalurl.com"
+		expectedEmptyDepURL := "git clone -b myBranch --single-branch https://github.com/globocom/secDevLabs.git code --quiet 2> /tmp/errorGitCloneRetirejs -- "
 
-		Context("When inputRepositoryURL, inputRepositoryBranch and inputCMD are not empty", func() {
+		Context("When inputRepositoryURL, inputRepositoryBranch, internalDepURL and inputCMD are not empty", func() {
 			It("Should return a string based on these params", func() {
-				Expect(util.HandleCmd(inputRepositoryURL, inputRepositoryBranch, inputCMD)).To(Equal(expected))
+				Expect(util.HandleCmd(inputRepositoryURL, inputRepositoryBranch, internalDepURL, inputCMD)).To(Equal(expected))
 			})
 		})
 		Context("When inputRepositoryURL is empty", func() {
 			It("Should return an empty string.", func() {
-				Expect(util.HandleCmd("", inputRepositoryBranch, inputCMD)).To(Equal(""))
+				Expect(util.HandleCmd("", inputRepositoryBranch, internalDepURL, inputCMD)).To(Equal(""))
 			})
 		})
 		Context("When inputRepositoryBranch is empty", func() {
 			It("Should return an empty string.", func() {
-				Expect(util.HandleCmd(inputRepositoryURL, "", inputCMD)).To(Equal(""))
+				Expect(util.HandleCmd(inputRepositoryURL, "", internalDepURL, inputCMD)).To(Equal(""))
 			})
 		})
 		Context("When inputCMD is empty", func() {
 			It("Should return an empty string.", func() {
-				Expect(util.HandleCmd(inputRepositoryURL, inputRepositoryBranch, "")).To(Equal(""))
+				Expect(util.HandleCmd(inputRepositoryURL, inputRepositoryBranch, internalDepURL, "")).To(Equal(""))
+			})
+		})
+		Context("When internalDepURL is empty", func() {
+			It("Should return expectedEmptyDepURL", func() {
+				Expect(util.HandleCmd(inputRepositoryURL, inputRepositoryBranch, "", inputCMD)).To(Equal(expectedEmptyDepURL))
 			})
 		})
 	})

--- a/client/analysis/analysis.go
+++ b/client/analysis/analysis.go
@@ -24,6 +24,7 @@ func StartAnalysis() (string, error) {
 	requestPayload := types.JSONPayload{
 		RepositoryURL:    config.RepositoryURL,
 		RepositoryBranch: config.RepositoryBranch,
+		InternalDepURL:   config.InternalDepURL,
 	}
 	marshalPayload, err := json.Marshal(requestPayload)
 	if err != nil {

--- a/client/analysis/output.go
+++ b/client/analysis/output.go
@@ -154,7 +154,7 @@ func prepareRetirejsOutput(mongoDBcontainerOutput string, mongoDBcontainerInfo s
 				retirejsVuln.Code = result.Component
 				retirejsVuln.Version = result.Version
 				for _, info := range vulnerability.Info {
-					retirejsVuln.Details = retirejsVuln.Details + info
+					retirejsVuln.Details = retirejsVuln.Details + info + "\n"
 				}
 				retirejsVuln.Details = retirejsVuln.Details + vulnerability.Identifiers.Summary
 

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -19,6 +19,9 @@ var HuskyAPI string
 // RepositoryBranch stores the repository branch of the project to be analyzed.
 var RepositoryBranch string
 
+// InternalDepURL stores the URL needed by NPM to properly install internal dependencies.
+var InternalDepURL string
+
 // HuskyUseTLS stores if huskyCI is to use an HTTPS connection.
 var HuskyUseTLS bool
 
@@ -27,6 +30,7 @@ func SetConfigs() {
 	RepositoryURL = os.Getenv(`HUSKYCI_CLIENT_REPO_URL`)
 	RepositoryBranch = os.Getenv(`HUSKYCI_CLIENT_REPO_BRANCH`)
 	HuskyAPI = os.Getenv(`HUSKYCI_CLIENT_API_ADDR`)
+	InternalDepURL = os.Getenv(`HUSKYCI_CLIENT_NPM_DEP_URL`)
 	HuskyUseTLS = getUseTLS()
 }
 
@@ -38,6 +42,7 @@ func CheckEnvVars() error {
 		"HUSKYCI_CLIENT_REPO_URL",
 		"HUSKYCI_CLIENT_REPO_BRANCH",
 		// "HUSKYCI_CLIENT_API_USE_HTTPS" (optional)
+		// "HUSKYCI_CLIENT_NPM_DEP_URL" (optional)
 	}
 
 	var envIsSet bool

--- a/client/types/types.go
+++ b/client/types/types.go
@@ -23,18 +23,20 @@ var IsJSONoutput bool
 type JSONPayload struct {
 	RepositoryURL    string `json:"repositoryURL"`
 	RepositoryBranch string `json:"repositoryBranch"`
+	InternalDepURL   string `json:"internaldepURL"`
 }
 
 // Analysis is the struct that stores all data from analysis performed.
 type Analysis struct {
-	ID            bson.ObjectId  `bson:"_id,omitempty"`
-	RID           string         `bson:"RID" json:"RID"`
-	URL           string         `bson:"repositoryURL" json:"repositoryURL"`
-	Branch        string         `bson:"repositoryBranch" json:"repositoryBranch"`
-	SecurityTests []SecurityTest `bson:"securityTests" json:"securityTests"`
-	Status        string         `bson:"status" json:"status"`
-	Result        string         `bson:"result" json:"result"`
-	Containers    []Container    `bson:"containers" json:"containers"`
+	ID             bson.ObjectId  `bson:"_id,omitempty"`
+	RID            string         `bson:"RID" json:"RID"`
+	URL            string         `bson:"repositoryURL" json:"repositoryURL"`
+	Branch         string         `bson:"repositoryBranch" json:"repositoryBranch"`
+	SecurityTests  []SecurityTest `bson:"securityTests" json:"securityTests"`
+	Status         string         `bson:"status" json:"status"`
+	Result         string         `bson:"result" json:"result"`
+	Containers     []Container    `bson:"containers" json:"containers"`
+	InternalDepURL string         `bson:"internaldepURL" json:"internaldepURL"`
 }
 
 // Container is the struct that stores all data from a container run.


### PR DESCRIPTION
## Closes #235 
This PR aims to add support for RetireJS to install internal project dependencies.

### API:
* `api/analysis/analysis.go`: Add `InternalDepURL` field to the `Analysis` struct.
* `api/config.yaml`: Add install internal dependencies commands to `config.yaml`.
* `api/db/huskydb.go`: Add `InternalDepURL` to `Repository` struct.
* `api/dockers/api.go`: Add `InternalDepURL` to the `handleCMD` function to be replaced by the actual value read from the `HUSKYCI_CLIENT_NPM_DEP_URL` environment variable.
* `api/log/messagecodes.go`: Add error message for invalid dependency URL.
* `api/routes/analysis.go`: Add regexp to verify if the `string` received is a valid URL.
* `api/types/types.go`: Add `InternalDepURL` field to the `Analysis` and `Repository` structs.
* `api/util/util.go`: Modify the `handleCMD` function to replace the internal dependencies placeholder with the actual value.

### Client:
* `client/analysis/analysis.go`: Add `InternalDepURL` field to the `Analysis` struct.
* `client/analysis/output.go`: Add line break to RetireJS's Details output.
* `client/config/config.go`: Add new optional environment variable, `HUSKYCI_CLIENT_NPM_DEP_URL`, to huskyCI's client.
* `client/types/types.go`: Add `InternalDepURL` field to the `Analysis` and `JSONPayload` structs.