### PR TITLE
Update security tests each time huskyCI starts

### DIFF
--- a/api/util/api/api-util.go
+++ b/api/util/api/api-util.go
@@ -155,13 +155,13 @@ func checkSecurityTest(securityTestName string, configAPI *apiContext.APIConfig)
 	}
 
 	securityTestQuery := map[string]interface{}{"name": securityTestName}
-	_, err := db.FindOneDBSecurityTest(securityTestQuery)
-	if err == mgo.ErrNotFound {
-		// As securityTest is not set into MongoDB, huskyCI will insert it.
-		if err := db.InsertDBSecurityTest(securityTestConfig); err != nil {
-			return err
+	err := db.UpdateOneDBSecurityTest(securityTestQuery, securityTestConfig)
+	if err != nil {
+		if err == mgo.ErrNotFound {
+			if err := db.InsertDBSecurityTest(securityTestConfig); err != nil {
+				return err
+			}
 		}
-	} else if err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
## Closes #271
Adds `UpdateOneDBSecurityTest()` step to `checkSecurityTest()` function, forcing the app to update each security test with the contents from `config.yaml` file each time huskyCI starts.