### PR TITLE
Update sec tests insertion logic 

### DIFF
--- a/api/db/huskydb.go
+++ b/api/db/huskydb.go
@@ -12,6 +12,7 @@ import (
 	"github.com/globocom/huskyCI/api/log"
 	"github.com/globocom/huskyCI/api/types"
 	"github.com/globocom/huskyCI/api/util"
+	mgo "gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 )
 
@@ -184,15 +185,15 @@ func UpdateOneDBRepository(mapParams, updateQuery map[string]interface{}) error 
 	return err
 }
 
-// UpdateOneDBSecurityTest checks if a given securityTest is present into SecurityTestCollection and update it.
-func UpdateOneDBSecurityTest(mapParams map[string]interface{}, updatedSecurityTest types.SecurityTest) error {
+// UpsertOneDBSecurityTest checks if a given securityTest is present into SecurityTestCollection and update it.
+func UpsertOneDBSecurityTest(mapParams map[string]interface{}, updatedSecurityTest types.SecurityTest) (*mgo.ChangeInfo, error) {
 	securityTestQuery := []bson.M{}
 	for k, v := range mapParams {
 		securityTestQuery = append(securityTestQuery, bson.M{k: v})
 	}
 	securityTestFinalQuery := bson.M{"$and": securityTestQuery}
-	_, err := mongoHuskyCI.Conn.Upsert(securityTestFinalQuery, updatedSecurityTest, mongoHuskyCI.SecurityTestCollection)
-	return err
+	changeInfo, err := mongoHuskyCI.Conn.Upsert(securityTestFinalQuery, updatedSecurityTest, mongoHuskyCI.SecurityTestCollection)
+	return changeInfo, err
 }
 
 // UpdateOneDBAnalysis checks if a given analysis is present into AnalysisCollection and update it.

--- a/api/db/huskydb.go
+++ b/api/db/huskydb.go
@@ -191,7 +191,7 @@ func UpdateOneDBSecurityTest(mapParams map[string]interface{}, updatedSecurityTe
 		securityTestQuery = append(securityTestQuery, bson.M{k: v})
 	}
 	securityTestFinalQuery := bson.M{"$and": securityTestQuery}
-	err := mongoHuskyCI.Conn.Update(securityTestFinalQuery, updatedSecurityTest, mongoHuskyCI.SecurityTestCollection)
+	_, err := mongoHuskyCI.Conn.Upsert(securityTestFinalQuery, updatedSecurityTest, mongoHuskyCI.SecurityTestCollection)
 	return err
 }
 

--- a/api/log/messagecodes.go
+++ b/api/log/messagecodes.go
@@ -12,6 +12,7 @@ var MsgCode = map[int]string{
 	16: "Request received to start the following branch, repository and internal dependencies URL: ",
 	17: "Repository created into MongoDB: ",
 	18: "SecurityTest created into MongoDB: ",
+	19: "SecurityTest upserted in MondoDB: ",
 
 	// HuskyCI API warnings
 	104: "An analysis is already in place for this URL: ",
@@ -45,6 +46,7 @@ var MsgCode = map[int]string{
 	1020: "Error searching for an analysis: ",
 	1021: "Received an invalid internal dependency URL: ",
 	1022: "Could not Unmarshall the following npmauditOutput: ",
+	1023: "Could not upsert securityTest into MongoDB: ",
 
 	// MongoDB infos
 	21: "Connecting to MongoDB.",


### PR DESCRIPTION
This MR changes how husky includes new secTests into MondoDB, using `Upsert()` instead of `Update()`. `Upsert()` search for an element in the database. If he finds it, he updates it. If he doesn't, he creates a new entry with the given configurations.

This prevents `ErrNotFound` error from happening. 