### PR TITLE
Add npm audit security test into huskyCI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,7 @@ pull-images:
 	docker exec huskyCI_Docker_API /bin/sh -c "docker pull huskyci/brakeman"
 	docker exec huskyCI_Docker_API /bin/sh -c "docker pull huskyci/retirejs"
 	docker exec huskyCI_Docker_API /bin/sh -c "docker pull huskyci/safety"
+	docker exec huskyCI_Docker_API /bin/sh -c "docker pull huskyci/npmaudit"
 
 ## Runs huskyci-client
 run-client: build-client

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ huskyCI is an open source tool that performs security tests inside CI pipelines 
  
 The main goal of this project is to help development teams improve the quality of their code by finding vulnerabilities as soon as possible.
 
-huskyCI can perform static security analysis in Python ([Bandit][Bandit] and [Safety][Safety]), Ruby ([Brakeman][Brakeman]), JavaScript ([RetireJS][RetireJS]) and Golang ([Gosec][Gosec]). You should check our [wiki](https://github.com/globocom/huskyCI/wiki/How-does-huskyCI-work%3F) to better understand how this tool could help securing your organization projects!
+huskyCI can perform static security analysis in Python ([Bandit][Bandit] and [Safety][Safety]), Ruby ([Brakeman][Brakeman]), JavaScript ([RetireJS][RetireJS] and [Npm Audit][NpmAudit]) and Golang ([Gosec][Gosec]). You should check our [wiki](https://github.com/globocom/huskyCI/wiki/How-does-huskyCI-work%3F) to better understand how this tool could help securing your organization projects!
 
 ## Requirements
 
@@ -88,3 +88,4 @@ This project is licensed under the BSD 3-Clause "New" or "Revised" License - rea
 [Brakeman]: https://github.com/presidentbeef/brakeman
 [Gosec]: https://github.com/securego/gosec
 [RetireJS]: https://github.com/retirejs/retire.js
+[NpmAudit]: https://docs.npmjs.com/cli/audit

--- a/api/analysis/dockerrun.go
+++ b/api/analysis/dockerrun.go
@@ -88,6 +88,8 @@ func DockerRun(RID string, analysis *types.Analysis, securityTest types.Security
 		RetirejsStartAnalysis(d.CID, cOutput)
 	case "safety":
 		SafetyStartAnalysis(d.CID, cOutput)
+	case "npmaudit":
+		NpmAuditStartAnalysis(d.CID, cOutput)
 	default:
 		log.Error("DockerRun", "DOCKERRUN", 3018, err)
 	}

--- a/api/analysis/npmaudit.go
+++ b/api/analysis/npmaudit.go
@@ -1,0 +1,117 @@
+// Copyright 2019 Globo.com authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package analysis
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/globocom/huskyCI/api/db"
+	"github.com/globocom/huskyCI/api/log"
+	"gopkg.in/mgo.v2/bson"
+)
+
+type NpmAuditOutput struct {
+	Advisories map[string]Vulnerability `json:"advisories"`
+	Metadata   Metadata                 `json:"metadata"`
+}
+
+type Vulnerability struct {
+	Findings           []Finding `json:"findings"`
+	ID                 int       `json:"id"`
+	ModuleName         string    `json:"module_name"`
+	VulnerableVersions string    `json:"vulnerable_versions"`
+	Severity           string    `json:"severity"`
+	Overview           string    `json:"overview"`
+}
+
+type Finding struct {
+	Version string `json:"version"`
+}
+
+type Metadata struct {
+	Vulnerabilities VulnerabilitiesSummary `json:"vulnerabilities"`
+}
+
+type VulnerabilitiesSummary struct {
+	Info     int `json:"info"`
+	Low      int `json:"low"`
+	Moderate int `json:"moderate"`
+	High     int `json:"high"`
+	Critical int `json:"critical"`
+}
+
+func NpmAuditStartAnalysis(CID string, cOutput string) {
+
+	var cResult string
+	analysisQuery := map[string]interface{}{"containers.CID": CID}
+
+	// step 0.1: error cloning repository!
+	if strings.Contains(cOutput, "ERROR_CLONING") {
+		errorOutput := fmt.Sprintf("Container error: %s", cOutput)
+		updateContainerAnalysisQuery := bson.M{
+			"$set": bson.M{
+				"containers.$.cResult": "error",
+				"containers.$.cInfo":   errorOutput,
+			},
+		}
+		err := db.UpdateOneDBAnalysisContainer(analysisQuery, updateContainerAnalysisQuery)
+		if err != nil {
+			log.Error("NpmAuditStartAnalysis", "NPMAUDIT", 2007, "Step 0.1 ", err)
+		}
+		return
+	}
+
+	// step 0.2: repository doesn't have package.json
+	if strings.Contains(cOutput, "ERROR_RUNNING_NPMAUDIT") {
+		errorOutput := fmt.Sprintf("Container error: %s", cOutput)
+		updateContainerAnalysisQuery := bson.M{
+			"$set": bson.M{
+				"containers.$.cResult": "error",
+				"containers.$.cInfo":   errorOutput,
+			},
+		}
+		err := db.UpdateOneDBAnalysisContainer(analysisQuery, updateContainerAnalysisQuery)
+		if err != nil {
+			log.Error("NpmAuditStartAnalysis", "NPMAUDIT", 2007, "Step 0.2 ", err)
+		}
+		return
+	}
+
+	// step 1: Unmarshall cOutput into NpmAuditOutput struct.
+	npmAuditOutput := NpmAuditOutput{}
+	err := json.Unmarshal([]byte(cOutput), &npmAuditOutput)
+	if err != nil {
+		log.Error("NpmAuditStartAnalysis", "NPMAUDIT", 1022, cOutput, err)
+		return
+	}
+
+	// step 2: find Issues that have severity "moderate" or "high.
+	cResult = "passed"
+	for _, vulnerability := range npmAuditOutput.Advisories {
+		if vulnerability.Severity == "high" || vulnerability.Severity == "moderate" {
+			cResult = "failed"
+			break
+		}
+	}
+
+	// step 3: update analysis' cResult into AnalyisCollection.
+	issueMessage := "No issues found."
+	if cResult == "failed" {
+		issueMessage = "Issues found."
+	}
+	updateContainerAnalysisQuery := bson.M{
+		"$set": bson.M{
+			"containers.$.cResult": cResult,
+			"containers.$.cInfo":   issueMessage,
+		},
+	}
+	err = db.UpdateOneDBAnalysisContainer(analysisQuery, updateContainerAnalysisQuery)
+	if err != nil {
+		log.Error("NpmAuditStartAnalysis", "NPMAUDIT", 2007, "Step 3 ", err)
+		return
+	}
+}

--- a/api/config.yaml
+++ b/api/config.yaml
@@ -177,3 +177,29 @@ safety:
   language: Python
   default: true
   timeOutInSeconds: 360
+
+npmaudit:
+  name: npmaudit
+  image: huskyci/npmaudit
+  cmd: |+
+    mkdir -p ~/.ssh &&
+    echo 'GIT_PRIVATE_SSH_KEY' > ~/.ssh/huskyci_id_rsa &&
+    chmod 600 ~/.ssh/huskyci_id_rsa &&
+    echo "IdentityFile ~/.ssh/huskyci_id_rsa" >> /etc/ssh/ssh_config &&
+    echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config &&
+    git clone -b %GIT_BRANCH% --single-branch %GIT_REPO% code --quiet 2> /tmp/errorGitCloneNpmAudit
+    if [ $? -eq 0 ]; then
+      cd code
+      if [ -f package.json ]; then
+        npm audit --only=prod --json > /tmp/results.json
+        cat /tmp/results.json
+      else
+        echo 'ERROR_RUNNING_NPMAUDIT'
+      fi
+    else
+      echo "ERROR_CLONING"
+      cat /tmp/errorGitCloneSafety
+    fi
+  language: JavaScript
+  default: true
+  timeOutInSeconds: 360

--- a/api/config.yaml
+++ b/api/config.yaml
@@ -190,9 +190,9 @@ npmaudit:
     git clone -b %GIT_BRANCH% --single-branch %GIT_REPO% code --quiet 2> /tmp/errorGitCloneNpmAudit
     if [ $? -eq 0 ]; then
       cd code
-      if [ -f package.json ]; then
-        npm audit --only=prod --json > /tmp/results.json
-        cat /tmp/results.json
+      if [ -f package-lock.json ]; then
+        npm audit --only=prod --json > /tmp/results.json 2> /tmp/errorNpmaudit
+        jq -j -M -c . /tmp/results.json
       else
         echo 'ERROR_RUNNING_NPMAUDIT'
       fi

--- a/api/context/context.go
+++ b/api/context/context.go
@@ -67,6 +67,7 @@ type APIConfig struct {
 	BanditSecurityTest   *types.SecurityTest
 	BrakemanSecurityTest *types.SecurityTest
 	RetirejsSecurityTest *types.SecurityTest
+	NpmAuditSecurityTest *types.SecurityTest
 	SafetySecurityTest   *types.SecurityTest
 }
 
@@ -101,6 +102,7 @@ func SetOnceConfig() {
 			BanditSecurityTest:   getSecurityTestConfig("bandit"),
 			BrakemanSecurityTest: getSecurityTestConfig("brakeman"),
 			RetirejsSecurityTest: getSecurityTestConfig("retirejs"),
+			NpmAuditSecurityTest: getSecurityTestConfig("npmaudit"),
 			SafetySecurityTest:   getSecurityTestConfig("safety"),
 		}
 	})

