### PR TITLE
Fix retireJS not writing cResult and cInfo in the database in case of success

### DIFF
--- a/api/analysis/retirejs.go
+++ b/api/analysis/retirejs.go
@@ -110,22 +110,24 @@ func RetirejsStartAnalysis(CID string, cOutput string) {
 				}
 			}
 		}
-
-		// step 3: update analysis' cResult into AnalyisCollection.
-		issueMessage := "No issues found."
-		if cResult != "passed" {
-			issueMessage = "Issues found."
-		}
-		updateContainerAnalysisQuery := bson.M{
-			"$set": bson.M{
-				"containers.$.cResult": cResult,
-				"containers.$.cInfo":   issueMessage,
-			},
-		}
-		err = db.UpdateOneDBAnalysisContainer(analysisQuery, updateContainerAnalysisQuery)
-		if err != nil {
-			log.Error("RetirejsStartAnalysis", "RETIREJS", 2007, err)
-			return
-		}
 	}
+
+	// step 3: update analysis' cResult into AnalyisCollection.
+	issueMessage := "No issues found."
+	if cResult != "passed" {
+		issueMessage = "Issues found."
+	}
+	updateContainerAnalysisQuery := bson.M{
+		"$set": bson.M{
+			"containers.$.cResult": cResult,
+			"containers.$.cInfo":   issueMessage,
+		},
+	}
+	err = db.UpdateOneDBAnalysisContainer(analysisQuery, updateContainerAnalysisQuery)
+	if err != nil {
+		log.Error("RetirejsStartAnalysis", "RETIREJS", 2007, err)
+	}
+
+	return
+
 }


### PR DESCRIPTION
This PR aims to fix a bug in which retireJS would not write in MongoDB any values for `cResult` and `cInfo` in case of success (no issues found).

* `api/analysis/retirejs.go`: Moved function to be outside of `for` loop and moved the `return` statement outside of the error found clause.