### PR TITLE
Add vulnerabilities into Analysis struct

### DIFF
--- a/api/analysis/analysis.go
+++ b/api/analysis/analysis.go
@@ -195,6 +195,8 @@ func updateHuskyCIResultsBasedOnRID(RID, securityTest string, securityTestResult
 		analysis.HuskyCIResults.PythonResults.HuskyCIBanditOutput = prepareHuskyCIBanditOutput(securityTestResult.(BanditOutput))
 	case "retirejs":
 		analysis.HuskyCIResults.JavaScriptResults.HuskyCIRetireJSOutput = prepareHuskyCIRetirejsOutput(securityTestResult.([]RetirejsOutput))
+	case "npmaudit":
+		analysis.HuskyCIResults.JavaScriptResults.HuskyCINpmAuditOutput = prepareHuskyCINpmAuditResults(securityTestResult.(NpmAuditOutput))
 	case "brakeman":
 		analysis.HuskyCIResults.RubyResults.HuskyCIBrakemanOutput = prepareHuskyCIBrakemanResults(securityTestResult.(BrakemanOutput))
 	case "gosec":

--- a/api/analysis/analysis.go
+++ b/api/analysis/analysis.go
@@ -197,6 +197,8 @@ func updateHuskyCIResultsBasedOnRID(RID, securityTest string, securityTestResult
 		analysis.HuskyCIResults.JavaScriptResults.HuskyCIRetireJSOutput = prepareHuskyCIRetirejsOutput(securityTestResult.([]RetirejsOutput))
 	case "brakeman":
 		analysis.HuskyCIResults.RubyResults.HuskyCIBrakemanOutput = prepareHuskyCIBrakemanResults(securityTestResult.(BrakemanOutput))
+	case "gosec":
+		analysis.HuskyCIResults.GoResults.HuskyCIGosecOutput = prepareHuskyCIGosecResults(securityTestResult.(GosecOutput))
 	}
 
 	err = db.UpdateOneDBAnalysis(analysisQuery, analysis)

--- a/api/analysis/analysis.go
+++ b/api/analysis/analysis.go
@@ -193,6 +193,8 @@ func updateHuskyCIResultsBasedOnRID(RID, securityTest string, securityTestResult
 	switch securityTest {
 	case "bandit":
 		analysis.HuskyCIResults.PythonResults.HuskyCIBanditOutput = prepareHuskyCIBanditOutput(securityTestResult.(BanditOutput))
+	case "safety":
+		analysis.HuskyCIResults.PythonResults.HuskyCISafetyOutput = prepareHuskyCISafetyResults(securityTestResult.(SafetyOutput))
 	case "retirejs":
 		analysis.HuskyCIResults.JavaScriptResults.HuskyCIRetireJSOutput = prepareHuskyCIRetirejsOutput(securityTestResult.([]RetirejsOutput))
 	case "npmaudit":

--- a/api/analysis/analysis.go
+++ b/api/analysis/analysis.go
@@ -161,3 +161,45 @@ func monitorAnalysisCheckStatus(RID string) (bool, error) {
 	}
 	return analysisFinished, err
 }
+
+func updateInfoAndResultBasedOnCID(cInfo, cResult, CID string) error {
+
+	updateContainerAnalysisQuery := bson.M{
+		"$set": bson.M{
+			"containers.$.cResult": cResult,
+			"containers.$.cInfo":   cInfo,
+		},
+	}
+
+	analysisQuery := map[string]interface{}{"containers.CID": CID}
+	err := db.UpdateOneDBAnalysisContainer(analysisQuery, updateContainerAnalysisQuery)
+	if err != nil {
+		log.Error("updateCIDinfoAndResult", "ANALYSIS", 2007, err)
+		return err
+	}
+
+	return nil
+}
+
+func updateHuskyCIResultsBasedOnRID(RID, securityTest string, securityTestResult interface{}) error {
+
+	analysisQuery := map[string]interface{}{"RID": RID}
+	analysis, err := db.FindOneDBAnalysis(analysisQuery)
+	if err != nil {
+		log.Error("updateHuskyCIResultsBasedOnRID", "ANALYSIS", 2008, err)
+		return err
+	}
+
+	switch securityTest {
+	case "bandit":
+		analysis.HuskyCIResults.PythonResults.HuskyCIBanditOutput = prepareHuskyCIBanditOutput(securityTestResult.(BanditOutput))
+	}
+
+	err = db.UpdateOneDBAnalysis(analysisQuery, analysis)
+	if err != nil {
+		log.Error("updateHuskyCIResultsBasedOnRID", "ANALYSIS", 2007, err)
+		return err
+	}
+
+	return nil
+}

--- a/api/analysis/analysis.go
+++ b/api/analysis/analysis.go
@@ -193,6 +193,8 @@ func updateHuskyCIResultsBasedOnRID(RID, securityTest string, securityTestResult
 	switch securityTest {
 	case "bandit":
 		analysis.HuskyCIResults.PythonResults.HuskyCIBanditOutput = prepareHuskyCIBanditOutput(securityTestResult.(BanditOutput))
+	case "retirejs":
+		analysis.HuskyCIResults.JavaScriptResults.HuskyCIRetireJSOutput = prepareHuskyCIRetirejsOutput(securityTestResult.([]RetirejsOutput))
 	}
 
 	err = db.UpdateOneDBAnalysis(analysisQuery, analysis)

--- a/api/analysis/analysis.go
+++ b/api/analysis/analysis.go
@@ -174,7 +174,7 @@ func updateInfoAndResultBasedOnCID(cInfo, cResult, CID string) error {
 	analysisQuery := map[string]interface{}{"containers.CID": CID}
 	err := db.UpdateOneDBAnalysisContainer(analysisQuery, updateContainerAnalysisQuery)
 	if err != nil {
-		log.Error("updateCIDinfoAndResult", "ANALYSIS", 2007, err)
+		log.Error("updateInfoAndResultBasedOnCID", "ANALYSIS", 2007, err)
 		return err
 	}
 

--- a/api/analysis/analysis.go
+++ b/api/analysis/analysis.go
@@ -195,6 +195,8 @@ func updateHuskyCIResultsBasedOnRID(RID, securityTest string, securityTestResult
 		analysis.HuskyCIResults.PythonResults.HuskyCIBanditOutput = prepareHuskyCIBanditOutput(securityTestResult.(BanditOutput))
 	case "retirejs":
 		analysis.HuskyCIResults.JavaScriptResults.HuskyCIRetireJSOutput = prepareHuskyCIRetirejsOutput(securityTestResult.([]RetirejsOutput))
+	case "brakeman":
+		analysis.HuskyCIResults.RubyResults.HuskyCIBrakemanOutput = prepareHuskyCIBrakemanResults(securityTestResult.(BrakemanOutput))
 	}
 
 	err = db.UpdateOneDBAnalysis(analysisQuery, analysis)

--- a/api/analysis/bandit.go
+++ b/api/analysis/bandit.go
@@ -32,8 +32,8 @@ type Result struct {
 	TestName        string `json:"test_name"`
 }
 
-// BanditStartAnalysis analyses the output from Bandit and sets a cResult based on it.
-func BanditStartAnalysis(CID string, cOutput string, RID string) {
+// BanditCheckOutputFlow analyses the output from Bandit and sets a cResult based on it.
+func BanditCheckOutputFlow(CID string, cOutput string, RID string) {
 
 	// step 1: check for any errors when clonning repo
 	errorClonning := strings.Contains(cOutput, "ERROR_CLONING")

--- a/api/analysis/bandit.go
+++ b/api/analysis/bandit.go
@@ -87,9 +87,9 @@ func BanditCheckOutputFlow(CID string, cOutput string, RID string) {
 }
 
 // prepareHuskyCIBanditOutput will prepare Bandit output to be added into pythonResults struct
-func prepareHuskyCIBanditOutput(banditOutput BanditOutput) types.HuskyCIBanditOutput {
+func prepareHuskyCIBanditOutput(banditOutput BanditOutput) types.HuskyCISecurityTestOutput {
 
-	var huskyCIbanditResults types.HuskyCIBanditOutput
+	var huskyCIbanditResults types.HuskyCISecurityTestOutput
 
 	for _, issue := range banditOutput.Results {
 		banditVuln := types.HuskyCIVulnerability{}
@@ -104,11 +104,11 @@ func prepareHuskyCIBanditOutput(banditOutput BanditOutput) types.HuskyCIBanditOu
 
 		switch banditVuln.Severity {
 		case "LOW":
-			huskyCIbanditResults.LowVulnsBandit = append(huskyCIbanditResults.LowVulnsBandit, banditVuln)
+			huskyCIbanditResults.LowVulns = append(huskyCIbanditResults.LowVulns, banditVuln)
 		case "MEDIUM":
-			huskyCIbanditResults.MediumVulnsBandit = append(huskyCIbanditResults.MediumVulnsBandit, banditVuln)
+			huskyCIbanditResults.MediumVulns = append(huskyCIbanditResults.MediumVulns, banditVuln)
 		case "HIGH":
-			huskyCIbanditResults.HighVulnsBandit = append(huskyCIbanditResults.HighVulnsBandit, banditVuln)
+			huskyCIbanditResults.HighVulns = append(huskyCIbanditResults.HighVulns, banditVuln)
 		}
 	}
 

--- a/api/analysis/bandit.go
+++ b/api/analysis/bandit.go
@@ -35,7 +35,7 @@ type Result struct {
 // BanditStartAnalysis analyses the output from Bandit and sets a cResult based on it.
 func BanditStartAnalysis(CID string, cOutput string, RID string) {
 
-	// check for any error when clonning repo
+	// step 1: check for any errors when clonning repo
 	errorClonning := strings.Contains(cOutput, "ERROR_CLONING")
 	if errorClonning {
 		if err := updateInfoAndResultBasedOnCID("Error clonning repository", "error", CID); err != nil {
@@ -43,14 +43,14 @@ func BanditStartAnalysis(CID string, cOutput string, RID string) {
 		}
 	}
 
-	// get Bandit output to be checked
+	// step 2: get Bandit output to be checked
 	var banditResult BanditOutput
 	if err := json.Unmarshal([]byte(cOutput), &banditResult); err != nil {
 		log.Error("BanditStartAnalysis", "BANDIT", 1006, cOutput, err)
 		return
 	}
 
-	// Sets the container output to "No issues found" if banditResult returns an empty slice
+	// step 3: sets the container output to "No issues found" if banditResult returns an empty slice
 	if len(banditResult.Results) == 0 {
 		if err := updateInfoAndResultBasedOnCID("No issues found.", "passed", CID); err != nil {
 			return
@@ -58,14 +58,14 @@ func BanditStartAnalysis(CID string, cOutput string, RID string) {
 		return
 	}
 
-	// verify if there was any error in the analysis.
+	// step 4: verify if there was any error in the analysis.
 	if banditResult.Errors != nil {
 		if err := updateInfoAndResultBasedOnCID("Internal error running Bandit.", "error", CID); err != nil {
 			return
 		}
 	}
 
-	// find Issues that have severity "MEDIUM" or "HIGH" and confidence "HIGH".
+	// step 5: find Issues that have severity "MEDIUM" or "HIGH" and confidence "HIGH".
 	cResult := "passed"
 	issueMessage := "No issues found."
 	for _, issue := range banditResult.Results {
@@ -79,7 +79,7 @@ func BanditStartAnalysis(CID string, cOutput string, RID string) {
 		return
 	}
 
-	// finally, update analysis with huskyCI results
+	// step 6: finally, update analysis with huskyCI results
 	if err := updateHuskyCIResultsBasedOnRID(RID, "bandit", banditResult); err != nil {
 		return
 	}

--- a/api/analysis/bandit.go
+++ b/api/analysis/bandit.go
@@ -119,7 +119,7 @@ func BanditStartAnalysis(CID string, cOutput string, RID string) {
 	analysisQuery = map[string]interface{}{"RID": RID}
 	analysis, err := db.FindOneDBAnalysis(analysisQuery)
 	if err != nil {
-		log.Error("GosecStartAnalysis", "BANDIT", 2008, CID, err)
+		log.Error("BanditStartAnalysis", "BANDIT", 2008, CID, err)
 		return
 	}
 
@@ -127,7 +127,7 @@ func BanditStartAnalysis(CID string, cOutput string, RID string) {
 	analysis.HuskyCIResults.PythonResults.HuskyCIBanditOutput = prepareHuskyCIBanditOutput(banditResult)
 	err = db.UpdateOneDBAnalysis(analysisQuery, analysis)
 	if err != nil {
-		log.Error("GosecStartAnalysis", "BANDIT", 2007, err)
+		log.Error("BanditStartAnalysis", "BANDIT", 2007, err)
 		return
 	}
 

--- a/api/analysis/bandit.go
+++ b/api/analysis/bandit.go
@@ -41,6 +41,7 @@ func BanditStartAnalysis(CID string, cOutput string, RID string) {
 		if err := updateInfoAndResultBasedOnCID("Error clonning repository", "error", CID); err != nil {
 			return
 		}
+		return
 	}
 
 	// step 2: get Bandit output to be checked

--- a/api/analysis/brakeman.go
+++ b/api/analysis/brakeman.go
@@ -38,6 +38,7 @@ func BrakemanStartAnalysis(CID string, cOutput string, RID string) {
 		if err := updateInfoAndResultBasedOnCID("Error clonning repository", "error", CID); err != nil {
 			return
 		}
+		return
 	}
 
 	// step 2: nil cOutput states that no Issues were found.

--- a/api/analysis/brakeman.go
+++ b/api/analysis/brakeman.go
@@ -29,8 +29,8 @@ type WarningItem struct {
 	Confidence string `json:"confidence"`
 }
 
-// BrakemanStartAnalysis analyses the output from Brakeman and sets a cResult based on it.
-func BrakemanStartAnalysis(CID string, cOutput string, RID string) {
+// BrakemanCheckOutputFlow analyses the output from Brakeman and sets a cResult based on it.
+func BrakemanCheckOutputFlow(CID string, cOutput string, RID string) {
 
 	// step 1: check for any errors when clonning repo
 	errorClonning := strings.Contains(cOutput, "ERROR_CLONING")

--- a/api/analysis/brakeman.go
+++ b/api/analysis/brakeman.go
@@ -86,9 +86,9 @@ func BrakemanCheckOutputFlow(CID string, cOutput string, RID string) {
 }
 
 // prepareHuskyCIBrakemanResults will prepare Brakeman output to be added into RubyResults struct
-func prepareHuskyCIBrakemanResults(brakemanOutput BrakemanOutput) types.HuskyCIBrakemanOutput {
+func prepareHuskyCIBrakemanResults(brakemanOutput BrakemanOutput) types.HuskyCISecurityTestOutput {
 
-	var huskyCIbrakemanResults types.HuskyCIBrakemanOutput
+	var huskyCIbrakemanResults types.HuskyCISecurityTestOutput
 
 	for _, warning := range brakemanOutput.Warnings {
 		brakemanVuln := types.HuskyCIVulnerability{}
@@ -103,11 +103,11 @@ func prepareHuskyCIBrakemanResults(brakemanOutput BrakemanOutput) types.HuskyCIB
 
 		switch brakemanVuln.Confidence {
 		case "High":
-			huskyCIbrakemanResults.LowVulnsBrakeman = append(huskyCIbrakemanResults.LowVulnsBrakeman, brakemanVuln)
+			huskyCIbrakemanResults.LowVulns = append(huskyCIbrakemanResults.LowVulns, brakemanVuln)
 		case "Medium":
-			huskyCIbrakemanResults.MediumVulnsBrakeman = append(huskyCIbrakemanResults.MediumVulnsBrakeman, brakemanVuln)
+			huskyCIbrakemanResults.MediumVulns = append(huskyCIbrakemanResults.MediumVulns, brakemanVuln)
 		case "Low":
-			huskyCIbrakemanResults.HighVulnsBrakeman = append(huskyCIbrakemanResults.HighVulnsBrakeman, brakemanVuln)
+			huskyCIbrakemanResults.HighVulns = append(huskyCIbrakemanResults.HighVulns, brakemanVuln)
 		}
 	}
 

--- a/api/analysis/dockerrun.go
+++ b/api/analysis/dockerrun.go
@@ -83,7 +83,7 @@ func DockerRun(RID string, analysis *types.Analysis, securityTest types.Security
 	case "bandit":
 		BanditStartAnalysis(d.CID, cOutput, analysis.RID)
 	case "brakeman":
-		BrakemanStartAnalysis(d.CID, cOutput)
+		BrakemanStartAnalysis(d.CID, cOutput, analysis.RID)
 	case "retirejs":
 		RetirejsStartAnalysis(d.CID, cOutput)
 	case "safety":

--- a/api/analysis/dockerrun.go
+++ b/api/analysis/dockerrun.go
@@ -87,7 +87,7 @@ func DockerRun(RID string, analysis *types.Analysis, securityTest types.Security
 	case "retirejs":
 		RetirejsStartAnalysis(d.CID, cOutput, analysis.RID)
 	case "safety":
-		SafetyStartAnalysis(d.CID, cOutput)
+		SafetyStartAnalysis(d.CID, cOutput, analysis.RID)
 	case "npmaudit":
 		NpmAuditStartAnalysis(d.CID, cOutput, analysis.RID)
 	default:

--- a/api/analysis/dockerrun.go
+++ b/api/analysis/dockerrun.go
@@ -81,7 +81,7 @@ func DockerRun(RID string, analysis *types.Analysis, securityTest types.Security
 	case "gosec":
 		GosecStartAnalysis(d.CID, cOutput, analysis.RID)
 	case "bandit":
-		BanditStartAnalysis(d.CID, cOutput)
+		BanditStartAnalysis(d.CID, cOutput, analysis.RID)
 	case "brakeman":
 		BrakemanStartAnalysis(d.CID, cOutput)
 	case "retirejs":

--- a/api/analysis/dockerrun.go
+++ b/api/analysis/dockerrun.go
@@ -79,7 +79,7 @@ func DockerRun(RID string, analysis *types.Analysis, securityTest types.Security
 	case "enry":
 		EnryStartAnalysis(d.CID, cOutput, analysis.RID)
 	case "gosec":
-		GosecStartAnalysis(d.CID, cOutput)
+		GosecStartAnalysis(d.CID, cOutput, analysis.RID)
 	case "bandit":
 		BanditStartAnalysis(d.CID, cOutput)
 	case "brakeman":

--- a/api/analysis/dockerrun.go
+++ b/api/analysis/dockerrun.go
@@ -77,19 +77,19 @@ func DockerRun(RID string, analysis *types.Analysis, securityTest types.Security
 	// step 5: send output to the proper analysis result function.
 	switch securityTest.Name {
 	case "enry":
-		EnryStartAnalysis(d.CID, cOutput, analysis.RID)
+		EnryCheckOutputFlow(d.CID, cOutput, analysis.RID)
 	case "gosec":
-		GosecStartAnalysis(d.CID, cOutput, analysis.RID)
+		GosecCheckOutputFlow(d.CID, cOutput, analysis.RID)
 	case "bandit":
-		BanditStartAnalysis(d.CID, cOutput, analysis.RID)
+		BanditCheckOutputFlow(d.CID, cOutput, analysis.RID)
 	case "brakeman":
-		BrakemanStartAnalysis(d.CID, cOutput, analysis.RID)
+		BrakemanCheckOutputFlow(d.CID, cOutput, analysis.RID)
 	case "retirejs":
-		RetirejsStartAnalysis(d.CID, cOutput, analysis.RID)
+		RetirejsCheckOutputFlow(d.CID, cOutput, analysis.RID)
 	case "safety":
-		SafetyStartAnalysis(d.CID, cOutput, analysis.RID)
+		SafetyCheckOutputFlow(d.CID, cOutput, analysis.RID)
 	case "npmaudit":
-		NpmAuditStartAnalysis(d.CID, cOutput, analysis.RID)
+		NpmAuditCheckOutputFlow(d.CID, cOutput, analysis.RID)
 	default:
 		log.Error("DockerRun", "DOCKERRUN", 3018, err)
 	}

--- a/api/analysis/dockerrun.go
+++ b/api/analysis/dockerrun.go
@@ -85,7 +85,7 @@ func DockerRun(RID string, analysis *types.Analysis, securityTest types.Security
 	case "brakeman":
 		BrakemanStartAnalysis(d.CID, cOutput, analysis.RID)
 	case "retirejs":
-		RetirejsStartAnalysis(d.CID, cOutput)
+		RetirejsStartAnalysis(d.CID, cOutput, analysis.RID)
 	case "safety":
 		SafetyStartAnalysis(d.CID, cOutput)
 	case "npmaudit":

--- a/api/analysis/dockerrun.go
+++ b/api/analysis/dockerrun.go
@@ -89,7 +89,7 @@ func DockerRun(RID string, analysis *types.Analysis, securityTest types.Security
 	case "safety":
 		SafetyStartAnalysis(d.CID, cOutput)
 	case "npmaudit":
-		NpmAuditStartAnalysis(d.CID, cOutput)
+		NpmAuditStartAnalysis(d.CID, cOutput, analysis.RID)
 	default:
 		log.Error("DockerRun", "DOCKERRUN", 3018, err)
 	}

--- a/api/analysis/enry.go
+++ b/api/analysis/enry.go
@@ -15,8 +15,8 @@ import (
 	"github.com/globocom/huskyCI/api/types"
 )
 
-// EnryStartAnalysis checks the languages of a repository, update them into mongoDB, and starts corresponding new securityTests.
-func EnryStartAnalysis(CID string, cOutput string, RID string) {
+// EnryCheckOutputFlow checks the languages of a repository, update them into mongoDB, and starts corresponding new securityTests.
+func EnryCheckOutputFlow(CID string, cOutput string, RID string) {
 
 	// step 1: check for any errors when clonning repo
 	errorClonning := strings.Contains(cOutput, "ERROR_CLONING")

--- a/api/analysis/enry.go
+++ b/api/analysis/enry.go
@@ -6,60 +6,100 @@ package analysis
 
 import (
 	"encoding/json"
-	"fmt"
+	"errors"
 	"reflect"
 	"strings"
 
 	"github.com/globocom/huskyCI/api/db"
 	"github.com/globocom/huskyCI/api/log"
 	"github.com/globocom/huskyCI/api/types"
-	"gopkg.in/mgo.v2/bson"
 )
 
 // EnryStartAnalysis checks the languages of a repository, update them into mongoDB, and starts corresponding new securityTests.
 func EnryStartAnalysis(CID string, cOutput string, RID string) {
 
-	// step 0.1: get analysis based on CID.
+	// step 1: check for any errors when clonning repo
+	errorClonning := strings.Contains(cOutput, "ERROR_CLONING")
+	if errorClonning || cOutput == "" {
+		if err := updateInfoAndResultBasedOnCID("Error clonning repository", "error", CID); err != nil {
+			return
+		}
+		return
+	}
+
+	// step 2: get each language found in cOutput.
+	repositoryLanguages, err := getLanguagesFromEnryOutput(cOutput)
+	if err != nil {
+		return
+	}
+
+	// step 3.1: get all generic securityTests from MongoDB
+	genericSecurityTests, err := getAllSecurityTestsBasedOnLanguage("Generic")
+	if err != nil {
+		return
+	}
+
+	// step 3.2: get all securityTests based on each language found
+	newLanguageSecurityTests := []types.SecurityTest{}
+	for _, languageFound := range repositoryLanguages {
+		languageFoundSecurityTests, err := getAllSecurityTestsBasedOnLanguage(languageFound.Language)
+		if err != nil {
+			return
+		}
+		newLanguageSecurityTests = append(newLanguageSecurityTests, languageFoundSecurityTests...)
+	}
+
+	// step 3.3: gather up generics securityTests + languages securityTests
+	allSecurityTests := append(genericSecurityTests, newLanguageSecurityTests...)
+
+	// step 4: update analysis with the all securityTests to be run in this repository
 	analysisQuery := map[string]interface{}{"containers.CID": CID}
 	analysis, err := db.FindOneDBAnalysis(analysisQuery)
 	if err != nil {
 		log.Error("EnryStartAnalysis", "ENRY", 2008, CID, err)
 		return
 	}
-
-	// step 0.2: ERROR_CLONING or nil cOutput states that there were errors cloning a repository.
-	if strings.Contains(cOutput, "ERROR_CLONING") || cOutput == "" {
-		errorOutput := fmt.Sprintf("Container error: %s", cOutput)
-		updateContainerAnalysisQuery := bson.M{
-			"$set": bson.M{
-				"containers.$.cResult": "failed",
-				"containers.$.cInfo":   errorOutput,
-			},
-		}
-		err := db.UpdateOneDBAnalysisContainer(analysisQuery, updateContainerAnalysisQuery)
-		if err != nil {
-			log.Error("EnryStartAnalysis", "ENRY", 2007, err)
-		}
+	analysis.SecurityTests = allSecurityTests
+	analysis.Codes = repositoryLanguages
+	if err := db.UpdateOneDBAnalysis(analysisQuery, analysis); err != nil {
+		log.Error("EnryStartAnalysis", "ENRY", 2007, err)
 		return
 	}
 
-	// step 1: get each language found in cOutput.
-	mapLanguages := make(map[string][]interface{})
-	err = json.Unmarshal([]byte(cOutput), &mapLanguages)
-	if err != nil {
-		log.Error("EnryStartAnalysis", "ENRY", 1003, cOutput, err)
+	// step 5: update enry cInfo and cResult
+	if err := updateInfoAndResultBasedOnCID("Finished successfully.", "passed", CID); err != nil {
 		return
 	}
+
+	// step 6: start all new securityTests.
+	for _, securityTest := range newLanguageSecurityTests {
+		// avoiding a loop here with this if condition.
+		if securityTest.Name != "enry" {
+			go DockerRun(RID, &analysis, securityTest)
+		}
+	}
+}
+
+func getLanguagesFromEnryOutput(cOutput string) ([]types.Code, error) {
+
 	repositoryLanguages := []types.Code{}
 	newLanguage := types.Code{}
+
+	mapLanguages := make(map[string][]interface{})
+	err := json.Unmarshal([]byte(cOutput), &mapLanguages)
+	if err != nil {
+		log.Error("EnryStartAnalysis", "ENRY", 1003, cOutput, err)
+		return repositoryLanguages, err
+	}
+
 	for name, files := range mapLanguages {
 		fs := []string{}
 		for _, f := range files {
 			if reflect.TypeOf(f).String() == "string" {
 				fs = append(fs, f.(string))
 			} else {
-				log.Error("EnryStartAnalysis", "ENRY", 1004, err)
-				return
+				log.Error("getLanguagesFromEnryOutput", "ENRY", 1004, err)
+				return repositoryLanguages, errors.New("error mapping languages")
 			}
 		}
 		newLanguage = types.Code{
@@ -69,52 +109,19 @@ func EnryStartAnalysis(CID string, cOutput string, RID string) {
 		repositoryLanguages = append(repositoryLanguages, newLanguage)
 	}
 
-	// step 2: get all securityTests to be updated into Analysiscollection.
+	return repositoryLanguages, nil
+}
 
-	// step 2.1: querying MongoDB to gather up all securityTests that match (language=Generic and default=true).
-	genericSecurityTestQuery := map[string]interface{}{"language": "Generic", "default": true}
-	genericSecurityTests, err := db.FindAllDBSecurityTest(genericSecurityTestQuery)
+func getAllSecurityTestsBasedOnLanguage(language string) ([]types.SecurityTest, error) {
+
+	securityTests := []types.SecurityTest{}
+	securityTestQuery := map[string]interface{}{"language": language, "default": true}
+
+	securityTests, err := db.FindAllDBSecurityTest(securityTestQuery)
 	if err != nil {
-		log.Error("EnryStartAnalysis", "ENRY", 2009, err)
-		return
+		log.Error("getAllSecurityTestsBasedOnLanguage", "ENRY", 2009, err)
+		return securityTests, err
 	}
 
-	// step 2.2: querying MongoDB to gather up all securityTests that match (language=languageFound and default=true).
-	newLanguageSecurityTests := []types.SecurityTest{}
-	for _, code := range repositoryLanguages {
-		languageSecurityTestQuery := map[string]interface{}{"language": code.Language, "default": true}
-		languageSecurityTestResult, err := db.FindAllDBSecurityTest(languageSecurityTestQuery)
-		if err == nil {
-			newLanguageSecurityTests = append(newLanguageSecurityTests, languageSecurityTestResult...)
-		}
-	}
-
-	allSecurityTests := append(genericSecurityTests, newLanguageSecurityTests...)
-
-	// step 3: update analysis with the all securityTests found.
-	analysis.SecurityTests = allSecurityTests
-	analysis.Codes = repositoryLanguages
-	err = db.UpdateOneDBAnalysis(analysisQuery, analysis)
-	if err != nil {
-		log.Error("EnryStartAnalysis", "ENRY", 2007, err)
-		return
-	}
-
-	updateContainerAnalysisQuery := bson.M{
-		"$set": bson.M{
-			"containers.$.cInfo": "Finished successfully.",
-		},
-	}
-	err = db.UpdateOneDBAnalysisContainer(analysisQuery, updateContainerAnalysisQuery)
-	if err != nil {
-		log.Error("EnryStartAnalysis", "ENRY", 2007, err)
-	}
-
-	// step 4: start all new securityTests.
-	for _, securityTest := range newLanguageSecurityTests {
-		// avoiding a loop here with this if condition.
-		if securityTest.Name != "enry" {
-			go DockerRun(RID, &analysis, securityTest)
-		}
-	}
+	return securityTests, nil
 }

--- a/api/analysis/gosec.go
+++ b/api/analysis/gosec.go
@@ -86,9 +86,9 @@ func GosecCheckOutputFlow(CID string, cOutput string, RID string) {
 }
 
 // prepareHuskyCIGosecResults will prepare Gosec output to be added into goResults struct
-func prepareHuskyCIGosecResults(gosecOutput GosecOutput) types.HuskyCIGosecOutput {
+func prepareHuskyCIGosecResults(gosecOutput GosecOutput) types.HuskyCISecurityTestOutput {
 
-	var huskyCIgosecResults types.HuskyCIGosecOutput
+	var huskyCIgosecResults types.HuskyCISecurityTestOutput
 
 	for _, issue := range gosecOutput.GosecIssues {
 		gosecVuln := types.HuskyCIVulnerability{}
@@ -103,11 +103,11 @@ func prepareHuskyCIGosecResults(gosecOutput GosecOutput) types.HuskyCIGosecOutpu
 
 		switch gosecVuln.Severity {
 		case "LOW":
-			huskyCIgosecResults.LowVulnsGosec = append(huskyCIgosecResults.LowVulnsGosec, gosecVuln)
+			huskyCIgosecResults.LowVulns = append(huskyCIgosecResults.LowVulns, gosecVuln)
 		case "MEDIUM":
-			huskyCIgosecResults.MediumVulnsGosec = append(huskyCIgosecResults.MediumVulnsGosec, gosecVuln)
+			huskyCIgosecResults.MediumVulns = append(huskyCIgosecResults.MediumVulns, gosecVuln)
 		case "HIGH":
-			huskyCIgosecResults.HighVulnsGosec = append(huskyCIgosecResults.HighVulnsGosec, gosecVuln)
+			huskyCIgosecResults.HighVulns = append(huskyCIgosecResults.HighVulns, gosecVuln)
 		}
 	}
 

--- a/api/analysis/gosec.go
+++ b/api/analysis/gosec.go
@@ -46,6 +46,7 @@ func GosecStartAnalysis(CID string, cOutput string, RID string) {
 		if err := updateInfoAndResultBasedOnCID("Error clonning repository", "error", CID); err != nil {
 			return
 		}
+		return
 	}
 
 	// step 2: nil cOutput states that no Issues were found.

--- a/api/analysis/gosec.go
+++ b/api/analysis/gosec.go
@@ -37,8 +37,8 @@ type GosecStats struct {
 	Found int `json:"found"`
 }
 
-// GosecStartAnalysis analyses the output from Gosec and sets a cResult based on it.
-func GosecStartAnalysis(CID string, cOutput string, RID string) {
+// GosecCheckOutputFlow analyses the output from Gosec and sets a cResult based on it.
+func GosecCheckOutputFlow(CID string, cOutput string, RID string) {
 
 	// step 1: check for any errors when clonning repo
 	errorClonning := strings.Contains(cOutput, "ERROR_CLONING")

--- a/api/analysis/npmaudit.go
+++ b/api/analysis/npmaudit.go
@@ -59,6 +59,7 @@ func NpmAuditStartAnalysis(CID string, cOutput string, RID string) {
 		if err := updateInfoAndResultBasedOnCID("Error clonning repository", "error", CID); err != nil {
 			return
 		}
+		return
 	}
 
 	// step 2: check for any errors when running securityTest
@@ -67,8 +68,7 @@ func NpmAuditStartAnalysis(CID string, cOutput string, RID string) {
 			return
 		}
 
-		npmAuditOutput := NpmAuditOutput{}
-		npmAuditOutput.FailedRunning = failedRunning
+		npmAuditOutput := NpmAuditOutput{FailedRunning: failedRunning}
 		if err := updateHuskyCIResultsBasedOnRID(RID, "npmaudit", npmAuditOutput); err != nil {
 			return
 		}

--- a/api/analysis/npmaudit.go
+++ b/api/analysis/npmaudit.go
@@ -8,16 +8,15 @@ import (
 	"encoding/json"
 	"strings"
 
-	"github.com/globocom/huskyCI/api/db"
 	"github.com/globocom/huskyCI/api/log"
 	"github.com/globocom/huskyCI/api/types"
-	"gopkg.in/mgo.v2/bson"
 )
 
 // NpmAuditOutput is the struct that stores all npm audit output
 type NpmAuditOutput struct {
-	Advisories map[string]Vulnerability `json:"advisories"`
-	Metadata   Metadata                 `json:"metadata"`
+	Advisories    map[string]Vulnerability `json:"advisories"`
+	Metadata      Metadata                 `json:"metadata"`
+	FailedRunning bool
 }
 
 // Vulnerability is the granular output of a security info found
@@ -52,60 +51,32 @@ type VulnerabilitiesSummary struct {
 // NpmAuditStartAnalysis analyses the output from Npm Audit and sets a cResult based on it.
 func NpmAuditStartAnalysis(CID string, cOutput string, RID string) {
 
-	var cResult string
-	analysisQuery := map[string]interface{}{"containers.CID": CID}
-
-	// step 0.1: error cloning repository!
-	if strings.Contains(cOutput, "ERROR_CLONING") {
-		updateContainerAnalysisQuery := bson.M{
-			"$set": bson.M{
-				"containers.$.cResult": "error",
-				"containers.$.cInfo":   "Error clonning repository.",
-			},
-		}
-		err := db.UpdateOneDBAnalysisContainer(analysisQuery, updateContainerAnalysisQuery)
-		if err != nil {
-			log.Error("NpmAuditStartAnalysis", "NPMAUDIT", 2007, "Step 0.1 ", err)
-		}
-		return
-	}
-
-	// step 0.2: repository doesn't have package.json
+	errorClonning := strings.Contains(cOutput, "ERROR_CLONING")
 	failedRunning := strings.Contains(cOutput, "ERROR_RUNNING_NPMAUDIT")
+
+	// step 1: check for any errors when clonning repo
+	if errorClonning {
+		if err := updateInfoAndResultBasedOnCID("Error clonning repository", "error", CID); err != nil {
+			return
+		}
+	}
+
+	// step 2: check for any errors when running securityTest
 	if failedRunning {
-		updateContainerAnalysisQuery := bson.M{
-			"$set": bson.M{
-				"containers.$.cResult": "error",
-				"containers.$.cInfo":   "Internal error running NPM Audit.",
-			},
-		}
-		err := db.UpdateOneDBAnalysisContainer(analysisQuery, updateContainerAnalysisQuery)
-		if err != nil {
-			log.Error("NpmAuditStartAnalysis", "NPMAUDIT", 2007, "Step 0.2 ", err)
+		if err := updateInfoAndResultBasedOnCID("Internal error running NPM Audit.", "error", CID); err != nil {
 			return
 		}
 
-		// get updated analysis based on its RID
-		analysisQuery = map[string]interface{}{"RID": RID}
-		analysis, err := db.FindOneDBAnalysis(analysisQuery)
-		if err != nil {
-			log.Error("NpmAuditStartAnalysis", "NPMAUDIT", 2008, CID, err)
-			return
-		}
-
-		// finally, update analysis with huskyCI results
 		npmAuditOutput := NpmAuditOutput{}
-		analysis.HuskyCIResults.JavaScriptResults.HuskyCINpmAuditOutput = prepareHuskyCINpmAuditResults(npmAuditOutput, failedRunning)
-		err = db.UpdateOneDBAnalysis(analysisQuery, analysis)
-		if err != nil {
-			log.Error("NpmAuditStartAnalysis", "NPMAUDIT", 2007, err)
+		npmAuditOutput.FailedRunning = failedRunning
+		if err := updateHuskyCIResultsBasedOnRID(RID, "npmaudit", npmAuditOutput); err != nil {
 			return
 		}
 
 		return
 	}
 
-	// step 1: Unmarshall cOutput into NpmAuditOutput struct.
+	// step 3: Unmarshall cOutput into NpmAuditOutput struct.
 	npmAuditOutput := NpmAuditOutput{}
 	err := json.Unmarshal([]byte(cOutput), &npmAuditOutput)
 	if err != nil {
@@ -113,56 +84,33 @@ func NpmAuditStartAnalysis(CID string, cOutput string, RID string) {
 		return
 	}
 
-	// step 2: find Issues that have severity "moderate" or "high.
-	cResult = "passed"
+	// step 4: find Issues that have severity "moderate" or "high.
+	cResult := "passed"
+	issueMessage := "No issues found."
 	for _, vulnerability := range npmAuditOutput.Advisories {
 		if vulnerability.Severity == "high" || vulnerability.Severity == "moderate" {
 			cResult = "failed"
+			issueMessage = "Issues found."
 			break
 		}
 	}
-
-	// step 3: update analysis' cResult into AnalyisCollection.
-	issueMessage := "No issues found."
-	if cResult == "failed" {
-		issueMessage = "Issues found."
-	}
-	updateContainerAnalysisQuery := bson.M{
-		"$set": bson.M{
-			"containers.$.cResult": cResult,
-			"containers.$.cInfo":   issueMessage,
-		},
-	}
-	err = db.UpdateOneDBAnalysisContainer(analysisQuery, updateContainerAnalysisQuery)
-	if err != nil {
-		log.Error("NpmAuditStartAnalysis", "NPMAUDIT", 2007, "Step 3 ", err)
+	if err := updateInfoAndResultBasedOnCID(issueMessage, cResult, CID); err != nil {
 		return
 	}
 
-	// step 4: get updated analysis based on its RID
-	analysisQuery = map[string]interface{}{"RID": RID}
-	analysis, err := db.FindOneDBAnalysis(analysisQuery)
-	if err != nil {
-		log.Error("NpmAuditStartAnalysis", "NPMAUDIT", 2008, CID, err)
-		return
-	}
-
-	// step 5: finally, update analysis with huskyCI results
-	analysis.HuskyCIResults.JavaScriptResults.HuskyCINpmAuditOutput = prepareHuskyCINpmAuditResults(npmAuditOutput, failedRunning)
-	err = db.UpdateOneDBAnalysis(analysisQuery, analysis)
-	if err != nil {
-		log.Error("NpmAuditStartAnalysis", "NPMAUDIT", 2007, err)
+	// step 6: finally, update analysis with huskyCI results
+	if err := updateHuskyCIResultsBasedOnRID(RID, "npmaudit", npmAuditOutput); err != nil {
 		return
 	}
 
 }
 
 // prepareHuskyCINpmAuditResults will prepare NpmAudit output to be added into JavaScriptResults struct
-func prepareHuskyCINpmAuditResults(npmAuditOutput NpmAuditOutput, failedRunning bool) types.HuskyCINpmAuditOutput {
+func prepareHuskyCINpmAuditResults(npmAuditOutput NpmAuditOutput) types.HuskyCINpmAuditOutput {
 
 	var huskyCInpmAuditResults types.HuskyCINpmAuditOutput
 
-	if failedRunning {
+	if npmAuditOutput.FailedRunning {
 		npmauditVuln := types.HuskyCIVulnerability{}
 		npmauditVuln.Language = "JavaScript"
 		npmauditVuln.SecurityTool = "NpmAudit"

--- a/api/analysis/npmaudit.go
+++ b/api/analysis/npmaudit.go
@@ -48,8 +48,8 @@ type VulnerabilitiesSummary struct {
 	Critical int `json:"critical"`
 }
 
-// NpmAuditStartAnalysis analyses the output from Npm Audit and sets a cResult based on it.
-func NpmAuditStartAnalysis(CID string, cOutput string, RID string) {
+// NpmAuditCheckOutputFlow analyses the output from Npm Audit and sets a cResult based on it.
+func NpmAuditCheckOutputFlow(CID string, cOutput string, RID string) {
 
 	errorClonning := strings.Contains(cOutput, "ERROR_CLONING")
 	failedRunning := strings.Contains(cOutput, "ERROR_RUNNING_NPMAUDIT")

--- a/api/analysis/npmaudit.go
+++ b/api/analysis/npmaudit.go
@@ -106,9 +106,9 @@ func NpmAuditCheckOutputFlow(CID string, cOutput string, RID string) {
 }
 
 // prepareHuskyCINpmAuditResults will prepare NpmAudit output to be added into JavaScriptResults struct
-func prepareHuskyCINpmAuditResults(npmAuditOutput NpmAuditOutput) types.HuskyCINpmAuditOutput {
+func prepareHuskyCINpmAuditResults(npmAuditOutput NpmAuditOutput) types.HuskyCISecurityTestOutput {
 
-	var huskyCInpmAuditResults types.HuskyCINpmAuditOutput
+	var huskyCInpmAuditResults types.HuskyCISecurityTestOutput
 
 	if npmAuditOutput.FailedRunning {
 		npmauditVuln := types.HuskyCIVulnerability{}
@@ -117,7 +117,7 @@ func prepareHuskyCINpmAuditResults(npmAuditOutput NpmAuditOutput) types.HuskyCIN
 		npmauditVuln.Severity = "low"
 		npmauditVuln.Details = "It looks like your project doesn't have package-lock.json. huskyCI was not able to run npm audit properly."
 
-		huskyCInpmAuditResults.LowVulnsNpmAudit = append(huskyCInpmAuditResults.LowVulnsNpmAudit, npmauditVuln)
+		huskyCInpmAuditResults.LowVulns = append(huskyCInpmAuditResults.LowVulns, npmauditVuln)
 
 		return huskyCInpmAuditResults
 	}
@@ -136,19 +136,19 @@ func prepareHuskyCINpmAuditResults(npmAuditOutput NpmAuditOutput) types.HuskyCIN
 		switch issue.Severity {
 		case "info":
 			npmauditVuln.Severity = "low"
-			huskyCInpmAuditResults.LowVulnsNpmAudit = append(huskyCInpmAuditResults.LowVulnsNpmAudit, npmauditVuln)
+			huskyCInpmAuditResults.LowVulns = append(huskyCInpmAuditResults.LowVulns, npmauditVuln)
 		case "low":
 			npmauditVuln.Severity = "low"
-			huskyCInpmAuditResults.LowVulnsNpmAudit = append(huskyCInpmAuditResults.LowVulnsNpmAudit, npmauditVuln)
+			huskyCInpmAuditResults.LowVulns = append(huskyCInpmAuditResults.LowVulns, npmauditVuln)
 		case "moderate":
 			npmauditVuln.Severity = "medium"
-			huskyCInpmAuditResults.MediumVulnsNpmAudit = append(huskyCInpmAuditResults.MediumVulnsNpmAudit, npmauditVuln)
+			huskyCInpmAuditResults.MediumVulns = append(huskyCInpmAuditResults.MediumVulns, npmauditVuln)
 		case "high":
 			npmauditVuln.Severity = "high"
-			huskyCInpmAuditResults.HighVulnsNpmAudit = append(huskyCInpmAuditResults.HighVulnsNpmAudit, npmauditVuln)
+			huskyCInpmAuditResults.HighVulns = append(huskyCInpmAuditResults.HighVulns, npmauditVuln)
 		case "critical":
 			npmauditVuln.Severity = "high"
-			huskyCInpmAuditResults.HighVulnsNpmAudit = append(huskyCInpmAuditResults.HighVulnsNpmAudit, npmauditVuln)
+			huskyCInpmAuditResults.HighVulns = append(huskyCInpmAuditResults.HighVulns, npmauditVuln)
 		}
 
 	}

--- a/api/analysis/retirejs.go
+++ b/api/analysis/retirejs.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/globocom/huskyCI/api/log"
 	"github.com/globocom/huskyCI/api/types"
-	"github.com/globocom/huskyCI/api/util"
 )
 
 //RetirejsOutput is the struct that holds issues, messages and errors found on a Retire scan.
@@ -152,9 +151,29 @@ func prepareHuskyCIRetirejsOutput(retirejsOutput []RetirejsOutput) types.HuskyCI
 		}
 	}
 
-	huskyCIretireJSResultsFinal.LowVulns = util.CountRetireJSOccurrences(huskyCIretireJSResults.LowVulns)
-	huskyCIretireJSResultsFinal.MediumVulns = util.CountRetireJSOccurrences(huskyCIretireJSResults.MediumVulns)
-	huskyCIretireJSResultsFinal.HighVulns = util.CountRetireJSOccurrences(huskyCIretireJSResults.HighVulns)
+	huskyCIretireJSResultsFinal.LowVulns = countRetireJSOccurrences(huskyCIretireJSResults.LowVulns)
+	huskyCIretireJSResultsFinal.MediumVulns = countRetireJSOccurrences(huskyCIretireJSResults.MediumVulns)
+	huskyCIretireJSResultsFinal.HighVulns = countRetireJSOccurrences(huskyCIretireJSResults.HighVulns)
 
 	return huskyCIretireJSResultsFinal
+}
+
+// countRetireJSOccurrences remove duplicates and increment occurrences in each RetireJS vuln found
+func countRetireJSOccurrences(retireJSresults []types.HuskyCIVulnerability) []types.HuskyCIVulnerability {
+
+	var result []types.HuskyCIVulnerability
+	for _, vuln1 := range retireJSresults {
+		exists := false
+		for i, res := range result {
+			if res.Code == vuln1.Code {
+				exists = true
+				result[i].Occurrences++
+			}
+		}
+		if !exists {
+			result = append(result, vuln1)
+			result[len(result)-1].Occurrences++
+		}
+	}
+	return result
 }

--- a/api/analysis/retirejs.go
+++ b/api/analysis/retirejs.go
@@ -49,11 +49,12 @@ func RetirejsStartAnalysis(CID string, cOutput string, RID string) {
 		if err := updateInfoAndResultBasedOnCID("Error clonning repository", "error", CID); err != nil {
 			return
 		}
+		return
 	}
 
 	// step 2: check for any errors when running securityTest
 	if failedRunning {
-		if err := updateInfoAndResultBasedOnCID("Error clonning repository", "error", CID); err != nil {
+		if err := updateInfoAndResultBasedOnCID("Internal error running RetireJS.", "error", CID); err != nil {
 			return
 		}
 

--- a/api/analysis/retirejs.go
+++ b/api/analysis/retirejs.go
@@ -38,8 +38,8 @@ type RetireJSVulnerabilityIdentifiers struct {
 	Summary string
 }
 
-//RetirejsStartAnalysis analyses the output from RetireJS and sets cResult basdes on it.
-func RetirejsStartAnalysis(CID string, cOutput string, RID string) {
+//RetirejsCheckOutputFlow analyses the output from RetireJS and sets cResult basdes on it.
+func RetirejsCheckOutputFlow(CID string, cOutput string, RID string) {
 
 	errorClonning := strings.Contains(cOutput, "ERROR_CLONING")
 	failedRunning := strings.Contains(cOutput, "ERROR_RUNNING_RETIREJS")

--- a/api/analysis/retirejs.go
+++ b/api/analysis/retirejs.go
@@ -108,10 +108,10 @@ func RetirejsCheckOutputFlow(CID string, cOutput string, RID string) {
 }
 
 // prepareHuskyCIRetirejsOutput will prepare Retirejs output to be added into JavaScriptResults struct
-func prepareHuskyCIRetirejsOutput(retirejsOutput []RetirejsOutput) types.HuskyCIRetireJSOutput {
+func prepareHuskyCIRetirejsOutput(retirejsOutput []RetirejsOutput) types.HuskyCISecurityTestOutput {
 
-	var huskyCIretireJSResults types.HuskyCIRetireJSOutput
-	var huskyCIretireJSResultsFinal types.HuskyCIRetireJSOutput
+	var huskyCIretireJSResults types.HuskyCISecurityTestOutput
+	var huskyCIretireJSResultsFinal types.HuskyCISecurityTestOutput
 
 	// failedRunning
 	if retirejsOutput == nil {
@@ -121,7 +121,7 @@ func prepareHuskyCIRetirejsOutput(retirejsOutput []RetirejsOutput) types.HuskyCI
 		retirejsVuln.Severity = "low"
 		retirejsVuln.Details = "It looks like your project doesn't have package.json or yarn.lock. huskyCI was not able to run RetireJS properly."
 
-		huskyCIretireJSResults.LowVulnsNpmRetireJS = append(huskyCIretireJSResults.LowVulnsNpmRetireJS, retirejsVuln)
+		huskyCIretireJSResults.LowVulns = append(huskyCIretireJSResults.LowVulns, retirejsVuln)
 
 		return huskyCIretireJSResults
 	}
@@ -142,19 +142,19 @@ func prepareHuskyCIRetirejsOutput(retirejsOutput []RetirejsOutput) types.HuskyCI
 
 				switch retirejsVuln.Severity {
 				case "low":
-					huskyCIretireJSResults.LowVulnsNpmRetireJS = append(huskyCIretireJSResults.LowVulnsNpmRetireJS, retirejsVuln)
+					huskyCIretireJSResults.LowVulns = append(huskyCIretireJSResults.LowVulns, retirejsVuln)
 				case "medium":
-					huskyCIretireJSResults.MediumVulnsRetireJS = append(huskyCIretireJSResults.MediumVulnsRetireJS, retirejsVuln)
+					huskyCIretireJSResults.MediumVulns = append(huskyCIretireJSResults.MediumVulns, retirejsVuln)
 				case "high":
-					huskyCIretireJSResults.HighVulnsRetireJS = append(huskyCIretireJSResults.HighVulnsRetireJS, retirejsVuln)
+					huskyCIretireJSResults.HighVulns = append(huskyCIretireJSResults.HighVulns, retirejsVuln)
 				}
 			}
 		}
 	}
 
-	huskyCIretireJSResultsFinal.LowVulnsNpmRetireJS = util.CountRetireJSOccurrences(huskyCIretireJSResults.LowVulnsNpmRetireJS)
-	huskyCIretireJSResultsFinal.MediumVulnsRetireJS = util.CountRetireJSOccurrences(huskyCIretireJSResults.MediumVulnsRetireJS)
-	huskyCIretireJSResultsFinal.HighVulnsRetireJS = util.CountRetireJSOccurrences(huskyCIretireJSResults.HighVulnsRetireJS)
+	huskyCIretireJSResultsFinal.LowVulns = util.CountRetireJSOccurrences(huskyCIretireJSResults.LowVulns)
+	huskyCIretireJSResultsFinal.MediumVulns = util.CountRetireJSOccurrences(huskyCIretireJSResults.MediumVulns)
+	huskyCIretireJSResultsFinal.HighVulns = util.CountRetireJSOccurrences(huskyCIretireJSResults.HighVulns)
 
 	return huskyCIretireJSResultsFinal
 }

--- a/api/analysis/safety.go
+++ b/api/analysis/safety.go
@@ -121,9 +121,9 @@ func SafetyCheckOutputFlow(CID string, cOutput string, RID string) {
 }
 
 // prepareHuskyCISafetyResults will prepare Safety output to be added into PythonResults struct
-func prepareHuskyCISafetyResults(safetyOutput SafetyOutput) types.HuskyCISafetyOutput {
+func prepareHuskyCISafetyResults(safetyOutput SafetyOutput) types.HuskyCISecurityTestOutput {
 
-	var huskyCIsafetyResults types.HuskyCISafetyOutput
+	var huskyCIsafetyResults types.HuskyCISecurityTestOutput
 	var onlyWarning bool
 
 	if safetyOutput.ReqNotFound {
@@ -133,7 +133,7 @@ func prepareHuskyCISafetyResults(safetyOutput SafetyOutput) types.HuskyCISafetyO
 		safetyVuln.Severity = "info"
 		safetyVuln.Details = "requirements.txt not found"
 
-		huskyCIsafetyResults.LowVulnsSafety = append(huskyCIsafetyResults.LowVulnsSafety, safetyVuln)
+		huskyCIsafetyResults.LowVulns = append(huskyCIsafetyResults.LowVulns, safetyVuln)
 
 		return huskyCIsafetyResults
 	}
@@ -151,7 +151,7 @@ func prepareHuskyCISafetyResults(safetyOutput SafetyOutput) types.HuskyCISafetyO
 			safetyVuln.Severity = "warning"
 			safetyVuln.Details = util.AdjustWarningMessage(warning)
 
-			huskyCIsafetyResults.LowVulnsSafety = append(huskyCIsafetyResults.LowVulnsSafety, safetyVuln)
+			huskyCIsafetyResults.LowVulns = append(huskyCIsafetyResults.LowVulns, safetyVuln)
 
 		}
 		if onlyWarning {
@@ -168,7 +168,7 @@ func prepareHuskyCISafetyResults(safetyOutput SafetyOutput) types.HuskyCISafetyO
 		safetyVuln.Code = issue.Dependency + " " + issue.Version
 		safetyVuln.VunerableBelow = issue.Below
 
-		huskyCIsafetyResults.HighVulnsSafety = append(huskyCIsafetyResults.HighVulnsSafety, safetyVuln)
+		huskyCIsafetyResults.HighVulns = append(huskyCIsafetyResults.HighVulns, safetyVuln)
 	}
 
 	return huskyCIsafetyResults

--- a/api/analysis/safety.go
+++ b/api/analysis/safety.go
@@ -30,8 +30,8 @@ type SafetyIssue struct {
 	ID         string `json:"id"`
 }
 
-//SafetyStartAnalysis analyses the output from Safety and sets cResult based on it.
-func SafetyStartAnalysis(CID string, cOutput string, RID string) {
+//SafetyCheckOutputFlow analyses the output from Safety and sets cResult based on it.
+func SafetyCheckOutputFlow(CID string, cOutput string, RID string) {
 
 	reqNotFound := strings.Contains(cOutput, "ERROR_REQ_NOT_FOUND")
 	failedRunning := strings.Contains(cOutput, "ERROR_RUNNING_SAFETY")

--- a/api/analysis/safety.go
+++ b/api/analysis/safety.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/globocom/huskyCI/api/db"
 	"github.com/globocom/huskyCI/api/log"
+	"github.com/globocom/huskyCI/api/types"
 	"github.com/globocom/huskyCI/api/util"
 	"gopkg.in/mgo.v2/bson"
 )
@@ -29,13 +30,21 @@ type SafetyIssue struct {
 }
 
 //SafetyStartAnalysis analyses the output from Safety and sets cResult based on it.
-func SafetyStartAnalysis(CID string, cOutput string) {
+func SafetyStartAnalysis(CID string, cOutput string, RID string) {
 
 	var outputJSON string
+	var outputWarnings []string
+
 	analysisQuery := map[string]interface{}{"containers.CID": CID}
 
-	errorSafety := strings.Contains(cOutput, "ERROR_RUNNING_SAFETY")
-	if errorSafety {
+	reqNotFound := strings.Contains(cOutput, "ERROR_REQ_NOT_FOUND")
+	failedRunning := strings.Contains(cOutput, "ERROR_RUNNING_SAFETY")
+	warningFound := strings.Contains(cOutput, "Warning: unpinned requirement ")
+	errorCloning := strings.Contains(cOutput, "ERROR_CLONING")
+
+	safetyOutput := SafetyOutput{}
+
+	if failedRunning {
 		updateContainerAnalysisQuery := bson.M{
 			"$set": bson.M{
 				"containers.$.cResult": "warning", // will not fail CI now
@@ -45,12 +54,17 @@ func SafetyStartAnalysis(CID string, cOutput string) {
 		err := db.UpdateOneDBAnalysisContainer(analysisQuery, updateContainerAnalysisQuery)
 		if err != nil {
 			log.Warning("SafetyStartAnalysis", "SAFETY", 2007, err)
+			return
 		}
+
+		if err := updateSafetyAnalysisWithResults(RID, CID, safetyOutput, failedRunning, reqNotFound, warningFound, outputWarnings); err != nil {
+			return
+		}
+
 		return
 	}
 
-	requirementsNotFound := strings.Contains(cOutput, "ERROR_REQ_NOT_FOUND")
-	if requirementsNotFound {
+	if reqNotFound {
 		updateContainerAnalysisQuery := bson.M{
 			"$set": bson.M{
 				"containers.$.cResult": "warning", // will not fail CI now
@@ -60,11 +74,16 @@ func SafetyStartAnalysis(CID string, cOutput string) {
 		err := db.UpdateOneDBAnalysisContainer(analysisQuery, updateContainerAnalysisQuery)
 		if err != nil {
 			log.Warning("SafetyStartAnalysis", "SAFETY", 2007, err)
+			return
 		}
+
+		if err := updateSafetyAnalysisWithResults(RID, CID, safetyOutput, failedRunning, reqNotFound, warningFound, outputWarnings); err != nil {
+			return
+		}
+
 		return
 	}
 
-	errorCloning := strings.Contains(cOutput, "ERROR_CLONING")
 	if errorCloning {
 		updateContainerAnalysisQuery := bson.M{
 			"$set": bson.M{
@@ -75,19 +94,19 @@ func SafetyStartAnalysis(CID string, cOutput string) {
 		err := db.UpdateOneDBAnalysisContainer(analysisQuery, updateContainerAnalysisQuery)
 		if err != nil {
 			log.Error("SafetyStartAnalysis", "SAFETY", 2007, err)
+			return
 		}
 		return
 	}
 
-	warningFound := strings.Contains(cOutput, "Warning: unpinned requirement ")
 	if warningFound {
 		outputJSON = util.GetLastLine(cOutput)
+		outputWarnings = util.GetAllLinesButLast(cOutput)
 		cOutput = outputJSON
 	}
 
 	cOutputSanitized := util.SanitizeSafetyJSON(cOutput)
 
-	safetyOutput := SafetyOutput{}
 	err := json.Unmarshal([]byte(cOutputSanitized), &safetyOutput)
 	if err != nil {
 		log.Error("SafetyStartAnalysis", "SAFETY", 1018, cOutput, err)
@@ -106,7 +125,13 @@ func SafetyStartAnalysis(CID string, cOutput string) {
 			err := db.UpdateOneDBAnalysisContainer(analysisQuery, updateContainerAnalysisQuery)
 			if err != nil {
 				log.Error("SafetyStartAnalysis", "SAFETY", 2007, err)
+				return
 			}
+
+			if err := updateSafetyAnalysisWithResults(RID, CID, safetyOutput, failedRunning, reqNotFound, warningFound, outputWarnings); err != nil {
+				return
+			}
+
 			return
 		}
 
@@ -120,6 +145,11 @@ func SafetyStartAnalysis(CID string, cOutput string) {
 		if err != nil {
 			log.Error("SafetyStartAnalysis", "SAFETY", 2007, err)
 		}
+
+		if err := updateSafetyAnalysisWithResults(RID, CID, safetyOutput, failedRunning, reqNotFound, warningFound, outputWarnings); err != nil {
+			return
+		}
+
 		return
 	}
 
@@ -134,6 +164,96 @@ func SafetyStartAnalysis(CID string, cOutput string) {
 	if err != nil {
 		log.Error("SafetyStartAnalysis", "SAFETY", 2007, err)
 	}
-	return
 
+	if err := updateSafetyAnalysisWithResults(RID, CID, safetyOutput, failedRunning, reqNotFound, warningFound, outputWarnings); err != nil {
+		return
+	}
+
+}
+
+func updateSafetyAnalysisWithResults(RID, CID string, safetyOutput SafetyOutput, failedRunning, reqNotFound, warningFound bool, outputWarnings []string) error {
+
+	// get updated analysis based on its RID
+	analysisQuery := map[string]interface{}{"RID": RID}
+	analysis, err := db.FindOneDBAnalysis(analysisQuery)
+	if err != nil {
+		log.Error("SafetyStartAnalysis", "SAFETY", 2008, CID, err)
+		return err
+	}
+
+	// update analysis with huskyCI results
+	analysis.HuskyCIResults.PythonResults.HuskyCISafetyOutput = prepareHuskyCISafetyOutput(safetyOutput, failedRunning, reqNotFound, warningFound, outputWarnings)
+	err = db.UpdateOneDBAnalysis(analysisQuery, analysis)
+	if err != nil {
+		log.Error("SafetyStartAnalysis", "SAFETY", 2007, err)
+		return err
+	}
+
+	return nil
+}
+
+// prepareHuskyCISafetyOutput will prepare Safety output to be added into PythonResults struct
+func prepareHuskyCISafetyOutput(safetyOutput SafetyOutput, failedRunning, reqNotFound, warningFound bool, outputWarnings []string) types.HuskyCISafetyOutput {
+
+	var huskyCIsafetyResults types.HuskyCISafetyOutput
+	var onlyWarning bool
+
+	if failedRunning {
+		safetyVuln := types.HuskyCIVulnerability{}
+		safetyVuln.Language = "Python"
+		safetyVuln.SecurityTool = "Safety"
+		safetyVuln.Severity = "info"
+		safetyVuln.Details = "Internal error running Safety."
+
+		huskyCIsafetyResults.LowVulnsSafety = append(huskyCIsafetyResults.LowVulnsSafety, safetyVuln)
+
+		return huskyCIsafetyResults
+	}
+
+	if reqNotFound {
+		safetyVuln := types.HuskyCIVulnerability{}
+		safetyVuln.Language = "Python"
+		safetyVuln.SecurityTool = "Safety"
+		safetyVuln.Severity = "info"
+		safetyVuln.Details = "requirements.txt not found"
+
+		huskyCIsafetyResults.LowVulnsSafety = append(huskyCIsafetyResults.LowVulnsSafety, safetyVuln)
+
+		return huskyCIsafetyResults
+	}
+
+	if warningFound {
+
+		if len(safetyOutput.SafetyIssues) == 0 {
+			onlyWarning = true
+		}
+
+		for _, warning := range outputWarnings {
+			safetyVuln := types.HuskyCIVulnerability{}
+			safetyVuln.Language = "Python"
+			safetyVuln.SecurityTool = "Safety"
+			safetyVuln.Severity = "warning"
+			safetyVuln.Details = util.AdjustWarningMessage(warning)
+
+			huskyCIsafetyResults.LowVulnsSafety = append(huskyCIsafetyResults.LowVulnsSafety, safetyVuln)
+
+		}
+		if onlyWarning {
+			return huskyCIsafetyResults
+		}
+	}
+
+	for _, issue := range safetyOutput.SafetyIssues {
+		safetyVuln := types.HuskyCIVulnerability{}
+		safetyVuln.Language = "Python"
+		safetyVuln.SecurityTool = "Safety"
+		safetyVuln.Severity = "high"
+		safetyVuln.Details = issue.Comment
+		safetyVuln.Code = issue.Dependency + " " + issue.Version
+		safetyVuln.VunerableBelow = issue.Below
+
+		huskyCIsafetyResults.HighVulnsSafety = append(huskyCIsafetyResults.HighVulnsSafety, safetyVuln)
+	}
+
+	return huskyCIsafetyResults
 }

--- a/api/routes/analysis.go
+++ b/api/routes/analysis.go
@@ -51,7 +51,7 @@ func ReceiveRequest(c echo.Context) error {
 	}
 
 	// step-01: Check malicious inputs
-	sanitizedRepoURL, err := util.CheckMaliciousInput(repository, c)
+	sanitizedRepoURL, err := util.CheckValidInput(repository, c)
 	if err != nil {
 		return err
 	}

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -65,6 +65,22 @@ type Code struct {
 	Files    []string `bson:"files" json:"files"`
 }
 
+// HuskyCIVulnerability is the struct that stores vulnerability information.
+type HuskyCIVulnerability struct {
+	Language       string `bson:"language" json:"language,omitempty"`
+	SecurityTool   string `bson:"securitytool" json:"securitytool,omitempty"`
+	Severity       string `bson:"severity,omitempty" json:"severity,omitempty"`
+	Confidence     string `bson:"confidence,omitempty" json:"confidence,omitempty"`
+	File           string `bson:"file,omitempty" json:"file,omitempty"`
+	Line           string `bson:"line,omitempty" json:"line,omitempty"`
+	Code           string `bson:"code,omitempty" json:"code,omitempty"`
+	Details        string `bson:"details" json:"details,omitempty"`
+	Type           string `bson:"type,omitempty" json:"type,omitempty"`
+	VunerableBelow string `bson:"vulnerablebelow,omitempty" json:"vulnerablebelow,omitempty"`
+	Version        string `bson:"version,omitempty" json:"version,omitempty"`
+	Occurrences    int    `bson:"occurrences,omitempty" json:"occurrences,omitempty"`
+}
+
 // HuskyCIResults is a struct that represents huskyCI scan results.
 type HuskyCIResults struct {
 	GoResults         GoResults         `bson:"goresults,omitempty" json:"goresults,omitempty"`
@@ -80,8 +96,8 @@ type GoResults struct {
 
 // PythonResults represents all Python security tests results.
 type PythonResults struct {
-	HuskyCIBanditOutput HuskyCIBanditOutput    `bson:"banditoutput,omitempty" json:"banditoutput,omitempty"`
-	HuskyCISafetyOutput []HuskyCIVulnerability `bson:"safetyoutput,omitempty" json:"safetyoutput,omitempty"`
+	HuskyCIBanditOutput HuskyCIBanditOutput `bson:"banditoutput,omitempty" json:"banditoutput,omitempty"`
+	HuskyCISafetyOutput HuskyCISafetyOutput `bson:"safetyoutput,omitempty" json:"safetyoutput,omitempty"`
 }
 
 // JavaScriptResults represents all JavaScript security tests results.
@@ -109,6 +125,13 @@ type HuskyCIBanditOutput struct {
 	HighVulnsBandit   []HuskyCIVulnerability `bson:"highvulnsbandit,omitempty" json:"highvulnsbandit,omitempty"`
 }
 
+// HuskyCISafetyOutput stores all Low, Medium and High Safety vulnerabilities
+type HuskyCISafetyOutput struct {
+	LowVulnsSafety    []HuskyCIVulnerability `bson:"lowvulnssafety,omitempty" json:"lowvulnssafety,omitempty"`
+	MediumVulnsSafety []HuskyCIVulnerability `bson:"mediumvulnssafety,omitempty" json:"mediumvulnssafety,omitempty"`
+	HighVulnsSafety   []HuskyCIVulnerability `bson:"highvulnssafety,omitempty" json:"highvulnssafety,omitempty"`
+}
+
 // HuskyCIBrakemanOutput stores all Low, Medium and High Brakeman vulnerabilities
 type HuskyCIBrakemanOutput struct {
 	LowVulnsBrakeman    []HuskyCIVulnerability `bson:"lowvulnsbrakeman,omitempty" json:"lowvulnsbrakeman,omitempty"`
@@ -128,20 +151,4 @@ type HuskyCIRetireJSOutput struct {
 	LowVulnsNpmRetireJS []HuskyCIVulnerability `bson:"lowvulnsretireJS,omitempty" json:"lowvulnsretireJS,omitempty"`
 	MediumVulnsRetireJS []HuskyCIVulnerability `bson:"mediumvulnsretireJS,omitempty" json:"mediumvulnsretireJS,omitempty"`
 	HighVulnsRetireJS   []HuskyCIVulnerability `bson:"highvulnsretireJS,omitempty" json:"highvulnsretireJS,omitempty"`
-}
-
-// HuskyCIVulnerability is the struct that stores vulnerability information.
-type HuskyCIVulnerability struct {
-	Language       string `bson:"language" json:"language,omitempty"`
-	SecurityTool   string `bson:"securitytool" json:"securitytool,omitempty"`
-	Severity       string `bson:"severity,omitempty" json:"severity,omitempty"`
-	Confidence     string `bson:"confidence,omitempty" json:"confidence,omitempty"`
-	File           string `bson:"file,omitempty" json:"file,omitempty"`
-	Line           string `bson:"line,omitempty" json:"line,omitempty"`
-	Code           string `bson:"code,omitempty" json:"code,omitempty"`
-	Details        string `bson:"details" json:"details,omitempty"`
-	Type           string `bson:"type,omitempty" json:"type,omitempty"`
-	VunerableBelow string `bson:"vulnerablebelow,omitempty" json:"vulnerablebelow,omitempty"`
-	Version        string `bson:"version,omitempty" json:"version,omitempty"`
-	Occurrences    int    `bson:"occurrences,omitempty" json:"occurrences,omitempty"`
 }

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -44,6 +44,7 @@ type Analysis struct {
 	FinishedAt     time.Time      `bson:"finishedAt" json:"finishedAt"`
 	InternalDepURL string         `bson:"internaldepURL,omitempty" json:"internaldepURL"`
 	Codes          []Code         `bson:"codes" json:"codes"`
+	HuskyCIResults HuskyCIResults `bson:"huskyciresults,omitempty" json:"huskyciresults"`
 }
 
 // Container is the struct that stores all data from a container run.
@@ -51,7 +52,7 @@ type Container struct {
 	CID          string       `bson:"CID" json:"CID"`
 	SecurityTest SecurityTest `bson:"securityTest" json:"securityTest"`
 	CStatus      string       `bson:"cStatus" json:"cStatus"`
-	COuput       string       `bson:"cOutput" json:"cOutput"`
+	COutput      string       `bson:"cOutput" json:"cOutput"`
 	CResult      string       `bson:"cResult" json:"cResult"`
 	CInfo        string       `bson:"cInfo" json:"cInfo"`
 	StartedAt    time.Time    `bson:"startedAt" json:"startedAt"`
@@ -62,4 +63,50 @@ type Container struct {
 type Code struct {
 	Language string   `bson:"language" json:"language"`
 	Files    []string `bson:"files" json:"files"`
+}
+
+// HuskyCIResults is a struct that represents huskyCI scan results.
+type HuskyCIResults struct {
+	GoResults         GoResults         `bson:"goresults,omitempty" json:"goresults,omitempty"`
+	PythonResults     PythonResults     `bson:"pythonresults,omitempty" json:"pythonresults,omitempty"`
+	JavaScriptResults JavaScriptResults `bson:"javascriptresults,omitempty" json:"javascriptresults,omitempty"`
+	RubyResults       RubyResults       `bson:"rubyresults,omitempty" json:"rubyresults,omitempty"`
+}
+
+// GoResults represents all Golang security tests results.
+type GoResults struct {
+	HuskyCIGosecOutput []HuskyCIVulnerability `bson:"gosecoutput,omitempty" json:"gosecoutput,omitempty"`
+}
+
+// PythonResults represents all Python security tests results.
+type PythonResults struct {
+	HuskyCIBanditOutput []HuskyCIVulnerability `bson:"banditoutput,omitempty" json:"banditoutput,omitempty"`
+	HuskyCISafetyOutput []HuskyCIVulnerability `bson:"safetyoutput,omitempty" json:"safetyoutput,omitempty"`
+}
+
+// JavaScriptResults represents all JavaScript security tests results.
+type JavaScriptResults struct {
+	HuskyCIRetirejsResult []HuskyCIVulnerability `bson:"retirejsoutput,omitempty" json:"retirejsoutput,omitempty"`
+	HuskyCINpmAuditResult []HuskyCIVulnerability `bson:"npmauditoutput,omitempty" json:"npmauditoutput,omitempty"`
+}
+
+// RubyResults represents all Ruby security tests results.
+type RubyResults struct {
+	HuskyCIBrakemanOutput []HuskyCIVulnerability `bson:"brakemanoutput,omitempty" json:"brakemanoutput,omitempty"`
+}
+
+// HuskyCIVulnerability is the struct that stores vulnerability information.
+type HuskyCIVulnerability struct {
+	Language       string `bson:"language" json:"language,omitempty"`
+	SecurityTool   string `bson:"securitytool" json:"securitytool,omitempty"`
+	Severity       string `bson:"severity" json:"severity,omitempty"`
+	Confidence     string `bson:"confidence,omitempty" json:"confidence,omitempty"`
+	File           string `bson:"file,omitempty" json:"file,omitempty"`
+	Line           string `bson:"line,omitempty" json:"line,omitempty"`
+	Code           string `bson:"code,omitempty" json:"code,omitempty"`
+	Details        string `bson:"details" json:"details,omitempty"`
+	Type           string `bson:"type,omitempty" json:"type,omitempty"`
+	VunerableBelow string `bson:"vulnerablebelow,omitempty" json:"vulnerablebelow,omitempty"`
+	Version        string `bson:"version,omitempty" json:"version,omitempty"`
+	Occurrences    int    `bson:"occurrences,omitempty" json:"occurrences,omitempty"`
 }

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -92,10 +92,10 @@ type JavaScriptResults struct {
 
 // RubyResults represents all Ruby security tests results.
 type RubyResults struct {
-	HuskyCIBrakemanOutput []HuskyCIVulnerability `bson:"brakemanoutput,omitempty" json:"brakemanoutput,omitempty"`
+	HuskyCIBrakemanOutput HuskyCIBrakemanOutput `bson:"brakemanoutput,omitempty" json:"brakemanoutput,omitempty"`
 }
 
-// HuskyCIGosecOutput stores all Low, Medium and High Bandit vulnerabilities
+// HuskyCIGosecOutput stores all Low, Medium and High Gosec vulnerabilities
 type HuskyCIGosecOutput struct {
 	LowVulnsGosec    []HuskyCIVulnerability `bson:"lowvulnsgosec,omitempty" json:"lowvulnsbandit,omitempty"`
 	MediumVulnsGosec []HuskyCIVulnerability `bson:"mediumvulnsgosec,omitempty" json:"mediumvulnsbandit,omitempty"`
@@ -109,11 +109,18 @@ type HuskyCIBanditOutput struct {
 	HighVulnsBandit   []HuskyCIVulnerability `bson:"highvulnsbandit,omitempty" json:"highvulnsbandit,omitempty"`
 }
 
+// HuskyCIBrakemanOutput stores all Low, Medium and High Brakeman vulnerabilities
+type HuskyCIBrakemanOutput struct {
+	LowVulnsBrakeman    []HuskyCIVulnerability `bson:"lowvulnsbrakeman,omitempty" json:"lowvulnsbrakeman,omitempty"`
+	MediumVulnsBrakeman []HuskyCIVulnerability `bson:"mediumvulnsbrakeman,omitempty" json:"mediumvulnsbrakeman,omitempty"`
+	HighVulnsBrakeman   []HuskyCIVulnerability `bson:"highvulnsbrakeman,omitempty" json:"highvulnsbrakeman,omitempty"`
+}
+
 // HuskyCIVulnerability is the struct that stores vulnerability information.
 type HuskyCIVulnerability struct {
 	Language       string `bson:"language" json:"language,omitempty"`
 	SecurityTool   string `bson:"securitytool" json:"securitytool,omitempty"`
-	Severity       string `bson:"severity" json:"severity,omitempty"`
+	Severity       string `bson:"severity,omitempty" json:"severity,omitempty"`
 	Confidence     string `bson:"confidence,omitempty" json:"confidence,omitempty"`
 	File           string `bson:"file,omitempty" json:"file,omitempty"`
 	Line           string `bson:"line,omitempty" json:"line,omitempty"`

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -91,64 +91,29 @@ type HuskyCIResults struct {
 
 // GoResults represents all Golang security tests results.
 type GoResults struct {
-	HuskyCIGosecOutput HuskyCIGosecOutput `bson:"gosecoutput,omitempty" json:"gosecoutput,omitempty"`
+	HuskyCIGosecOutput HuskyCISecurityTestOutput `bson:"gosecoutput,omitempty" json:"gosecoutput,omitempty"`
 }
 
 // PythonResults represents all Python security tests results.
 type PythonResults struct {
-	HuskyCIBanditOutput HuskyCIBanditOutput `bson:"banditoutput,omitempty" json:"banditoutput,omitempty"`
-	HuskyCISafetyOutput HuskyCISafetyOutput `bson:"safetyoutput,omitempty" json:"safetyoutput,omitempty"`
+	HuskyCIBanditOutput HuskyCISecurityTestOutput `bson:"banditoutput,omitempty" json:"banditoutput,omitempty"`
+	HuskyCISafetyOutput HuskyCISecurityTestOutput `bson:"safetyoutput,omitempty" json:"safetyoutput,omitempty"`
 }
 
 // JavaScriptResults represents all JavaScript security tests results.
 type JavaScriptResults struct {
-	HuskyCIRetireJSOutput HuskyCIRetireJSOutput `bson:"retirejsoutput,omitempty" json:"retirejsoutput,omitempty"`
-	HuskyCINpmAuditOutput HuskyCINpmAuditOutput `bson:"npmauditoutput,omitempty" json:"npmauditoutput,omitempty"`
+	HuskyCIRetireJSOutput HuskyCISecurityTestOutput `bson:"retirejsoutput,omitempty" json:"retirejsoutput,omitempty"`
+	HuskyCINpmAuditOutput HuskyCISecurityTestOutput `bson:"npmauditoutput,omitempty" json:"npmauditoutput,omitempty"`
 }
 
 // RubyResults represents all Ruby security tests results.
 type RubyResults struct {
-	HuskyCIBrakemanOutput HuskyCIBrakemanOutput `bson:"brakemanoutput,omitempty" json:"brakemanoutput,omitempty"`
+	HuskyCIBrakemanOutput HuskyCISecurityTestOutput `bson:"brakemanoutput,omitempty" json:"brakemanoutput,omitempty"`
 }
 
-// HuskyCIGosecOutput stores all Low, Medium and High Gosec vulnerabilities
-type HuskyCIGosecOutput struct {
-	LowVulnsGosec    []HuskyCIVulnerability `bson:"lowvulnsgosec,omitempty" json:"lowvulnsbandit,omitempty"`
-	MediumVulnsGosec []HuskyCIVulnerability `bson:"mediumvulnsgosec,omitempty" json:"mediumvulnsbandit,omitempty"`
-	HighVulnsGosec   []HuskyCIVulnerability `bson:"highvulnsgosec,omitempty" json:"highvulnsbandit,omitempty"`
-}
-
-// HuskyCIBanditOutput stores all Low, Medium and High Bandit vulnerabilities
-type HuskyCIBanditOutput struct {
-	LowVulnsBandit    []HuskyCIVulnerability `bson:"lowvulnsbandit,omitempty" json:"lowvulnsbandit,omitempty"`
-	MediumVulnsBandit []HuskyCIVulnerability `bson:"mediumvulnsbandit,omitempty" json:"mediumvulnsbandit,omitempty"`
-	HighVulnsBandit   []HuskyCIVulnerability `bson:"highvulnsbandit,omitempty" json:"highvulnsbandit,omitempty"`
-}
-
-// HuskyCISafetyOutput stores all Low, Medium and High Safety vulnerabilities
-type HuskyCISafetyOutput struct {
-	LowVulnsSafety    []HuskyCIVulnerability `bson:"lowvulnssafety,omitempty" json:"lowvulnssafety,omitempty"`
-	MediumVulnsSafety []HuskyCIVulnerability `bson:"mediumvulnssafety,omitempty" json:"mediumvulnssafety,omitempty"`
-	HighVulnsSafety   []HuskyCIVulnerability `bson:"highvulnssafety,omitempty" json:"highvulnssafety,omitempty"`
-}
-
-// HuskyCIBrakemanOutput stores all Low, Medium and High Brakeman vulnerabilities
-type HuskyCIBrakemanOutput struct {
-	LowVulnsBrakeman    []HuskyCIVulnerability `bson:"lowvulnsbrakeman,omitempty" json:"lowvulnsbrakeman,omitempty"`
-	MediumVulnsBrakeman []HuskyCIVulnerability `bson:"mediumvulnsbrakeman,omitempty" json:"mediumvulnsbrakeman,omitempty"`
-	HighVulnsBrakeman   []HuskyCIVulnerability `bson:"highvulnsbrakeman,omitempty" json:"highvulnsbrakeman,omitempty"`
-}
-
-// HuskyCINpmAuditOutput stores all Low, Medium and High Npm Audit vulnerabilities
-type HuskyCINpmAuditOutput struct {
-	LowVulnsNpmAudit    []HuskyCIVulnerability `bson:"lowvulnsnpmaudit,omitempty" json:"lowvulnsnpmaudit,omitempty"`
-	MediumVulnsNpmAudit []HuskyCIVulnerability `bson:"mediumvulnsnpmaudit,omitempty" json:"mediumvulnsnpmaudit,omitempty"`
-	HighVulnsNpmAudit   []HuskyCIVulnerability `bson:"highvulnsnpmaudit,omitempty" json:"highvulnsnpmaudit,omitempty"`
-}
-
-// HuskyCIRetireJSOutput stores all Low, Medium and High RetireJS vulnerabilities
-type HuskyCIRetireJSOutput struct {
-	LowVulnsNpmRetireJS []HuskyCIVulnerability `bson:"lowvulnsretireJS,omitempty" json:"lowvulnsretireJS,omitempty"`
-	MediumVulnsRetireJS []HuskyCIVulnerability `bson:"mediumvulnsretireJS,omitempty" json:"mediumvulnsretireJS,omitempty"`
-	HighVulnsRetireJS   []HuskyCIVulnerability `bson:"highvulnsretireJS,omitempty" json:"highvulnsretireJS,omitempty"`
+// HuskyCISecurityTestOutput stores all Low, Medium and High vulnerabilities for a sec test
+type HuskyCISecurityTestOutput struct {
+	LowVulns    []HuskyCIVulnerability `bson:"lowvulns,omitempty" json:"lowvulns,omitempty"`
+	MediumVulns []HuskyCIVulnerability `bson:"mediumvulns,omitempty" json:"mediumvulns,omitempty"`
+	HighVulns   []HuskyCIVulnerability `bson:"highvulns,omitempty" json:"highvulns,omitempty"`
 }

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -87,7 +87,7 @@ type PythonResults struct {
 // JavaScriptResults represents all JavaScript security tests results.
 type JavaScriptResults struct {
 	HuskyCIRetirejsResult []HuskyCIVulnerability `bson:"retirejsoutput,omitempty" json:"retirejsoutput,omitempty"`
-	HuskyCINpmAuditResult []HuskyCIVulnerability `bson:"npmauditoutput,omitempty" json:"npmauditoutput,omitempty"`
+	HuskyCINpmAuditOutput HuskyCINpmAuditOutput  `bson:"npmauditoutput,omitempty" json:"npmauditoutput,omitempty"`
 }
 
 // RubyResults represents all Ruby security tests results.
@@ -114,6 +114,13 @@ type HuskyCIBrakemanOutput struct {
 	LowVulnsBrakeman    []HuskyCIVulnerability `bson:"lowvulnsbrakeman,omitempty" json:"lowvulnsbrakeman,omitempty"`
 	MediumVulnsBrakeman []HuskyCIVulnerability `bson:"mediumvulnsbrakeman,omitempty" json:"mediumvulnsbrakeman,omitempty"`
 	HighVulnsBrakeman   []HuskyCIVulnerability `bson:"highvulnsbrakeman,omitempty" json:"highvulnsbrakeman,omitempty"`
+}
+
+// HuskyCINpmAuditOutput stores all Low, Medium and High Npm Audit vulnerabilities
+type HuskyCINpmAuditOutput struct {
+	LowVulnsNpmAudit    []HuskyCIVulnerability `bson:"lowvulnsnpmaudit,omitempty" json:"lowvulnsnpmaudit,omitempty"`
+	MediumVulnsNpmAudit []HuskyCIVulnerability `bson:"mediumvulnsnpmaudit,omitempty" json:"mediumvulnsnpmaudit,omitempty"`
+	HighVulnsNpmAudit   []HuskyCIVulnerability `bson:"highvulnsnpmaudit,omitempty" json:"highvulnsnpmaudit,omitempty"`
 }
 
 // HuskyCIVulnerability is the struct that stores vulnerability information.

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -86,8 +86,8 @@ type PythonResults struct {
 
 // JavaScriptResults represents all JavaScript security tests results.
 type JavaScriptResults struct {
-	HuskyCIRetirejsResult []HuskyCIVulnerability `bson:"retirejsoutput,omitempty" json:"retirejsoutput,omitempty"`
-	HuskyCINpmAuditOutput HuskyCINpmAuditOutput  `bson:"npmauditoutput,omitempty" json:"npmauditoutput,omitempty"`
+	HuskyCIRetireJSOutput HuskyCIRetireJSOutput `bson:"retirejsoutput,omitempty" json:"retirejsoutput,omitempty"`
+	HuskyCINpmAuditOutput HuskyCINpmAuditOutput `bson:"npmauditoutput,omitempty" json:"npmauditoutput,omitempty"`
 }
 
 // RubyResults represents all Ruby security tests results.
@@ -121,6 +121,13 @@ type HuskyCINpmAuditOutput struct {
 	LowVulnsNpmAudit    []HuskyCIVulnerability `bson:"lowvulnsnpmaudit,omitempty" json:"lowvulnsnpmaudit,omitempty"`
 	MediumVulnsNpmAudit []HuskyCIVulnerability `bson:"mediumvulnsnpmaudit,omitempty" json:"mediumvulnsnpmaudit,omitempty"`
 	HighVulnsNpmAudit   []HuskyCIVulnerability `bson:"highvulnsnpmaudit,omitempty" json:"highvulnsnpmaudit,omitempty"`
+}
+
+// HuskyCIRetireJSOutput stores all Low, Medium and High RetireJS vulnerabilities
+type HuskyCIRetireJSOutput struct {
+	LowVulnsNpmRetireJS []HuskyCIVulnerability `bson:"lowvulnsretireJS,omitempty" json:"lowvulnsretireJS,omitempty"`
+	MediumVulnsRetireJS []HuskyCIVulnerability `bson:"mediumvulnsretireJS,omitempty" json:"mediumvulnsretireJS,omitempty"`
+	HighVulnsRetireJS   []HuskyCIVulnerability `bson:"highvulnsretireJS,omitempty" json:"highvulnsretireJS,omitempty"`
 }
 
 // HuskyCIVulnerability is the struct that stores vulnerability information.

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -75,12 +75,12 @@ type HuskyCIResults struct {
 
 // GoResults represents all Golang security tests results.
 type GoResults struct {
-	HuskyCIGosecOutput []HuskyCIVulnerability `bson:"gosecoutput,omitempty" json:"gosecoutput,omitempty"`
+	HuskyCIGosecOutput HuskyCIGosecOutput `bson:"gosecoutput,omitempty" json:"gosecoutput,omitempty"`
 }
 
 // PythonResults represents all Python security tests results.
 type PythonResults struct {
-	HuskyCIBanditOutput []HuskyCIVulnerability `bson:"banditoutput,omitempty" json:"banditoutput,omitempty"`
+	HuskyCIBanditOutput HuskyCIBanditOutput    `bson:"banditoutput,omitempty" json:"banditoutput,omitempty"`
 	HuskyCISafetyOutput []HuskyCIVulnerability `bson:"safetyoutput,omitempty" json:"safetyoutput,omitempty"`
 }
 
@@ -93,6 +93,20 @@ type JavaScriptResults struct {
 // RubyResults represents all Ruby security tests results.
 type RubyResults struct {
 	HuskyCIBrakemanOutput []HuskyCIVulnerability `bson:"brakemanoutput,omitempty" json:"brakemanoutput,omitempty"`
+}
+
+// HuskyCIGosecOutput stores all Low, Medium and High Bandit vulnerabilities
+type HuskyCIGosecOutput struct {
+	LowVulnsGosec    []HuskyCIVulnerability `bson:"lowvulnsgosec,omitempty" json:"lowvulnsbandit,omitempty"`
+	MediumVulnsGosec []HuskyCIVulnerability `bson:"mediumvulnsgosec,omitempty" json:"mediumvulnsbandit,omitempty"`
+	HighVulnsGosec   []HuskyCIVulnerability `bson:"highvulnsgosec,omitempty" json:"highvulnsbandit,omitempty"`
+}
+
+// HuskyCIBanditOutput stores all Low, Medium and High Bandit vulnerabilities
+type HuskyCIBanditOutput struct {
+	LowVulnsBandit    []HuskyCIVulnerability `bson:"lowvulnsbandit,omitempty" json:"lowvulnsbandit,omitempty"`
+	MediumVulnsBandit []HuskyCIVulnerability `bson:"mediumvulnsbandit,omitempty" json:"mediumvulnsbandit,omitempty"`
+	HighVulnsBandit   []HuskyCIVulnerability `bson:"highvulnsbandit,omitempty" json:"highvulnsbandit,omitempty"`
 }
 
 // HuskyCIVulnerability is the struct that stores vulnerability information.

--- a/api/util/util.go
+++ b/api/util/util.go
@@ -198,3 +198,16 @@ func CountRetireJSOccurrences(retireJSresults []types.HuskyCIVulnerability) []ty
 	}
 	return result
 }
+
+// AdjustWarningMessage returns the Safety Warning string that will be printed.
+func AdjustWarningMessage(warningRaw string) string {
+	warning := strings.Split(warningRaw, ":")
+	if len(warning) > 1 {
+		warning[1] = strings.Replace(warning[1], "safety_huskyci_analysis_requirements_raw.txt", "'requirements.txt'", -1)
+		warning[1] = strings.Replace(warning[1], " unpinned", "Unpinned", -1)
+
+		return (warning[1] + " huskyCI can check it if you pin it in a format such as this: \"mypacket==3.2.9\" :D")
+	}
+
+	return warningRaw
+}

--- a/api/util/util.go
+++ b/api/util/util.go
@@ -179,26 +179,6 @@ func CheckMaliciousRID(RID string, c echo.Context) error {
 	return nil
 }
 
-// CountRetireJSOccurrences remove duplicates and increment occurrences in each RetireJS vuln found
-func CountRetireJSOccurrences(retireJSresults []types.HuskyCIVulnerability) []types.HuskyCIVulnerability {
-
-	var result []types.HuskyCIVulnerability
-	for _, vuln1 := range retireJSresults {
-		exists := false
-		for i, res := range result {
-			if res.Code == vuln1.Code {
-				exists = true
-				result[i].Occurrences++
-			}
-		}
-		if !exists {
-			result = append(result, vuln1)
-			result[len(result)-1].Occurrences++
-		}
-	}
-	return result
-}
-
 // AdjustWarningMessage returns the Safety Warning string that will be printed.
 func AdjustWarningMessage(warningRaw string) string {
 	warning := strings.Split(warningRaw, ":")

--- a/api/util/util.go
+++ b/api/util/util.go
@@ -89,8 +89,8 @@ func RemoveDuplicates(s []string) []string {
 	return s[:i]
 }
 
-// CheckMaliciousInput checks if an user's input is "malicious" or not
-func CheckMaliciousInput(repository types.Repository, c echo.Context) (string, error) {
+// CheckValidInput checks if an user's input is "malicious" or not
+func CheckValidInput(repository types.Repository, c echo.Context) (string, error) {
 
 	sanitiziedURL, err := CheckMaliciousRepoURL(repository.URL, c)
 	if err != nil {

--- a/api/util/util.go
+++ b/api/util/util.go
@@ -178,3 +178,23 @@ func CheckMaliciousRID(RID string, c echo.Context) error {
 	}
 	return nil
 }
+
+// CountRetireJSOccurrences remove duplicates and increment occurrences in each RetireJS vuln found
+func CountRetireJSOccurrences(retireJSresults []types.HuskyCIVulnerability) []types.HuskyCIVulnerability {
+
+	var result []types.HuskyCIVulnerability
+	for _, vuln1 := range retireJSresults {
+		exists := false
+		for i, res := range result {
+			if res.Code == vuln1.Code {
+				exists = true
+				result[i].Occurrences++
+			}
+		}
+		if !exists {
+			result = append(result, vuln1)
+			result[len(result)-1].Occurrences++
+		}
+	}
+	return result
+}

--- a/client/analysis/output.go
+++ b/client/analysis/output.go
@@ -129,15 +129,15 @@ func prepareRetirejsOutput(mongoDBcontainerOutput string, mongoDBcontainerInfo s
 		return
 	}
 
-	if strings.Contains(mongoDBcontainerInfo, "ERROR_RUNNING_RETIREJS") {
+	if strings.Contains(mongoDBcontainerOutput, "ERROR_RUNNING_RETIREJS") {
 		retirejsVuln := types.HuskyCIVulnerability{}
 		retirejsVuln.Language = "JavaScript"
 		retirejsVuln.SecurityTool = "RetireJS"
-		retirejsVuln.Severity = "info"
+		retirejsVuln.Severity = "low"
 		retirejsVuln.Confidence = "high"
 		retirejsVuln.Details = "It looks like your project doesn't have package.json or yarn.lock. huskyCI was not able to run RetireJS properly."
 		tmpRetireJSResults.RetirejsResult = append(tmpRetireJSResults.RetirejsResult, retirejsVuln)
-    types.FoundInfo = true
+		types.FoundInfo = true
 		return
 	}
 
@@ -432,7 +432,7 @@ func printSTDOUTOutput() {
 		if !strings.Contains(issue.Details, "doesn't have package.json") {
 			fmt.Printf("[HUSKYCI][!] Code: %s\n", issue.Code)
 			fmt.Printf("[HUSKYCI][!] Version: %s\n", issue.Version)
-      fmt.Printf("[HUSKYCI][!] Occurrences: %d\n", issue.Occurrences)
+			fmt.Printf("[HUSKYCI][!] Occurrences: %d\n", issue.Occurrences)
 		}
 		fmt.Printf("[HUSKYCI][!] Details: %s\n", issue.Details)
 	}


### PR DESCRIPTION
## Closes #307 

An `Analysis` now stores all vulnerabilities found on a huskyCI scan. Examples:

![image](https://user-images.githubusercontent.com/8943477/61650610-7af74300-ac8a-11e9-8942-d0b0f073f27b.png)


![image](https://user-images.githubusercontent.com/8943477/61650319-ceb55c80-ac89-11e9-9cde-acc0fe1cf5f4.png)


If this PR is merged, we can proceed on refactoring the huskyCI-client to avoid doing all this logic again and just consulting huskyCI MongoDB documents.