--- a/api/log/messagecodes.go
+++ b/api/log/messagecodes.go
@@ -44,6 +44,7 @@ var MsgCode = map[int]string{
 	1019: "Error loading viper: ",
 	1020: "Error searching for an analysis: ",
 	1021: "Received an invalid internal dependency URL: ",
+	1022: "Could not Unmarshall the following npmauditOutput: ",
 
 	// MongoDB infos
 	21: "Connecting to MongoDB.",

--- a/api/util/api/api-util.go
+++ b/api/util/api/api-util.go
@@ -124,7 +124,7 @@ func checkMongoDB() error {
 }
 
 func checkEachSecurityTest(configAPI *apiContext.APIConfig) error {
-	securityTests := []string{"enry", "gosec", "brakeman", "bandit", "retirejs", "safety"}
+	securityTests := []string{"enry", "gosec", "brakeman", "bandit", "retirejs", "npmaudit", "safety"}
 	for _, securityTest := range securityTests {
 		if err := checkSecurityTest(securityTest, configAPI); err != nil {
 			return err
@@ -148,6 +148,8 @@ func checkSecurityTest(securityTestName string, configAPI *apiContext.APIConfig)
 		securityTestConfig = *configAPI.BanditSecurityTest
 	case "retirejs":
 		securityTestConfig = *configAPI.RetirejsSecurityTest
+	case "npmaudit":
+		securityTestConfig = *configAPI.NpmAuditSecurityTest
 	case "safety":
 		securityTestConfig = *configAPI.SafetySecurityTest
 	default:

--- a/client/types/npmaudit.go
+++ b/client/types/npmaudit.go
@@ -4,11 +4,13 @@
 
 package types
 
+// NpmAuditOutput is the struct that stores all npm audit output
 type NpmAuditOutput struct {
 	Advisories map[string]Vulnerability `json:"advisories"`
 	Metadata   Metadata                 `json:"metadata"`
 }
 
+// Vulnerability is the granular output of a security info found
 type Vulnerability struct {
 	Findings           []Finding `json:"findings"`
 	ID                 int       `json:"id"`
@@ -18,14 +20,17 @@ type Vulnerability struct {
 	Overview           string    `json:"overview"`
 }
 
+// Finding holds the version of a given security issue found
 type Finding struct {
 	Version string `json:"version"`
 }
 
+// Metadata is the struct that holds vulnerabilities summary
 type Metadata struct {
 	Vulnerabilities VulnerabilitiesSummary `json:"vulnerabilities"`
 }
 
+// VulnerabilitiesSummary is the struct that has all types of possible vulnerabilities from npm audit
 type VulnerabilitiesSummary struct {
 	Info     int `json:"info"`
 	Low      int `json:"low"`

--- a/client/types/npmaudit.go
+++ b/client/types/npmaudit.go
@@ -1,0 +1,35 @@
+// Copyright 2019 Globo.com authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package types
+
+type NpmAuditOutput struct {
+	Advisories map[string]Vulnerability `json:"advisories"`
+	Metadata   Metadata                 `json:"metadata"`
+}
+
+type Vulnerability struct {
+	Findings           []Finding `json:"findings"`
+	ID                 int       `json:"id"`
+	ModuleName         string    `json:"module_name"`
+	VulnerableVersions string    `json:"vulnerable_versions"`
+	Severity           string    `json:"severity"`
+	Overview           string    `json:"overview"`
+}
+
+type Finding struct {
+	Version string `json:"version"`
+}
+
+type Metadata struct {
+	Vulnerabilities VulnerabilitiesSummary `json:"vulnerabilities"`
+}
+
+type VulnerabilitiesSummary struct {
+	Info     int `json:"info"`
+	Low      int `json:"low"`
+	Moderate int `json:"moderate"`
+	High     int `json:"high"`
+	Critical int `json:"critical"`
+}

--- a/client/types/types.go
+++ b/client/types/types.go
@@ -100,6 +100,7 @@ type PythonResults struct {
 // JavaScriptResults represents all JavaScript security tests results.
 type JavaScriptResults struct {
 	RetirejsResult []HuskyCIVulnerability `json:"retirejsoutput,omitempty"`
+	NpmAuditResult []HuskyCIVulnerability `json:"npmauditoutput,omitempty"`
 }
 
 // RubyResults represents all Ruby security tests results.
@@ -116,6 +117,7 @@ type Summary struct {
 	BanditSummary   HuskyCISummary `json:"banditsummary,omitempty"`
 	SafetySummary   HuskyCISummary `json:"safetysummary,omitempty"`
 	RetirejsSummary HuskyCISummary `json:"retirejssummary,omitempty"`
+	NpmAuditSummary HuskyCISummary `json:"npmauditsummary,omitempty"`
 	BrakemanSummary HuskyCISummary `json:"brakemansummary,omitempty"`
 	TotalSummary    HuskyCISummary `json:"totalsummary,omitempty"`
 }

--- a/deployments/dockerfiles/npmaudit/Dockerfile
+++ b/deployments/dockerfiles/npmaudit/Dockerfile
@@ -1,0 +1,8 @@
+# Dockerfile used to create "huskyci/npmaudit" image
+# https://hub.docker.com/r/huskyci/npmaudit/
+
+FROM node:alpine
+
+RUN apk update && apk upgrade \
+	&& apk add --no-cache alpine-sdk bash openssh-client \
+	&& apk add git

--- a/deployments/dockerfiles/npmaudit/Dockerfile
+++ b/deployments/dockerfiles/npmaudit/Dockerfile
@@ -6,3 +6,7 @@ FROM node:alpine
 RUN apk update && apk upgrade \
 	&& apk add --no-cache alpine-sdk bash openssh-client \
 	&& apk add git
+
+RUN wget -O jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
+RUN chmod +x ./jq
+RUN cp jq /usr/bin


### PR DESCRIPTION
## Closes #297 

This PR aims to add `npm audit` security test into huskyCI.

### API:
* `api/analysis/dockerrun.go`: Add new security test case to `dockerrun.go`
* `api/analysis/npmaudit.go`: Add `npmaudit` security test type and logic.
* `api/config.yaml`: Add commands to be run inside `npmaudit` security test container.
* `api/context/context.go`: Add `npmaudit` security test to `context.go`.
* `api/log/messagecodes.go`: Add new error code when `npmaudit` resulting `JSON` could not be unmarshalled.
* `api/util/api/api-util.go`: Add `npmaudit` security test into `api-util.go`

### Client:
* `client/analysis/output.go`: Add `npmaudit` security test to huskyCI's output.
* `client/types/npmaudit.go`: Add `npmaudit.go` logic to client.

### Deployments:
* `deployments/dockerfiles/npmaudit/Dockerfile`: Add Dockerfile used to create `huskyci/npmaudit` container image.
