### PR TITLE
[FIX] Define dockerd initialization to avoid flag collisions with daemon.json

### DIFF
--- a/deployments/docker-compose.yml
+++ b/deployments/docker-compose.yml
@@ -5,8 +5,9 @@ services:
         privileged: true
         image: docker:stable-dind
         container_name: huskyCI_Docker_API
+        command: "dockerd --host=unix:///var/run/docker.sock --host=tcp://0.0.0.0:2376"
         ports:
-          - "2375:2375"
+          - "2376:2376"
         volumes:
             - docker_vol:/var/lib/docker
             - ../deployments/daemon.json:/etc/docker/daemon.json:ro
@@ -29,7 +30,7 @@ services:
             HUSKYCI_DOCKERAPI_CERT_PATH: /go/src/github.com/globocom/huskyCI/
             HUSKYCI_DOCKERAPI_TLS_VERIFY: 1
             # optional envs
-            HUSKYCI_DOCKERAPI_PORT: 2375
+            HUSKYCI_DOCKERAPI_PORT: 2376
             HUSKYCI_LOGGING_GRAYLOG_APP_NAME: huskyCI   
         build:
             context: ../


### PR DESCRIPTION
Current stable-dind version defines TLS flags on daemon initialization. This P.R. fixes the collision of TLS configuration with daemon.json. So, it will define how the daemon will be initialized in `docker-compose.yml` file and daemon file will define TLS flags without any redundant configuration.