### PR TITLE
Fix mongoDB not updating if internaldepURL changes

### DIFF
--- a/api/db/huskydb.go
+++ b/api/db/huskydb.go
@@ -159,14 +159,15 @@ func InsertDBSecurityTest(securityTest types.SecurityTest) error {
 // InsertDBAnalysis inserts a new analysis into AnalysisCollection.
 func InsertDBAnalysis(analysis types.Analysis) error {
 	newAnalysis := bson.M{
-		"RID":          analysis.RID,
-		"URL":          analysis.URL,
-		"Branch":       analysis.Branch,
-		"securityTest": analysis.SecurityTests,
-		"status":       analysis.Status,
-		"result":       analysis.Result,
-		"containers":   analysis.Containers,
-		"startedAt":    analysis.StartedAt,
+		"RID":            analysis.RID,
+		"URL":            analysis.URL,
+		"Branch":         analysis.Branch,
+		"securityTest":   analysis.SecurityTests,
+		"status":         analysis.Status,
+		"result":         analysis.Result,
+		"containers":     analysis.Containers,
+		"startedAt":      analysis.StartedAt,
+		"internaldepURL": analysis.InternalDepURL,
 	}
 	err := mongoHuskyCI.Conn.Insert(newAnalysis, mongoHuskyCI.AnalysisCollection)
 	return err

--- a/api/log/messagecodes.go
+++ b/api/log/messagecodes.go
@@ -9,7 +9,7 @@ var MsgCode = map[int]string{
 	13: "Docker API is up and running.",
 	14: "Connection with MongoDB succeed.",
 	15: "Default securityTests found on MongoDB.",
-	16: "Request received to start the following branch and repository: ",
+	16: "Request received to start the following branch, repository and internal dependencies URL: ",
 	17: "Repository created into MongoDB: ",
 	18: "SecurityTest created into MongoDB: ",
 
@@ -75,6 +75,7 @@ var MsgCode = map[int]string{
 	2014: "Could not find an analysis using the following RID: ",
 	2015: "Could not create a new repository: ",
 	2016: "Could not create a new securityTest: ",
+	2017: "Could not update repository's internaldepURL: ",
 
 	// Docker API info
 	31: "Waiting pull image...",

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -20,7 +20,7 @@ type Repository struct {
 	CreatedAt        time.Time      `bson:"createdAt" json:"createdAt"`
 	DeletedAt        time.Time      `bson:"deletedAt" json:"deletedAt"`
 	Languages        []Language     `bson:"languages" json:"languages"`
-	InternalDepURL   string         `bson:"internaldepURL" json:"internaldepURL"`
+	InternalDepURL   string         `bson:"internaldepURL,omitempty" json:"internaldepURL"`
 }
 
 // SecurityTest is the struct that stores all data from the security tests to be executed.
@@ -46,7 +46,7 @@ type Analysis struct {
 	Containers     []Container    `bson:"containers" json:"containers"`
 	StartedAt      time.Time      `bson:"startedAt" json:"startedAt"`
 	FinishedAt     time.Time      `bson:"finishedAt" json:"finishedAt"`
-	InternalDepURL string         `bson:"internaldepURL" json:"internaldepURL"`
+	InternalDepURL string         `bson:"internaldepURL,omitempty" json:"internaldepURL"`
 }
 
 // Container is the struct that stores all data from a container run.


### PR DESCRIPTION
## Closes #293 

This PR aims to fix a bug in which `internaldepURL` would not be updated if the desired repository to be analyzes was already present in the database.

* `api/db/huskydb.go`: Add `internaldepURL` to the insert analysis struct.
* `api/log/messagecodes.go`: Add a new message code if huskyCI wasn't able to update a repository with a new `internaldepURL`.
* `api/routes/analysis.go`: Add logic to update the database if `internaldepURL` value changes.
* `api/types/types.go`: Add `omitempty` tag so `internaldepURL` won't show up in the database unless it's not empty.