### PR TITLE
Remove duplicated retireJS vulnerabilities

### DIFF
--- a/client/analysis/output.go
+++ b/client/analysis/output.go
@@ -120,6 +120,8 @@ func prepareBanditOutput(mongoDBcontainerOutput string, mongoDBcontainerInfo str
 // prepareRetirejsOutput will prepare Retirejs output.
 func prepareRetirejsOutput(mongoDBcontainerOutput string, mongoDBcontainerInfo string) {
 
+	var tmpRetireJSResults types.JavaScriptResults
+
 	if mongoDBcontainerInfo == "No issues found." {
 		return
 	}
@@ -132,7 +134,7 @@ func prepareRetirejsOutput(mongoDBcontainerOutput string, mongoDBcontainerInfo s
 		retirejsVuln.Confidence = "high"
 		retirejsVuln.Details = "It looks like your project doesn't have package.json or yarn.lock. huskyCI was not able to run RetireJS properly."
 
-		javaScriptResults.RetirejsResult = append(javaScriptResults.RetirejsResult, retirejsVuln)
+		tmpRetireJSResults.RetirejsResult = append(tmpRetireJSResults.RetirejsResult, retirejsVuln)
 
 		return
 	}
@@ -158,7 +160,7 @@ func prepareRetirejsOutput(mongoDBcontainerOutput string, mongoDBcontainerInfo s
 				}
 				retirejsVuln.Details = retirejsVuln.Details + vulnerability.Identifiers.Summary
 
-				javaScriptResults.RetirejsResult = append(javaScriptResults.RetirejsResult, retirejsVuln)
+				tmpRetireJSResults.RetirejsResult = append(tmpRetireJSResults.RetirejsResult, retirejsVuln)
 
 				if retirejsVuln.Severity == "high" || retirejsVuln.Severity == "medium" {
 					types.FoundVuln = true
@@ -168,6 +170,9 @@ func prepareRetirejsOutput(mongoDBcontainerOutput string, mongoDBcontainerInfo s
 			}
 		}
 	}
+
+	javaScriptResults.RetirejsResult = util.CountRetireJSOccurrences(tmpRetireJSResults.RetirejsResult)
+
 }
 
 // prepareBrakemanOutput will prepare Brakeman output.
@@ -363,6 +368,7 @@ func printSTDOUTOutput() {
 		fmt.Printf("[HUSKYCI][!] Language: %s\n", issue.Language)
 		fmt.Printf("[HUSKYCI][!] Tool: %s\n", issue.SecurityTool)
 		fmt.Printf("[HUSKYCI][!] Severity: %s\n", issue.Severity)
+		fmt.Printf("[HUSKYCI][!] Occurrences: %d\n", issue.Occurrences)
 		fmt.Printf("[HUSKYCI][!] Code: %s\n", issue.Code)
 		fmt.Printf("[HUSKYCI][!] Version: %s\n", issue.Version)
 		fmt.Printf("[HUSKYCI][!] Details: %s\n", issue.Details)
@@ -440,13 +446,13 @@ func prepareAllSummary() {
 		switch issue.Severity {
 		case "low":
 			outputJSON.Summary.RetirejsSummary.FoundInfo = true
-			outputJSON.Summary.RetirejsSummary.LowVuln++
+			outputJSON.Summary.RetirejsSummary.LowVuln = outputJSON.Summary.RetirejsSummary.LowVuln + issue.Occurrences
 		case "medium":
 			outputJSON.Summary.RetirejsSummary.FoundVuln = true
-			outputJSON.Summary.RetirejsSummary.MediumVuln++
+			outputJSON.Summary.RetirejsSummary.MediumVuln = outputJSON.Summary.RetirejsSummary.MediumVuln + issue.Occurrences
 		case "high":
 			outputJSON.Summary.RetirejsSummary.FoundVuln = true
-			outputJSON.Summary.RetirejsSummary.HighVuln++
+			outputJSON.Summary.RetirejsSummary.HighVuln = outputJSON.Summary.RetirejsSummary.HighVuln + issue.Occurrences
 		}
 	}
 

--- a/client/types/types.go
+++ b/client/types/types.go
@@ -75,6 +75,7 @@ type HuskyCIVulnerability struct {
 	Type           string `json:"type,omitempty"`
 	VunerableBelow string `json:"vulnerablebelow,omitempty"`
 	Version        string `json:"version,omitempty"`
+	Occurrences    int    `json:"occurrences,omitempty"`
 }
 
 // JSONOutput is a truct that represents huskyCI output in a JSON format.

--- a/client/util/util.go
+++ b/client/util/util.go
@@ -107,22 +107,16 @@ func CountRetireJSOccurrences(retireJSresults []types.HuskyCIVulnerability) []ty
 	var result []types.HuskyCIVulnerability
 	for _, vuln1 := range retireJSresults {
 		exists := false
-		for _, res := range result {
+		for i, res := range result {
 			if res.Code == vuln1.Code {
 				exists = true
+				result[i].Occurrences++
 			}
 		}
 		if !exists {
 			result = append(result, vuln1)
+			result[len(result)-1].Occurrences++
 		}
 	}
-	for i, res := range result {
-		for _, vuln1 := range retireJSresults {
-			if vuln1.Code == res.Code {
-				result[i].Occurrences = result[i].Occurrences + 1
-			}
-		}
-	}
-
 	return result
 }

--- a/client/util/util.go
+++ b/client/util/util.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/globocom/huskyCI/api/log"
+	"github.com/globocom/huskyCI/client/types"
 )
 
 const (
@@ -98,4 +99,30 @@ func AdjustWarningMessage(warningRaw string) string {
 	}
 
 	return warningRaw
+}
+
+// CountRetireJSOccurrences remove duplicates and increment occurrences in each RetireJS vuln found
+func CountRetireJSOccurrences(retireJSresults []types.HuskyCIVulnerability) []types.HuskyCIVulnerability {
+
+	var result []types.HuskyCIVulnerability
+	for _, vuln1 := range retireJSresults {
+		exists := false
+		for _, res := range result {
+			if res.Code == vuln1.Code {
+				exists = true
+			}
+		}
+		if !exists {
+			result = append(result, vuln1)
+		}
+	}
+	for i, res := range result {
+		for _, vuln1 := range retireJSresults {
+			if vuln1.Code == res.Code {
+				result[i].Occurrences = result[i].Occurrences + 1
+			}
+		}
+	}
+
+	return result
 }


### PR DESCRIPTION
## Closes #290 

This PR will add `CountRetireJSOccurrences` function and its logic to remove duplicated entries of huskyCI Client output. 

A new field `Occurrences` was added into `HuskyCIVulnerability` struct to do so.