### PR TITLE
Set retireJS as a not default securityTest

### DIFF
--- a/api/config.yaml
+++ b/api/config.yaml
@@ -135,7 +135,7 @@ retirejs:
       cat /tmp/errorGitCloneRetirejs
     fi
   language: JavaScript
-  default: true
+  default: false
   timeOutInSeconds: 360
 
 safety:


### PR DESCRIPTION
This PR will set retireJS as not a required securityTest to be run in JavaScript projects.

Currently, we are having some instability in using it and `npm audit` is much faster and more stable.