### PR TITLE
Test context package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ Godeps/_workspace
 .GOPATH
 #vendor
 coverage.txt
+c.out
+coverage.html
 *.pem
 .env
 .vagrant

--- a/api/analysis/dockerrun.go
+++ b/api/analysis/dockerrun.go
@@ -263,7 +263,11 @@ func dockerPullImage(d *docker.Docker, image string) error {
 }
 
 func updateAndCheckContainerList(d *docker.Docker) error {
-	configAPI := context.GetAPIConfig()
+	configAPI, err := context.DefaultConf.GetAPIConfig()
+	if err != nil {
+		log.Error("updateAndCheckContainerList", "DOCKERRUN", 3026, err)
+		return err
+	}
 	maxContainersAllowed := configAPI.DockerHostsConfig.MaxContainersAllowed
 	listedContainers++
 	if listedContainers >= maxContainersAllowed {

--- a/api/auth/pbkdf2caller.go
+++ b/api/auth/pbkdf2caller.go
@@ -17,35 +17,42 @@ import (
 	"golang.org/x/crypto/pbkdf2"
 )
 
+// GetCredsFromDB returns an user info given an username.
 func (pC *Pbkdf2Caller) GetCredsFromDB(username string) (types.User, error) {
 	searchParam := map[string]interface{}{"username": username}
 	return db.FindOneDBUser(searchParam)
 }
 
+// DecodeSaltValue decodes a salt and returns a string and an error.
 func (pC *Pbkdf2Caller) DecodeSaltValue(salt string) ([]byte, error) {
 	return base64.StdEncoding.DecodeString(salt)
 }
 
+// GenHashValue returns the hash value given all pbkdf2 parameters.
 func (pC *Pbkdf2Caller) GenHashValue(value, salt []byte, iter, keyLen int, h hash.Hash) string {
 	return base64.StdEncoding.EncodeToString(pbkdf2.Key(value, salt, iter, keyLen, func() hash.Hash {
 		return h
 	}))
 }
 
+// GenerateSalt returns a random salt and en error.
 func (pC *Pbkdf2Caller) GenerateSalt() (string, error) {
 	salt := make([]byte, 64)
 	_, err := io.ReadFull(rand.Reader, salt)
 	return base64.StdEncoding.EncodeToString(salt), err
 }
 
+// GetHashName returns the default hash name that is stored in an env var.
 func (pC *Pbkdf2Caller) GetHashName() string {
 	return os.Getenv("HUSKYCI_API_DEFAULT_HASH_FUNCTION")
 }
 
+// GetIterations returns the default number of iteration that is stored in an env var.
 func (pC *Pbkdf2Caller) GetIterations() (int, error) {
 	return strconv.Atoi(os.Getenv("HUSKYCI_API_DEFAULT_ITERATIONS"))
 }
 
+// GetKeyLength returns the default key lenght that is stored in an env var.
 func (pC *Pbkdf2Caller) GetKeyLength() (int, error) {
 	return strconv.Atoi(os.Getenv("HUSKYCI_API_DEFAULT_KEY_LENGTH"))
 }

--- a/api/auth/types.go
+++ b/api/auth/types.go
@@ -10,11 +10,13 @@ import (
 	"github.com/globocom/huskyCI/api/types"
 )
 
+// UserCredsHandler is the User handler used in auth.
 type UserCredsHandler interface {
 	GetPassFromDB(username string) (string, error)
 	GetHashedPass(password string) (string, error)
 }
 
+// Pbkdf2Generator is the interface that stores all pbkdf2 functions.
 type Pbkdf2Generator interface {
 	GetCredsFromDB(username string) (types.User, error)
 	DecodeSaltValue(salt string) ([]byte, error)
@@ -25,12 +27,15 @@ type Pbkdf2Generator interface {
 	GetKeyLength() (int, error)
 }
 
+// Pbkdf2Caller is the pbkdf2 caller struct.
 type Pbkdf2Caller struct{}
 
+// MongoBasic is the struct that stores the client handler
 type MongoBasic struct {
 	ClientHandler UserCredsHandler
 }
 
+//ClientPbkdf2 is the struct that stores all information regarding a the pbkdf2 client.
 type ClientPbkdf2 struct {
 	HashGen      Pbkdf2Generator
 	Salt         string

--- a/api/context/context.go
+++ b/api/context/context.go
@@ -71,45 +71,89 @@ type APIConfig struct {
 	SafetySecurityTest   *types.SecurityTest
 }
 
+type ExternalCalls struct{}
+
+func (eC *ExternalCalls) SetConfigFile(configName, configPath string) error {
+	viper.SetConfigFile(configName)
+	viper.AddConfigPath(configPath)
+	return viper.ReadInConfig()
+}
+
+func (eC *ExternalCalls) GetEnvironmentVariable(envName string) string {
+	return os.Getenv(envName)
+}
+
+func (eC *ExternalCalls) ConvertStrToInt(str string) (int, error) {
+	return strconv.Atoi(str)
+}
+
+func (eC *ExternalCalls) GetTimeDurationInSeconds(duration int) time.Duration {
+	return time.Duration(duration) * time.Second
+}
+
+func (eC *ExternalCalls) GetStringFromConfigFile(value string) string {
+	return viper.GetString(value)
+}
+
+func (eC *ExternalCalls) GetBoolFromConfigFile(value string) bool {
+	return viper.GetBool(value)
+}
+
+func (eC *ExternalCalls) GetIntFromConfigFile(value string) int {
+	return viper.GetInt(value)
+}
+
+type CallerInterface interface {
+	SetConfigFile(configName, configPath string) error
+	GetStringFromConfigFile(value string) string
+	GetBoolFromConfigFile(value string) bool
+	GetIntFromConfigFile(value string) int
+	GetEnvironmentVariable(envName string) string
+	ConvertStrToInt(str string) (int, error)
+	GetTimeDurationInSeconds(duration int) time.Duration
+}
+
+type DefaultConfig struct {
+	Caller CallerInterface
+}
+
 // GetAPIConfig returns the instance of an APIConfig.
-func GetAPIConfig() *APIConfig {
+func (dF DefaultConfig) GetAPIConfig() (*APIConfig, error) {
 
 	// load Viper using api/config.yml
-	viper.SetConfigName("config")
-	viper.AddConfigPath("api/")
-	if err := viper.ReadInConfig(); err != nil {
+	if err := dF.Caller.SetConfigFile("config", "api/"); err != nil {
 		fmt.Println("Error reading Viper config: ", err)
-		os.Exit(1)
+		return nil, err
 	}
 	SetOnceConfig()
 	return APIConfiguration
 }
 
 // SetOnceConfig sets APIConfiguration once
-func SetOnceConfig() {
+func (dF DefaultConfig) SetOnceConfig() {
 	onceConfig.Do(func() {
 		APIConfiguration = &APIConfig{
-			Port:                 getAPIPort(),
-			Version:              GetAPIVersion(),
-			ReleaseDate:          GetAPIReleaseDate(),
-			UseTLS:               getAPIUseTLS(),
-			GitPrivateSSHKey:     getGitPrivateSSHKey(),
-			GraylogConfig:        getGraylogConfig(),
-			MongoDBConfig:        getMongoConfig(),
-			DockerHostsConfig:    getDockerHostsConfig(),
-			EnrySecurityTest:     getSecurityTestConfig("enry"),
-			GosecSecurityTest:    getSecurityTestConfig("gosec"),
-			BanditSecurityTest:   getSecurityTestConfig("bandit"),
-			BrakemanSecurityTest: getSecurityTestConfig("brakeman"),
-			RetirejsSecurityTest: getSecurityTestConfig("retirejs"),
-			NpmAuditSecurityTest: getSecurityTestConfig("npmaudit"),
-			SafetySecurityTest:   getSecurityTestConfig("safety"),
+			Port:                 dF.GetAPIPort(),
+			Version:              dF.GetAPIVersion(),
+			ReleaseDate:          dF.GetAPIReleaseDate(),
+			UseTLS:               dF.GetAPIUseTLS(),
+			GitPrivateSSHKey:     dF.getGitPrivateSSHKey(),
+			GraylogConfig:        dF.getGraylogConfig(),
+			MongoDBConfig:        dF.getMongoConfig(),
+			DockerHostsConfig:    dF.getDockerHostsConfig(),
+			EnrySecurityTest:     dF.getSecurityTestConfig("enry"),
+			GosecSecurityTest:    dF.getSecurityTestConfig("gosec"),
+			BanditSecurityTest:   dF.getSecurityTestConfig("bandit"),
+			BrakemanSecurityTest: dF.getSecurityTestConfig("brakeman"),
+			RetirejsSecurityTest: dF.getSecurityTestConfig("retirejs"),
+			NpmAuditSecurityTest: dF.getSecurityTestConfig("npmaudit"),
+			SafetySecurityTest:   dF.getSecurityTestConfig("safety"),
 		}
 	})
 }
 
-func getAPIPort() int {
-	apiPort, err := strconv.Atoi(os.Getenv("HUSKYCI_API_PORT"))
+func (dF DefaultConfig) GetAPIPort() int {
+	apiPort, err := dF.Caller.ConvertStrToInt(dF.Caller.GetEnvironmentVariable("HUSKYCI_API_PORT"))
 	if err != nil {
 		apiPort = 8888
 	}
@@ -117,91 +161,91 @@ func getAPIPort() int {
 }
 
 // GetAPIVersion returns current API version
-func GetAPIVersion() string {
+func (dF DefaultConfig) GetAPIVersion() string {
 	return "0.6.0"
 }
 
 // GetAPIReleaseDate returns current API release date
-func GetAPIReleaseDate() string {
+func (dF DefaultConfig) GetAPIReleaseDate() string {
 	return "2019-07-18"
 }
 
-func getAPIUseTLS() bool {
-	option := os.Getenv("HUSKYCI_API_ENABLE_HTTPS")
+func (dF DefaultConfig) GetAPIUseTLS() bool {
+	option := dF.Caller.GetEnvironmentVariable("HUSKYCI_API_ENABLE_HTTPS")
 	if option == "true" || option == "1" || option == "TRUE" {
 		return true
 	}
 	return false
 }
 
-func getGitPrivateSSHKey() string {
-	return os.Getenv("HUSKYCI_API_GIT_PRIVATE_SSH_KEY")
+func (dF DefaultConfig) getGitPrivateSSHKey() string {
+	return dF.Caller.GetEnvironmentVariable("HUSKYCI_API_GIT_PRIVATE_SSH_KEY")
 }
 
-func getGraylogConfig() *GraylogConfig {
+func (dF DefaultConfig) getGraylogConfig() *GraylogConfig {
 	return &GraylogConfig{
-		Address:        os.Getenv("HUSKYCI_LOGGING_GRAYLOG_ADDR"),
-		Protocol:       os.Getenv("HUSKYCI_LOGGING_GRAYLOG_PROTO"),
-		AppName:        os.Getenv("HUSKYCI_LOGGING_GRAYLOG_APP_NAME"),
-		Tag:            os.Getenv("HUSKYCI_LOGGING_GRAYLOG_TAG"),
-		DevelopmentEnv: getGraylogIsDev(),
+		Address:        dF.Caller.GetEnvironmentVariable("HUSKYCI_LOGGING_GRAYLOG_ADDR"),
+		Protocol:       dF.Caller.GetEnvironmentVariable("HUSKYCI_LOGGING_GRAYLOG_PROTO"),
+		AppName:        dF.Caller.GetEnvironmentVariable("HUSKYCI_LOGGING_GRAYLOG_APP_NAME"),
+		Tag:            dF.Caller.GetEnvironmentVariable("HUSKYCI_LOGGING_GRAYLOG_TAG"),
+		DevelopmentEnv: GetGraylogIsDev(),
 	}
 }
 
-func getGraylogIsDev() bool {
-	option := os.Getenv("HUSKYCI_LOGGING_GRAYLOG_DEV")
+func (dF DefaultConfig) GetGraylogIsDev() bool {
+	option := dF.Caller.GetEnvironmentVariable("HUSKYCI_LOGGING_GRAYLOG_DEV")
 	if option == "false" || option == "0" || option == "FALSE" {
 		return false
 	}
 	return true
 }
 
-func getMongoConfig() *MongoConfig {
-	mongoHost := os.Getenv("HUSKYCI_DATABASE_MONGO_ADDR")
-	mongoPort := getMongoPort()
+func (dF DefaultConfig) getMongoConfig() *MongoConfig {
+	mongoHost := dF.Caller.GetEnvironmentVariable("HUSKYCI_DATABASE_MONGO_ADDR")
+	mongoPort := GetMongoPort()
 	mongoAddress := fmt.Sprintf("%s:%d", mongoHost, mongoPort)
 	return &MongoConfig{
 		Address:      mongoAddress,
-		DatabaseName: os.Getenv("HUSKYCI_DATABASE_MONGO_DBNAME"),
-		Username:     os.Getenv("HUSKYCI_DATABASE_MONGO_DBUSERNAME"),
-		Password:     os.Getenv("HUSKYCI_DATABASE_MONGO_DBPASSWORD"),
+		DatabaseName: dF.Caller.GetEnvironmentVariable("HUSKYCI_DATABASE_MONGO_DBNAME"),
+		Username:     dF.Caller.GetEnvironmentVariable("HUSKYCI_DATABASE_MONGO_DBUSERNAME"),
+		Password:     dF.Caller.GetEnvironmentVariable("HUSKYCI_DATABASE_MONGO_DBPASSWORD"),
 		Port:         mongoPort,
-		Timeout:      getMongoTimeout(),
-		PoolLimit:    getMongoPoolLimit(),
+		Timeout:      GetMongoTimeout(),
+		PoolLimit:    GetMongoPoolLimit(),
 	}
 }
 
-func getMongoPort() int {
-	mongoPort, err := strconv.Atoi(os.Getenv("HUSKYCI_DATABASE_MONGO_PORT"))
+func (dF DefaultConfig) GetMongoPort() int {
+	mongoPort, err := dF.Caller.ConvertStrToInt(dF.Caller.GetEnvironmentVariable("HUSKYCI_DATABASE_MONGO_PORT"))
 	if err != nil {
 		return 27017
 	}
 	return mongoPort
 }
 
-func getMongoTimeout() time.Duration {
-	mongoTimeout, err := strconv.Atoi(os.Getenv("HUSKYCI_DATABASE_MONGO_TIMEOUT"))
+func (dF DefaultConfig) GetMongoTimeout() time.Duration {
+	mongoTimeout, err := dF.Caller.ConvertStrToInt(dF.Caller.GetEnvironmentVariable("HUSKYCI_DATABASE_MONGO_TIMEOUT"))
 	if err != nil {
-		return time.Duration(60) * time.Second
+		return dF.Caller.GetTimeDurationInSeconds(60)
 	}
-	return time.Duration(mongoTimeout) * time.Second
+	return dF.Caller.GetTimeDurationInSeconds(mongoTimeout)
 }
 
-func getMongoPoolLimit() int {
-	mongoPoolLimit, err := strconv.Atoi(os.Getenv("HUSKYCI_DATABASE_MONGO_POOL_LIMIT"))
+func (dF DefaultConfig) GetMongoPoolLimit() int {
+	mongoPoolLimit, err := dF.Caller.ConvertStrToInt(dF.Caller.GetEnvironmentVariable("HUSKYCI_DATABASE_MONGO_POOL_LIMIT"))
 	if err != nil && mongoPoolLimit <= 0 {
 		return 1000
 	}
 	return mongoPoolLimit
 }
 
-func getDockerHostsConfig() *DockerHostsConfig {
-	dockerAPIPort := getDockerAPIPort()
-	dockerHostsAddressesEnv := os.Getenv("HUSKYCI_DOCKERAPI_ADDR")
+func (dF DefaultConfig) getDockerHostsConfig() *DockerHostsConfig {
+	dockerAPIPort := GetDockerAPIPort()
+	dockerHostsAddressesEnv := dF.Caller.GetEnvironmentVariable("HUSKYCI_DOCKERAPI_ADDR")
 	dockerHostsAddresses := strings.Split(dockerHostsAddressesEnv, " ")
-	dockerHostsCertificate := os.Getenv("HUSKYCI_DOCKERAPI_CERT_FILE")
-	dockerHostsPathCertificates := os.Getenv("HUSKYCI_DOCKERAPI_CERT_PATH")
-	dockerHostsKey := os.Getenv("HUSKYCI_DOCKERAPI_CERT_KEY")
+	dockerHostsCertificate := dF.Caller.GetEnvironmentVariable("HUSKYCI_DOCKERAPI_CERT_FILE")
+	dockerHostsPathCertificates := dF.Caller.GetEnvironmentVariable("HUSKYCI_DOCKERAPI_CERT_PATH")
+	dockerHostsKey := dF.Caller.GetEnvironmentVariable("HUSKYCI_DOCKERAPI_CERT_KEY")
 	return &DockerHostsConfig{
 		Address:              dockerHostsAddresses[0],
 		DockerAPIPort:        dockerAPIPort,
@@ -209,40 +253,40 @@ func getDockerHostsConfig() *DockerHostsConfig {
 		PathCertificate:      dockerHostsPathCertificates,
 		Key:                  dockerHostsKey,
 		Host:                 fmt.Sprintf("%s:%d", dockerHostsAddresses[0], dockerAPIPort),
-		TLSVerify:            getDockerAPITLSVerify(),
-		MaxContainersAllowed: getMaxContainersAllowed(),
+		TLSVerify:            GetDockerAPITLSVerify(),
+		MaxContainersAllowed: GetMaxContainersAllowed(),
 	}
 }
 
-func getDockerAPIPort() int {
-	dockerAPIport, err := strconv.Atoi(os.Getenv("HUSKYCI_DOCKERAPI_PORT"))
+func (dF DefaultConfig) GetDockerAPIPort() int {
+	dockerAPIport, err := dF.Caller.ConvertStrToInt(dF.Caller.GetEnvironmentVariable("HUSKYCI_DOCKERAPI_PORT"))
 	if err != nil {
 		return 2376
 	}
 	return dockerAPIport
 }
 
-func getDockerAPITLSVerify() int {
-	option := os.Getenv("HUSKYCI_DOCKERAPI_TLS_VERIFY")
+func (dF DefaultConfig) GetDockerAPITLSVerify() int {
+	option := dF.Caller.GetEnvironmentVariable("HUSKYCI_DOCKERAPI_TLS_VERIFY")
 	if option == "false" || option == "0" || option == "FALSE" {
 		return 0
 	}
 	return 1
 }
 
-func getSecurityTestConfig(securityTestName string) *types.SecurityTest {
+func (dF DefaultConfig) getSecurityTestConfig(securityTestName string) *types.SecurityTest {
 	return &types.SecurityTest{
-		Name:             viper.GetString(fmt.Sprintf("%s.name", securityTestName)),
-		Image:            viper.GetString(fmt.Sprintf("%s.image", securityTestName)),
-		Cmd:              viper.GetString(fmt.Sprintf("%s.cmd", securityTestName)),
-		Language:         viper.GetString(fmt.Sprintf("%s.language", securityTestName)),
-		Default:          viper.GetBool(fmt.Sprintf("%s.default", securityTestName)),
-		TimeOutInSeconds: viper.GetInt(fmt.Sprintf("%s.timeOutInSeconds", securityTestName)),
+		Name:             dF.Caller.GetStringFromConfigFile(fmt.Sprintf("%s.name", securityTestName)),
+		Image:            dF.Caller.GetStringFromConfigFile(fmt.Sprintf("%s.image", securityTestName)),
+		Cmd:              dF.Caller.GetStringFromConfigFile(fmt.Sprintf("%s.cmd", securityTestName)),
+		Language:         dF.Caller.GetStringFromConfigFile(fmt.Sprintf("%s.language", securityTestName)),
+		Default:          dF.Caller.GetBoolFromConfigFile(fmt.Sprintf("%s.default", securityTestName)),
+		TimeOutInSeconds: dF.Caller.GetIntFromConfigFile(fmt.Sprintf("%s.timeOutInSeconds", securityTestName)),
 	}
 }
 
-func getMaxContainersAllowed() int {
-	maxContainersAllowed, err := strconv.Atoi(os.Getenv("HUSKYCI_DOCKERAPI_MAX_CONTAINERS_BEFORE_CLEANING"))
+func (dF DefaultConfig) GetMaxContainersAllowed() int {
+	maxContainersAllowed, err := dF.Caller.ConvertStrToInt(dF.Caller.GetEnvironmentVariable("HUSKYCI_DOCKERAPI_MAX_CONTAINERS_BEFORE_CLEANING"))
 	if err != nil {
 		return 50
 	}

--- a/api/context/context.go
+++ b/api/context/context.go
@@ -14,8 +14,17 @@ import (
 )
 
 // APIConfiguration holds all API configuration.
-var APIConfiguration *APIConfig
-var onceConfig sync.Once
+var (
+	APIConfiguration *APIConfig
+	onceConfig       sync.Once
+	DefaultConf      *DefaultConfig
+)
+
+func init() {
+	DefaultConf = &DefaultConfig{
+		Caller: &ExternalCalls{},
+	}
+}
 
 // MongoConfig represents MongoDB configuration.
 type MongoConfig struct {

--- a/api/context/context.go
+++ b/api/context/context.go
@@ -77,6 +77,7 @@ type APIConfig struct {
 	SafetySecurityTest   *types.SecurityTest
 }
 
+// DefaultConfig is the struct that stores the caller for testing.
 type DefaultConfig struct {
 	Caller CallerInterface
 }

--- a/api/context/context.go
+++ b/api/context/context.go
@@ -98,8 +98,8 @@ func (dF DefaultConfig) SetOnceConfig() {
 	onceConfig.Do(func() {
 		APIConfiguration = &APIConfig{
 			Port:                 dF.GetAPIPort(),
-			Version:              dF.getAPIVersion(),
-			ReleaseDate:          dF.getAPIReleaseDate(),
+			Version:              dF.GetAPIVersion(),
+			ReleaseDate:          dF.GetAPIReleaseDate(),
 			UseTLS:               dF.GetAPIUseTLS(),
 			GitPrivateSSHKey:     dF.getGitPrivateSSHKey(),
 			GraylogConfig:        dF.getGraylogConfig(),
@@ -128,13 +128,13 @@ func (dF DefaultConfig) GetAPIPort() int {
 	return apiPort
 }
 
-// getAPIVersion returns current API version
-func (dF DefaultConfig) getAPIVersion() string {
+// GetAPIVersion returns current API version
+func (dF DefaultConfig) GetAPIVersion() string {
 	return "0.6.0"
 }
 
-// getAPIReleaseDate returns current API release date
-func (dF DefaultConfig) getAPIReleaseDate() string {
+// GetAPIReleaseDate returns current API release date
+func (dF DefaultConfig) GetAPIReleaseDate() string {
 	return "2019-07-18"
 }
 

--- a/api/context/context_suite_test.go
+++ b/api/context/context_suite_test.go
@@ -1,0 +1,13 @@
+package context_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestContext(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Context Suite")
+}

--- a/api/context/types.go
+++ b/api/context/types.go
@@ -10,7 +10,7 @@ import (
 type ExternalCalls struct{}
 
 func (eC *ExternalCalls) SetConfigFile(configName, configPath string) error {
-	viper.SetConfigFile(configName)
+	viper.SetConfigName(configName)
 	viper.AddConfigPath(configPath)
 	return viper.ReadInConfig()
 }

--- a/api/context/types.go
+++ b/api/context/types.go
@@ -1,0 +1,50 @@
+package context
+
+import (
+	"github.com/spf13/viper"
+	"os"
+	"strconv"
+	"time"
+)
+
+type ExternalCalls struct{}
+
+func (eC *ExternalCalls) SetConfigFile(configName, configPath string) error {
+	viper.SetConfigFile(configName)
+	viper.AddConfigPath(configPath)
+	return viper.ReadInConfig()
+}
+
+func (eC *ExternalCalls) GetEnvironmentVariable(envName string) string {
+	return os.Getenv(envName)
+}
+
+func (eC *ExternalCalls) ConvertStrToInt(str string) (int, error) {
+	return strconv.Atoi(str)
+}
+
+func (eC *ExternalCalls) GetTimeDurationInSeconds(duration int) time.Duration {
+	return time.Duration(duration) * time.Second
+}
+
+func (eC *ExternalCalls) GetStringFromConfigFile(value string) string {
+	return viper.GetString(value)
+}
+
+func (eC *ExternalCalls) GetBoolFromConfigFile(value string) bool {
+	return viper.GetBool(value)
+}
+
+func (eC *ExternalCalls) GetIntFromConfigFile(value string) int {
+	return viper.GetInt(value)
+}
+
+type CallerInterface interface {
+	SetConfigFile(configName, configPath string) error
+	GetStringFromConfigFile(value string) string
+	GetBoolFromConfigFile(value string) bool
+	GetIntFromConfigFile(value string) int
+	GetEnvironmentVariable(envName string) string
+	ConvertStrToInt(str string) (int, error)
+	GetTimeDurationInSeconds(duration int) time.Duration
+}

--- a/api/context/types.go
+++ b/api/context/types.go
@@ -1,44 +1,54 @@
 package context
 
 import (
-	"github.com/spf13/viper"
 	"os"
 	"strconv"
 	"time"
+
+	"github.com/spf13/viper"
 )
 
+// ExternalCalls is the extruct that performs exernal calls.
 type ExternalCalls struct{}
 
+// SetConfigFile will set a configfile into a path.
 func (eC *ExternalCalls) SetConfigFile(configName, configPath string) error {
 	viper.SetConfigName(configName)
 	viper.AddConfigPath(configPath)
 	return viper.ReadInConfig()
 }
 
+// GetEnvironmentVariable will return the value of an env var.
 func (eC *ExternalCalls) GetEnvironmentVariable(envName string) string {
 	return os.Getenv(envName)
 }
 
+// ConvertStrToInt converts a string into int.
 func (eC *ExternalCalls) ConvertStrToInt(str string) (int, error) {
 	return strconv.Atoi(str)
 }
 
+// GetTimeDurationInSeconds returnin the number of seconds of a duration.
 func (eC *ExternalCalls) GetTimeDurationInSeconds(duration int) time.Duration {
 	return time.Duration(duration) * time.Second
 }
 
+// GetStringFromConfigFile returns a string from a config file.
 func (eC *ExternalCalls) GetStringFromConfigFile(value string) string {
 	return viper.GetString(value)
 }
 
+// GetBoolFromConfigFile returns a bool from a config file.
 func (eC *ExternalCalls) GetBoolFromConfigFile(value string) bool {
 	return viper.GetBool(value)
 }
 
+// GetIntFromConfigFile returns a int from a config file.
 func (eC *ExternalCalls) GetIntFromConfigFile(value string) int {
 	return viper.GetInt(value)
 }
 
+// CallerInterface is the interface that stores all external call functions.
 type CallerInterface interface {
 	SetConfigFile(configName, configPath string) error
 	GetStringFromConfigFile(value string) string

--- a/api/db/huskydb.go
+++ b/api/db/huskydb.go
@@ -171,7 +171,7 @@ func InsertDBAccessToken(accessToken types.DBToken) error {
 		"isValid":       accessToken.IsValid,
 		"createdAt":     accessToken.CreatedAt,
 		"salt":          accessToken.Salt,
-		"uuid":          accessToken.UUid,
+		"uuid":          accessToken.UUID,
 	}
 	err := mongoHuskyCI.Conn.Insert(newAccessToken, mongoHuskyCI.AccessTokenCollection)
 	return err

--- a/api/dockers/api.go
+++ b/api/dockers/api.go
@@ -130,7 +130,7 @@ func (d Docker) RemoveContainer() error {
 	return err
 }
 
-// ListContainers returns a Docker type list with CIDs of stopped containers
+// ListStoppedContainers returns a Docker type list with CIDs of stopped containers
 func (d Docker) ListStoppedContainers() ([]Docker, error) {
 
 	ctx := goContext.Background()

--- a/api/dockers/api.go
+++ b/api/dockers/api.go
@@ -36,11 +36,15 @@ type CreateContainerPayload struct {
 
 // NewDocker returns a new docker.
 func NewDocker() (*Docker, error) {
-	configAPI := context.GetAPIConfig()
+	configAPI, err := context.DefaultConf.GetAPIConfig()
+	if err != nil {
+		log.Error("NewDocker", "DOCKERAPI", 3026, err)
+		return nil, err
+	}
 	dockerHost := fmt.Sprintf("https://%s", configAPI.DockerHostsConfig.Host)
 
 	// env vars needed by docker/docker library to create a NewEnvClient:
-	err := os.Setenv("DOCKER_HOST", dockerHost)
+	err = os.Setenv("DOCKER_HOST", dockerHost)
 	if err != nil {
 		log.Error("NewDocker", "DOCKERAPI", 3001, err)
 		return nil, err

--- a/api/log/messagecodes.go
+++ b/api/log/messagecodes.go
@@ -119,6 +119,7 @@ var MsgCode = map[int]string{
 	3023: "Could not remove a container via d.client: ",
 	3024: "Could not call die containers: ",
 	3025: "Could not update listed containers: ",
+	3026: "Could not initialize default configurations: ",
 
 	// Util package errors
 	4001: "Could not read certificate file: ",

--- a/api/routes/analysis.go
+++ b/api/routes/analysis.go
@@ -20,17 +20,17 @@ import (
 )
 
 var (
-	tokenValidator token.TokenValidator
+	tokenValidator token.TValidator
 )
 
 func init() {
-	tokenCaller := token.TokenCaller{}
+	tokenCaller := token.TCaller{}
 	hashGen := auth.Pbkdf2Caller{}
-	tokenHandler := token.TokenHandler{
+	tokenHandler := token.THandler{
 		External: &tokenCaller,
 		HashGen:  &hashGen,
 	}
-	tokenValidator = token.TokenValidator{
+	tokenValidator = token.TValidator{
 		TokenVerifier: &tokenHandler,
 	}
 }

--- a/api/routes/token.go
+++ b/api/routes/token.go
@@ -15,13 +15,13 @@ import (
 )
 
 var (
-	tokenHandler token.TokenHandler
+	tokenHandler token.THandler
 )
 
 func init() {
-	tokenCaller := token.TokenCaller{}
+	tokenCaller := token.TCaller{}
 	hashGen := auth.Pbkdf2Caller{}
-	tokenHandler = token.TokenHandler{
+	tokenHandler = token.THandler{
 		External: &tokenCaller,
 		HashGen:  &hashGen,
 	}

--- a/api/routes/version_test.go
+++ b/api/routes/version_test.go
@@ -11,11 +11,11 @@ import (
 var _ = Describe("getRequestResult", func() {
 
 	expected := map[string]string{
-		"version": apiContext.GetAPIVersion(),
-		"date":    apiContext.GetAPIReleaseDate(),
+		"version": apiContext.DefaultConf.GetAPIVersion(),
+		"date":    apiContext.DefaultConf.GetAPIReleaseDate(),
 	}
 
-	apiContext.SetOnceConfig()
+	apiContext.DefaultConf.SetOnceConfig()
 	config := apiContext.APIConfiguration
 
 	Context("When version and date are requested", func() {

--- a/api/server.go
+++ b/api/server.go
@@ -20,7 +20,12 @@ import (
 
 func main() {
 
-	configAPI := apiContext.GetAPIConfig()
+	configAPI, err := apiContext.DefaultConf.GetAPIConfig()
+
+	if err != nil {
+		fmt.Println("Error in configuration file: ", err)
+		os.Exit(1)
+	}
 
 	log.InitLog()
 	log.Info("main", "SERVER", 11)

--- a/api/token/generator.go
+++ b/api/token/generator.go
@@ -39,7 +39,7 @@ func (tC *TokenCaller) FindAccessToken(id string) (types.DBToken, error) {
 }
 
 func (tC *TokenCaller) FindRepoURL(repositoryURL string) error {
-	repoQuery := map[string]interface{}{"repositoryURL": repositoryURL}
+	repoQuery := map[string]interface{}{"repositoryURL": repositoryURL, "isValid": true}
 	_, err := db.FindOneAccessToken(repoQuery)
 	return err
 }

--- a/api/token/generator.go
+++ b/api/token/generator.go
@@ -15,7 +15,8 @@ import (
 	"github.com/google/uuid"
 )
 
-func (tC *TokenCaller) ValidateURL(url string) (string, error) {
+// ValidateURL validates if an URL is malicious or not.
+func (tC *TCaller) ValidateURL(url string) (string, error) {
 	return util.CheckMaliciousRepoURL(url)
 }
 
@@ -25,44 +26,53 @@ func generateRandomBytes() ([]byte, error) {
 	return b, err
 }
 
-func (tC *TokenCaller) GenerateToken() (string, error) {
+// GenerateToken generates a new token to be used in auth.
+func (tC *TCaller) GenerateToken() (string, error) {
 	b, err := generateRandomBytes()
 	return base64.URLEncoding.EncodeToString(b), err
 }
 
-func (tC *TokenCaller) GetTimeNow() time.Time {
+// GetTimeNow returns the time now.
+func (tC *TCaller) GetTimeNow() time.Time {
 	return time.Now()
 }
 
-func (tC *TokenCaller) StoreAccessToken(accessToken types.DBToken) error {
+// StoreAccessToken stores a new access token into MongoDB.
+func (tC *TCaller) StoreAccessToken(accessToken types.DBToken) error {
 	return db.InsertDBAccessToken(accessToken)
 }
 
-func (tC *TokenCaller) FindAccessToken(id string) (types.DBToken, error) {
-	aTokenQuery := map[string]interface{}{"uuid": id}
+// FindAccessToken gets an AccessToken based on an given ID.
+func (tC *TCaller) FindAccessToken(ID string) (types.DBToken, error) {
+	aTokenQuery := map[string]interface{}{"uuid": ID}
 	return db.FindOneDBAccessToken(aTokenQuery)
 }
 
-func (tC *TokenCaller) FindRepoURL(repositoryURL string) error {
+// FindRepoURL checks if a Access TOken is present based on a given URL.
+func (tC *TCaller) FindRepoURL(repositoryURL string) error {
 	repoQuery := map[string]interface{}{"repositoryURL": repositoryURL, "isValid": true}
-	_, err := db.FindOneAccessToken(repoQuery)
+	_, err := db.FindOneDBAccessToken(repoQuery)
 	return err
 }
 
-func (tC *TokenCaller) GenerateUuid() string {
+// GenerateUUID returns a new UUID.
+func (tC *TCaller) GenerateUUID() string {
 	return uuid.New().String()
 }
 
-func (tC *TokenCaller) EncodeBase64(m string) string {
+// EncodeBase64 retunrs a string in base64.
+func (tC *TCaller) EncodeBase64(m string) string {
 	return base64.URLEncoding.EncodeToString([]byte(m))
 }
 
-func (tC *TokenCaller) DecodeToStringBase64(encodedVal string) (string, error) {
+// DecodeToStringBase64 decodes a base64 string.
+func (tC *TCaller) DecodeToStringBase64(encodedVal string) (string, error) {
 	decodedVal, err := base64.URLEncoding.DecodeString(encodedVal)
 	return string(decodedVal), err
 }
 
-func (tC *TokenCaller) UpdateAccessToken(id string, accesstoken types.DBToken) error {
-	aTokenQuery := map[string]interface{}{"uuid": id}
+// UpdateAccessToken updates an access Token in MongoDB based on its UUID.
+func (tC *TCaller) UpdateAccessToken(ID string, accesstoken types.DBToken) error {
+	aTokenQuery := map[string]interface{}{"uuid": ID}
 	return db.UpdateOneDBAccessToken(aTokenQuery, accesstoken)
 }

--- a/api/token/token.go
+++ b/api/token/token.go
@@ -20,7 +20,7 @@ import (
 // random data. The hash of the random data is stored
 // using PBKDF2 algorithm. It is returned the base64 of
 // the two parts separated by two points.
-func (tH *TokenHandler) GenerateAccessToken(repo types.TokenRequest) (string, error) {
+func (tH *THandler) GenerateAccessToken(repo types.TokenRequest) (string, error) {
 	accessToken := types.DBToken{}
 	validatedURL, err := tH.External.ValidateURL(repo.RepositoryURL)
 	if err != nil {
@@ -59,18 +59,18 @@ func (tH *TokenHandler) GenerateAccessToken(repo types.TokenRequest) (string, er
 	accessToken.IsValid = true
 	accessToken.CreatedAt = tH.External.GetTimeNow()
 	accessToken.Salt = salt
-	accessToken.UUid = tH.External.GenerateUuid()
+	accessToken.UUID = tH.External.GenerateUUID()
 	if err := tH.External.StoreAccessToken(accessToken); err != nil {
 		return "", err
 	}
-	return tH.External.EncodeBase64(fmt.Sprintf("%s:%s", accessToken.UUid, token)), nil
+	return tH.External.EncodeBase64(fmt.Sprintf("%s:%s", accessToken.UUID, token)), nil
 }
 
 // GetSplitted will return UUID and random part
 // of the received access token. It will decode
 // the base64 first. The first argument returned
 // is the UUID and the second is the random data.
-func (tH *TokenHandler) GetSplitted(rcvToken string) (string, string, error) {
+func (tH *THandler) GetSplitted(rcvToken string) (string, string, error) {
 	decodedToken, err := tH.External.DecodeToStringBase64(rcvToken)
 	if err != nil {
 		return "", "", err
@@ -86,7 +86,7 @@ func (tH *TokenHandler) GetSplitted(rcvToken string) (string, string, error) {
 // received data and compare with hashdata passed in
 // the argument. The hash calculated uses the salt
 // passed in the argument.
-func (tH *TokenHandler) ValidateRandomData(rdata, hashdata, salt string) error {
+func (tH *THandler) ValidateRandomData(rdata, hashdata, salt string) error {
 	bSalt, err := tH.HashGen.DecodeSaltValue(salt)
 	if err != nil {
 		return err
@@ -117,7 +117,7 @@ func (tH *TokenHandler) ValidateRandomData(rdata, hashdata, salt string) error {
 // is a valid token. It will verify the access token
 // has permission to start an analysis for the received
 // repository URL.
-func (tH *TokenHandler) ValidateToken(token, repositoryURL string) error {
+func (tH *THandler) ValidateToken(token, repositoryURL string) error {
 	validURL, err := tH.External.ValidateURL(repositoryURL)
 	if err != nil {
 		return err
@@ -141,7 +141,7 @@ func (tH *TokenHandler) ValidateToken(token, repositoryURL string) error {
 
 // VerifyRepo will verify if exists an entry
 // for the received repository
-func (tH *TokenHandler) VerifyRepo(repositoryURL string) error {
+func (tH *THandler) VerifyRepo(repositoryURL string) error {
 	validURL, err := tH.External.ValidateURL(repositoryURL)
 	if err != nil {
 		return err
@@ -152,7 +152,7 @@ func (tH *TokenHandler) VerifyRepo(repositoryURL string) error {
 // InvalidateToken will set boolean flag IsValid
 // to false if the passed access token is found
 // in DB.
-func (tH *TokenHandler) InvalidateToken(token string) error {
+func (tH *THandler) InvalidateToken(token string) error {
 	uUID, _, err := tH.GetSplitted(token)
 	if err != nil {
 		return err

--- a/api/token/token_test.go
+++ b/api/token/token_test.go
@@ -71,7 +71,7 @@ func (fE *FakeExternal) FindRepoURL(repositoryURL string) error {
 	return fE.expectedFindRepoError
 }
 
-func (fE *FakeExternal) GenerateUuid() string {
+func (fE *FakeExternal) GenerateUUID() string {
 	return fE.expectedUuid
 }
 
@@ -123,7 +123,7 @@ var _ = Describe("Token", func() {
 				expectedURL:           "",
 				expectedValidateError: errors.New("URL is not valid"),
 			}
-			tokenGen := TokenHandler{
+			tokenGen := THandler{
 				External: &fakeExt,
 			}
 			accessToken, err := tokenGen.GenerateAccessToken(types.TokenRequest{
@@ -139,7 +139,7 @@ var _ = Describe("Token", func() {
 				expectedURL:           "",
 				expectedValidateError: nil,
 			}
-			tokenGen := TokenHandler{
+			tokenGen := THandler{
 				External: &fakeExt,
 			}
 			accessToken, err := tokenGen.GenerateAccessToken(types.TokenRequest{
@@ -157,7 +157,7 @@ var _ = Describe("Token", func() {
 				expectedToken:         "",
 				expectedGenerateError: errors.New("Failed to generate token"),
 			}
-			tokenGen := TokenHandler{
+			tokenGen := THandler{
 				External: &fakeExt,
 			}
 			accessToken, err := tokenGen.GenerateAccessToken(types.TokenRequest{
@@ -179,7 +179,7 @@ var _ = Describe("Token", func() {
 				expectedSalt:              "",
 				expectedGenerateSaltError: errors.New("Could not generate a valid salt"),
 			}
-			tokenGen := TokenHandler{
+			tokenGen := THandler{
 				External: &fakeExt,
 				HashGen:  &fakeHash,
 			}
@@ -204,7 +204,7 @@ var _ = Describe("Token", func() {
 				expectedDecodedSalt:       make([]byte, 0),
 				expectedDecodeSaltError:   errors.New("Failed to decode salt value"),
 			}
-			tokenGen := TokenHandler{
+			tokenGen := THandler{
 				External: &fakeExt,
 				HashGen:  &fakeHash,
 			}
@@ -232,7 +232,7 @@ var _ = Describe("Token", func() {
 				expectedKeyLength:         0,
 				expectedGetKeyError:       errors.New("Error during key length conversion"),
 			}
-			tokenGen := TokenHandler{
+			tokenGen := THandler{
 				External: &fakeExt,
 				HashGen:  &fakeHash,
 			}
@@ -262,7 +262,7 @@ var _ = Describe("Token", func() {
 				expectedIterations:         0,
 				expectedGetIterationsError: errors.New("Failed to convert iterations"),
 			}
-			tokenGen := TokenHandler{
+			tokenGen := THandler{
 				External: &fakeExt,
 				HashGen:  &fakeHash,
 			}
@@ -292,7 +292,7 @@ var _ = Describe("Token", func() {
 				expectedIterations:         1024,
 				expectedGetIterationsError: nil,
 			}
-			tokenGen := TokenHandler{
+			tokenGen := THandler{
 				External: &fakeExt,
 				HashGen:  &fakeHash,
 			}
@@ -326,7 +326,7 @@ var _ = Describe("Token", func() {
 				expectedGetIterationsError: nil,
 				expectedHashValue:          "MyTokenHashValue",
 			}
-			tokenGen := TokenHandler{
+			tokenGen := THandler{
 				External: &fakeExt,
 				HashGen:  &fakeHash,
 			}
@@ -360,7 +360,7 @@ var _ = Describe("Token", func() {
 				expectedGetIterationsError: nil,
 				expectedHashValue:          "MyTokenHashValue",
 			}
-			tokenGen := TokenHandler{
+			tokenGen := THandler{
 				External: &fakeExt,
 				HashGen:  &fakeHash,
 			}
@@ -378,7 +378,7 @@ var _ = Describe("Token", func() {
 					expectedDecodedString: "",
 					expectedDecodeToError: errors.New("Failed to decode to base64"),
 				}
-				tokenVal := TokenHandler{
+				tokenVal := THandler{
 					External: &fakeExt,
 				}
 				UUid, Random, err := tokenVal.GetSplitted("MyTokenBase64")
@@ -393,7 +393,7 @@ var _ = Describe("Token", func() {
 					expectedDecodedString: "InvalidTokenFormat",
 					expectedDecodeToError: nil,
 				}
-				tokenVal := TokenHandler{
+				tokenVal := THandler{
 					External: &fakeExt,
 				}
 				UUid, Random, err := tokenVal.GetSplitted("MyTokenBase64")
@@ -408,7 +408,7 @@ var _ = Describe("Token", func() {
 					expectedDecodedString: "MyUUID:MyRandomData",
 					expectedDecodeToError: nil,
 				}
-				tokenVal := TokenHandler{
+				tokenVal := THandler{
 					External: &fakeExt,
 				}
 				UUid, Random, err := tokenVal.GetSplitted("MyTokenBase64")
@@ -425,7 +425,7 @@ var _ = Describe("Token", func() {
 					expectedDecodedSalt:     make([]byte, 0),
 					expectedDecodeSaltError: errors.New("Could not return the decoded value"),
 				}
-				tokenVal := TokenHandler{
+				tokenVal := THandler{
 					HashGen: &hashGen,
 				}
 				Expect(tokenVal.ValidateRandomData("ReceivedRandom", "StoredRandom", "StoredSalt")).To(Equal(hashGen.expectedDecodeSaltError))
@@ -438,7 +438,7 @@ var _ = Describe("Token", func() {
 					expectedDecodeSaltError: nil,
 					expectedHashName:        "InvalidSha",
 				}
-				tokenVal := TokenHandler{
+				tokenVal := THandler{
 					HashGen: &hashGen,
 				}
 				Expect(tokenVal.ValidateRandomData("ReceivedRandom", "StoredRandom", "StoredSalt")).To(Equal(errors.New("Invalid hash function")))
@@ -453,7 +453,7 @@ var _ = Describe("Token", func() {
 					expectedKeyLength:       0,
 					expectedGetKeyError:     errors.New("Invalid key format"),
 				}
-				tokenVal := TokenHandler{
+				tokenVal := THandler{
 					HashGen: &hashGen,
 				}
 				Expect(tokenVal.ValidateRandomData("ReceivedRandom", "StoredRandom", "StoredSalt")).To(Equal(hashGen.expectedGetKeyError))
@@ -470,7 +470,7 @@ var _ = Describe("Token", func() {
 					expectedIterations:         0,
 					expectedGetIterationsError: errors.New("Invalid iterations value format"),
 				}
-				tokenVal := TokenHandler{
+				tokenVal := THandler{
 					HashGen: &hashGen,
 				}
 				Expect(tokenVal.ValidateRandomData("ReceivedRandom", "StoredRandom", "StoredSalt")).To(Equal(hashGen.expectedGetIterationsError))
@@ -488,7 +488,7 @@ var _ = Describe("Token", func() {
 					expectedGetIterationsError: nil,
 					expectedHashValue:          "DifferentFromTheStored",
 				}
-				tokenVal := TokenHandler{
+				tokenVal := THandler{
 					HashGen: &hashGen,
 				}
 				Expect(tokenVal.ValidateRandomData("ReceivedRandom", "StoredRandom", "StoredSalt")).To(Equal(errors.New("Hash value from random data is different")))
@@ -506,7 +506,7 @@ var _ = Describe("Token", func() {
 					expectedGetIterationsError: nil,
 					expectedHashValue:          "StoredRandomHash",
 				}
-				tokenVal := TokenHandler{
+				tokenVal := THandler{
 					HashGen: &hashGen,
 				}
 				Expect(tokenVal.ValidateRandomData("ReceivedRandom", "StoredRandomHash", "StoredSalt")).To(BeNil())
@@ -520,7 +520,7 @@ var _ = Describe("Token", func() {
 					expectedURL:           "",
 					expectedValidateError: errors.New("Invalid URL format"),
 				}
-				tokenVal := TokenHandler{
+				tokenVal := THandler{
 					External: &fakeExt,
 				}
 				Expect(tokenVal.ValidateToken("RcvToken", "RcvRepo")).To(Equal(fakeExt.expectedValidateError))
@@ -532,7 +532,7 @@ var _ = Describe("Token", func() {
 					expectedURL:           "ValidURLRepo",
 					expectedValidateError: nil,
 				}
-				tokenVal := TokenHandler{
+				tokenVal := THandler{
 					External: &fakeExt,
 				}
 				Expect(tokenVal.ValidateToken("InvalidRcvToken", "RcvRepo")).To(Equal(errors.New("Invalid access token format")))
@@ -548,7 +548,7 @@ var _ = Describe("Token", func() {
 					expectedDecodedString:   "UUID:RandomVal",
 					expectedDecodeToError:   nil,
 				}
-				tokenVal := TokenHandler{
+				tokenVal := THandler{
 					External: &fakeExt,
 				}
 				Expect(tokenVal.ValidateToken("EncodedRcvToken", "RcvRepo")).To(Equal(fakeExt.expectedFindAccessError))
@@ -567,7 +567,7 @@ var _ = Describe("Token", func() {
 					expectedDecodedString: "UUID:RandomVal",
 					expectedDecodeToError: nil,
 				}
-				tokenVal := TokenHandler{
+				tokenVal := THandler{
 					External: &fakeExt,
 				}
 				Expect(tokenVal.ValidateToken("EncodedRcvToken", "RcvRepo")).To(Equal(errors.New("Access token is invalid")))
@@ -587,7 +587,7 @@ var _ = Describe("Token", func() {
 					expectedDecodedString: "UUID:RandomVal",
 					expectedDecodeToError: nil,
 				}
-				tokenVal := TokenHandler{
+				tokenVal := THandler{
 					External: &fakeExt,
 				}
 				Expect(tokenVal.ValidateToken("EncodedRcvToken", "RcvRepo")).To(Equal(errors.New("Access token doesn't have permission to run analysis in the provided repository")))
@@ -617,7 +617,7 @@ var _ = Describe("Token", func() {
 					expectedDecodedString: "UUID:RandomVal",
 					expectedDecodeToError: nil,
 				}
-				tokenVal := TokenHandler{
+				tokenVal := THandler{
 					External: &fakeExt,
 					HashGen:  &fakeHash,
 				}
@@ -648,7 +648,7 @@ var _ = Describe("Token", func() {
 					expectedDecodedString: "UUID:RandomVal",
 					expectedDecodeToError: nil,
 				}
-				tokenVal := TokenHandler{
+				tokenVal := THandler{
 					External: &fakeExt,
 					HashGen:  &fakeHash,
 				}
@@ -663,7 +663,7 @@ var _ = Describe("Token", func() {
 					expectedURL:           "",
 					expectedValidateError: errors.New("Repository does not have a valid format"),
 				}
-				verRepo := TokenHandler{
+				verRepo := THandler{
 					External: &fakeExt,
 				}
 				Expect(verRepo.VerifyRepo("MyRepo")).To(Equal(fakeExt.expectedValidateError))
@@ -676,7 +676,7 @@ var _ = Describe("Token", func() {
 					expectedValidateError: nil,
 					expectedFindRepoError: errors.New("Repository URL not found"),
 				}
-				verRepo := TokenHandler{
+				verRepo := THandler{
 					External: &fakeExt,
 				}
 				Expect(verRepo.VerifyRepo("MyRepo")).To(Equal(fakeExt.expectedFindRepoError))
@@ -687,7 +687,7 @@ var _ = Describe("Token", func() {
 					expectedValidateError: nil,
 					expectedFindRepoError: nil,
 				}
-				verRepo := TokenHandler{
+				verRepo := THandler{
 					External: &fakeExt,
 				}
 				Expect(verRepo.VerifyRepo("MyRepo")).To(BeNil())
@@ -701,7 +701,7 @@ var _ = Describe("Token", func() {
 					expectedDecodedString: "InvalidTokenFormat",
 					expectedDecodeToError: nil,
 				}
-				invalToken := TokenHandler{
+				invalToken := THandler{
 					External: &fakeExt,
 				}
 				Expect(invalToken.InvalidateToken("RcvToken")).To(Equal(errors.New("Invalid access token format")))
@@ -715,7 +715,7 @@ var _ = Describe("Token", func() {
 					expectedFindAccessError: errors.New("Could not find access token in DB"),
 					expectedAccessToken:     types.DBToken{},
 				}
-				invalToken := TokenHandler{
+				invalToken := THandler{
 					External: &fakeExt,
 				}
 				Expect(invalToken.InvalidateToken("RcvToken")).To(Equal(fakeExt.expectedFindAccessError))
@@ -730,19 +730,19 @@ var _ = Describe("Token", func() {
 					expectedAccessToken: types.DBToken{
 						IsValid:    true,
 						HuskyToken: "StoredEncodedRandomData",
-						UUid:       "MyUUID",
+						UUID:       "MyUUID",
 						URL:        "MyURL",
 						Salt:       "MySalt",
 					},
 					expectedUpdateAccessError: nil,
 				}
-				invalToken := TokenHandler{
+				invalToken := THandler{
 					External: &fakeExt,
 				}
 				err := invalToken.InvalidateToken("RcvToken")
 				Expect(err).To(BeNil())
 				Expect(fakeExt.returnedAccessToken.HuskyToken).To(Equal(fakeExt.expectedAccessToken.HuskyToken))
-				Expect(fakeExt.returnedAccessToken.UUid).To(Equal(fakeExt.expectedAccessToken.UUid))
+				Expect(fakeExt.returnedAccessToken.UUID).To(Equal(fakeExt.expectedAccessToken.UUID))
 				Expect(fakeExt.returnedAccessToken.URL).To(Equal(fakeExt.expectedAccessToken.URL))
 				Expect(fakeExt.returnedAccessToken.Salt).To(Equal(fakeExt.expectedAccessToken.Salt))
 				Expect(fakeExt.returnedAccessToken.IsValid).To(BeFalse())

--- a/api/token/tokenvalidator.go
+++ b/api/token/tokenvalidator.go
@@ -9,7 +9,7 @@ package token
 // it will validate the received access token. A true
 // bool is returned if it has authorization. If not,
 // it will return false.
-func (tV TokenValidator) HasAuthorization(accessToken, repositoryURL string) bool {
+func (tV TValidator) HasAuthorization(accessToken, repositoryURL string) bool {
 	// Temporary: Verify if exists an access token
 	// for that repo
 	if err := tV.TokenVerifier.VerifyRepo(repositoryURL); err != nil {

--- a/api/token/tokenvalidator.go
+++ b/api/token/tokenvalidator.go
@@ -1,5 +1,10 @@
 package token
 
+// HasAuthorization will verify if exists a valid
+// access token for the given repository. If exists,
+// it will validate the received access token. A true
+// bool is returned if it has authorization. If not,
+// it will return false.
 func (tV TokenValidator) HasAuthorization(accessToken, repositoryURL string) bool {
 	// Temporary: Verify if exists an access token
 	// for that repo

--- a/api/token/tokenvalidator_test.go
+++ b/api/token/tokenvalidator_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Tokenvalidator", func() {
 				fakeVerifier := FakeVerifier{
 					expectedVerifyError: errors.New("Could not find the repository URL"),
 				}
-				validator := TokenValidator{
+				validator := TValidator{
 					TokenVerifier: &fakeVerifier,
 				}
 				Expect(validator.HasAuthorization("MyToken", "MyRepo")).To(BeTrue())
@@ -50,7 +50,7 @@ var _ = Describe("Tokenvalidator", func() {
 					expectedVerifyError:   nil,
 					expectedValidateError: errors.New("Token is not valid"),
 				}
-				validator := TokenValidator{
+				validator := TValidator{
 					TokenVerifier: &FakeVerifier,
 				}
 				Expect(validator.HasAuthorization("MyToken", "MyRepo")).To(BeFalse())
@@ -62,7 +62,7 @@ var _ = Describe("Tokenvalidator", func() {
 					expectedVerifyError:   nil,
 					expectedValidateError: nil,
 				}
-				validator := TokenValidator{
+				validator := TValidator{
 					TokenVerifier: &FakeVerifier,
 				}
 				Expect(validator.HasAuthorization("MyToken", "MyRepo")).To(BeTrue())

--- a/api/token/types.go
+++ b/api/token/types.go
@@ -6,6 +6,9 @@ import (
 	"time"
 )
 
+// ExternalCalls defines a group of functions
+// used for external calls and validate some
+// necessary information about TokenHandler.
 type ExternalCalls interface {
 	ValidateURL(url string) (string, error)
 	GenerateToken() (string, error)
@@ -19,19 +22,27 @@ type ExternalCalls interface {
 	DecodeToStringBase64(encodedVal string) (string, error)
 }
 
+// TokenHandler is a struct used to handle with
+// token generation, validation and deactivation.
+// It implements TokenInterface interface.
 type TokenHandler struct {
 	External ExternalCalls
 	HashGen  auth.Pbkdf2Generator
 }
 
+// TokenCaller implements ExternalCalls interface.
 type TokenCaller struct{}
 
+// TokenInterface is used to define functions that
+// handle with access token management.
 type TokenInterface interface {
 	GenerateAccessToken(repo types.TokenRequest) (string, error)
 	ValidateToken(token, repositoryURL string) error
 	VerifyRepo(repositoryURL string) error
 }
 
+// TokenValidator is used to validate an access token
+// using the defined functions TokenInterface
 type TokenValidator struct {
 	TokenVerifier TokenInterface
 }

--- a/api/token/types.go
+++ b/api/token/types.go
@@ -22,32 +22,32 @@ type ExternalCalls interface {
 	FindAccessToken(id string) (types.DBToken, error)
 	UpdateAccessToken(id string, accesstoken types.DBToken) error
 	FindRepoURL(repositoryURL string) error
-	GenerateUuid() string
+	GenerateUUID() string
 	EncodeBase64(m string) string
 	DecodeToStringBase64(encodedVal string) (string, error)
 }
 
-// TokenHandler is a struct used to handle with
+// THandler is a struct used to handle with
 // token generation, validation and deactivation.
 // It implements TokenInterface interface.
-type TokenHandler struct {
+type THandler struct {
 	External ExternalCalls
 	HashGen  auth.Pbkdf2Generator
 }
 
-// TokenCaller implements ExternalCalls interface.
-type TokenCaller struct{}
+// TCaller implements ExternalCalls interface.
+type TCaller struct{}
 
-// TokenInterface is used to define functions that
+// TInterface is used to define functions that
 // handle with access token management.
-type TokenInterface interface {
+type TInterface interface {
 	GenerateAccessToken(repo types.TokenRequest) (string, error)
 	ValidateToken(token, repositoryURL string) error
 	VerifyRepo(repositoryURL string) error
 }
 
-// TokenValidator is used to validate an access token
+// TValidator is used to validate an access token
 // using the defined functions TokenInterface
-type TokenValidator struct {
-	TokenVerifier TokenInterface
+type TValidator struct {
+	TokenVerifier TInterface
 }

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -151,5 +151,5 @@ type DBToken struct {
 	IsValid    bool          `bson:"isValid"`
 	CreatedAt  time.Time     `bson:"createdAt"`
 	Salt       string        `bson:"salt"`
-	UUid       string        `bson:"uuid"`
+	UUID       string        `bson:"uuid"`
 }

--- a/api/user/user.go
+++ b/api/user/user.go
@@ -24,9 +24,12 @@ var (
 	// DefaultAPIUser is the default API user from huskyCI
 	DefaultAPIUser = os.Getenv("HUSKYCI_API_DEFAULT_USERNAME")
 	// DefaultAPIPassword is the default API password from huskyCI
-	DefaultAPIPassword  = os.Getenv("HUSKYCI_API_DEFAULT_PASSWORD")
-	DefaultIterations   = os.Getenv("HUSKYCI_API_DEFAULT_ITERATIONS")
-	DefaultKeyLength    = os.Getenv("HUSKYCI_API_DEFAULT_KEY_LENGTH")
+	DefaultAPIPassword = os.Getenv("HUSKYCI_API_DEFAULT_PASSWORD")
+	// DefaultIterations is the default number of iterations used for auth
+	DefaultIterations = os.Getenv("HUSKYCI_API_DEFAULT_ITERATIONS")
+	// DefaultKeyLength is the default key length used for auth
+	DefaultKeyLength = os.Getenv("HUSKYCI_API_DEFAULT_KEY_LENGTH")
+	// DefaultHashFunction is the default hash function name of iterations used for auth
 	DefaultHashFunction = os.Getenv("HUSKYCI_API_DEFAULT_HASH_FUNCTION")
 )
 

--- a/api/util/api/types.go
+++ b/api/util/api/types.go
@@ -4,6 +4,7 @@ import (
 	apiContext "github.com/globocom/huskyCI/api/context"
 )
 
+// CheckInterface is the interface that stores all check functions.
 type CheckInterface interface {
 	checkEnvVars() error
 	checkDockerHosts(configAPI *apiContext.APIConfig) error
@@ -12,12 +13,15 @@ type CheckInterface interface {
 	checkDefaultUser(configAPI *apiContext.APIConfig) error
 }
 
+// CheckUtils is the struct used for testing utils.
 type CheckUtils struct{}
 
+// HuskyUtils is the struct that stores the check handler used for testing.
 type HuskyUtils struct {
 	CheckHandler CheckInterface
 }
 
+// FakeCheck is the struct used for testing checks functions.
 type FakeCheck struct {
 	EnvVarsError          error
 	DockerHostsError      error


### PR DESCRIPTION
This P.R. makes a refactoring on the context package, so we can write unit tests and make a complete coverage of this piece of code.

All external calls was separated in an interface with functions defining each call.

A struct was defined to support the functions to be tested and using an interface, so we can "instantiate" a mocked structure and return preset values.