### PR TITLE
Fix coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,5 +18,6 @@ jobs:
             make test
             make check-sec
             mv coverage.html /tmp/artifacts
+            $GOPATH/bin/goveralls -coverprofile=c.out -service=circle-ci -repotoken=$COVERALLS_TOKEN
       - store_artifacts:
           path: /tmp/artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,7 @@ jobs:
             make test
             make check-sec
             mv coverage.html /tmp/artifacts
+            echo $COVERALLS_TOKEN
             $GOPATH/bin/goveralls -coverprofile=c.out -service=circle-ci -repotoken=$COVERALLS_TOKEN
       - store_artifacts:
           path: /tmp/artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,14 @@ jobs:
 
     steps:
       - checkout
-      - run: make test
-      - run: make check-sec
-      - run: mkdir -p /tmp/artifacts && mv coverage.html /tmp/artifacts
+      - run:
+          name: "Create a temp directory for artifacts"
+          command: |
+            mkdir -p /tmp/artifacts
+      - run:
+          command: |
+            make test
+            make check-sec
+            mv coverage.html /tmp/artifacts
+      - store_artifacts:
+          path: /tmp/artifacts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,6 @@ jobs:
             make test
             make check-sec
             mv coverage.html /tmp/artifacts
-            echo $COVERALLS_TOKEN
             $GOPATH/bin/goveralls -coverprofile=c.out -service=circle-ci -repotoken=$COVERALLS_TOKEN
       - store_artifacts:
           path: /tmp/artifacts

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ GODEP ?= $(GOBIN)/dep
 GOLINT ?= $(GOBIN)/golint
 GOSEC ?= $(GOBIN)/gosec
 GINKGO ?= $(GOBIN)/ginkgo
+GOVERALLS ?= $(GOBIN)/goveralls
 
 HUSKYCIBIN ?= huskyci
 HUSKYCICLIENTBIN ?= huskyci-client
@@ -72,6 +73,7 @@ get-test-deps:
 	$(GO) get -u golang.org/x/lint/golint
 	$(GO) get -u github.com/onsi/ginkgo/ginkgo
 	$(GO) get -u github.com/onsi/gomega/...
+	$(GO) get -u github.com/mattn/goveralls
 
 ## Prints help message
 help:
@@ -131,6 +133,7 @@ ginkgo:
 coverage:
 	$(GO) test ./... -coverprofile=c.out
 	$(GO) tool cover -html=c.out -o coverage.html
+	$(GOVERALLS) -coverprofile=c.out -service=circle-ci -repotoken=\$COVERALLS_TOKEN
 	
 ## Perfoms all make tests
 test: get-test-deps lint ginkgo coverage

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ GODEP ?= $(GOBIN)/dep
 GOLINT ?= $(GOBIN)/golint
 GOSEC ?= $(GOBIN)/gosec
 GINKGO ?= $(GOBIN)/ginkgo
-GOVERALLS ?= $(GOBIN)/goveralls
 
 HUSKYCIBIN ?= huskyci
 HUSKYCICLIENTBIN ?= huskyci-client
@@ -133,7 +132,6 @@ ginkgo:
 coverage:
 	$(GO) test ./... -coverprofile=c.out
 	$(GO) tool cover -html=c.out -o coverage.html
-	$(GOVERALLS) -coverprofile=c.out -service=circle-ci -repotoken=\$COVERALLS_TOKEN
 	
 ## Perfoms all make tests
 test: get-test-deps lint ginkgo coverage

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <img src="https://raw.githubusercontent.com/wiki/globocom/huskyCI/images/huskyCI-logo.png" align="center" height="" />
 <!-- logo font: Anton -->
 
-[![CircleCI](https://circleci.com/gh/globocom/huskyCI/tree/master.svg?style=svg&circle-token=415bfb6b5aa0dfce8d2129878a66326da9533150)](https://circleci.com/gh/globocom/huskyCI/tree/master) [![Join the chat at https://gitter.im/globocom/huskyCI](https://badges.gitter.im/globocom/huskyCI.svg)](https://gitter.im/globocom/huskyCI?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Coverage Status](https://coveralls.io/repos/github/globocom/huskyCI/badge.svg?branch=master)](https://coveralls.io/github/globocom/huskyCI?branch=master) [![CircleCI](https://circleci.com/gh/globocom/huskyCI/tree/master.svg?style=svg&circle-token=415bfb6b5aa0dfce8d2129878a66326da9533150)](https://circleci.com/gh/globocom/huskyCI/tree/master) [![Join the chat at https://gitter.im/globocom/huskyCI](https://badges.gitter.im/globocom/huskyCI.svg)](https://gitter.im/globocom/huskyCI?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 huskyCI is an open source tool that performs security tests inside CI pipelines of multiple projects and centralizes all results into a database for further analysis and metrics.
 


### PR DESCRIPTION
This P.R. integrates CircleCI's environment with `coveralls` for tracking test coverage  and indicates its actual coverage percentage in the README with the inserted `coveralls` badge.