### PR TITLE
Add GitAuthors securityTest 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,7 @@ pull-images:
 	docker exec huskyCI_Docker_API /bin/sh -c "docker pull huskyci/brakeman"
 	docker exec huskyCI_Docker_API /bin/sh -c "docker pull huskyci/safety"
 	docker exec huskyCI_Docker_API /bin/sh -c "docker pull huskyci/npmaudit"
+	docker exec huskyCI_Docker_API /bin/sh -c "docker pull huskyci/gitauthors"
 
 ## Runs huskyci-client
 run-client: build-client

--- a/api/analysis/analysis.go
+++ b/api/analysis/analysis.go
@@ -72,6 +72,7 @@ func registerFinishedAnalysis(RID string, allScanResults securitytest.RunAllInfo
 	updateAnalysisQuery := bson.M{
 		"$set": bson.M{
 			"status":         allScanResults.Status,
+			"commitAuthors":  allScanResults.CommitAuthors,
 			"result":         allScanResults.FinalResult,
 			"containers":     allScanResults.Containers,
 			"huskyciresults": allScanResults.HuskyCIResults,

--- a/api/config.yaml
+++ b/api/config.yaml
@@ -19,6 +19,33 @@ enry:
   default: true
   timeOutInSeconds: 60
 
+gitauthors:
+  name: gitauthors
+  image: huskyci/gitauthors
+  cmd: |+
+    mkdir -p ~/.ssh &&
+    echo 'GIT_PRIVATE_SSH_KEY' > ~/.ssh/huskyci_id_rsa &&
+    chmod 600 ~/.ssh/huskyci_id_rsa &&
+    echo "IdentityFile ~/.ssh/huskyci_id_rsa" >> /etc/ssh/ssh_config &&
+    echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config &&
+    git clone %GIT_REPO% code --quiet 2> /tmp/errorGitCloneEnry
+    if [ $? -eq 0 ]; then
+      cd code
+      for i in $(git log origin/master..origin/%GIT_BRANCH% --pretty="%ae" | sort -u); do
+        jsonMiddle="\"$i\",$jsonMiddle"
+      done
+      length=${#jsonMiddle}
+      endindex=$(expr $length - 1)
+      authors="${jsonMiddle:0:$endindex}"
+      echo "{\"authors\":[$authors]}"
+    else
+      echo "ERROR_CLONING"
+      cat /tmp/errorGitCloneEnry
+    fi
+  type: Generic
+  default: true
+  timeOutInSeconds: 60
+
 gosec:
   name: gosec
   image: huskyci/gosec

--- a/api/context/context.go
+++ b/api/context/context.go
@@ -60,20 +60,21 @@ type GraylogConfig struct {
 
 // APIConfig represents API configuration.
 type APIConfig struct {
-	Port                 int
-	Version              string
-	ReleaseDate          string
-	UseTLS               bool
-	GitPrivateSSHKey     string
-	GraylogConfig        *GraylogConfig
-	MongoDBConfig        *MongoConfig
-	DockerHostsConfig    *DockerHostsConfig
-	EnrySecurityTest     *types.SecurityTest
-	GosecSecurityTest    *types.SecurityTest
-	BanditSecurityTest   *types.SecurityTest
-	BrakemanSecurityTest *types.SecurityTest
-	NpmAuditSecurityTest *types.SecurityTest
-	SafetySecurityTest   *types.SecurityTest
+	Port                   int
+	Version                string
+	ReleaseDate            string
+	UseTLS                 bool
+	GitPrivateSSHKey       string
+	GraylogConfig          *GraylogConfig
+	MongoDBConfig          *MongoConfig
+	DockerHostsConfig      *DockerHostsConfig
+	EnrySecurityTest       *types.SecurityTest
+	GitAuthorsSecurityTest *types.SecurityTest
+	GosecSecurityTest      *types.SecurityTest
+	BanditSecurityTest     *types.SecurityTest
+	BrakemanSecurityTest   *types.SecurityTest
+	NpmAuditSecurityTest   *types.SecurityTest
+	SafetySecurityTest     *types.SecurityTest
 }
 
 // DefaultConfig is the struct that stores the caller for testing.
@@ -97,20 +98,21 @@ func (dF DefaultConfig) GetAPIConfig() (*APIConfig, error) {
 func (dF DefaultConfig) SetOnceConfig() {
 	onceConfig.Do(func() {
 		APIConfiguration = &APIConfig{
-			Port:                 dF.GetAPIPort(),
-			Version:              dF.GetAPIVersion(),
-			ReleaseDate:          dF.GetAPIReleaseDate(),
-			UseTLS:               dF.GetAPIUseTLS(),
-			GitPrivateSSHKey:     dF.getGitPrivateSSHKey(),
-			GraylogConfig:        dF.getGraylogConfig(),
-			MongoDBConfig:        dF.getMongoConfig(),
-			DockerHostsConfig:    dF.getDockerHostsConfig(),
-			EnrySecurityTest:     dF.getSecurityTestConfig("enry"),
-			GosecSecurityTest:    dF.getSecurityTestConfig("gosec"),
-			BanditSecurityTest:   dF.getSecurityTestConfig("bandit"),
-			BrakemanSecurityTest: dF.getSecurityTestConfig("brakeman"),
-			NpmAuditSecurityTest: dF.getSecurityTestConfig("npmaudit"),
-			SafetySecurityTest:   dF.getSecurityTestConfig("safety"),
+			Port:                   dF.GetAPIPort(),
+			Version:                dF.GetAPIVersion(),
+			ReleaseDate:            dF.GetAPIReleaseDate(),
+			UseTLS:                 dF.GetAPIUseTLS(),
+			GitPrivateSSHKey:       dF.getGitPrivateSSHKey(),
+			GraylogConfig:          dF.getGraylogConfig(),
+			MongoDBConfig:          dF.getMongoConfig(),
+			DockerHostsConfig:      dF.getDockerHostsConfig(),
+			EnrySecurityTest:       dF.getSecurityTestConfig("enry"),
+			GitAuthorsSecurityTest: dF.getSecurityTestConfig("gitauthors"),
+			GosecSecurityTest:      dF.getSecurityTestConfig("gosec"),
+			BanditSecurityTest:     dF.getSecurityTestConfig("bandit"),
+			BrakemanSecurityTest:   dF.getSecurityTestConfig("brakeman"),
+			NpmAuditSecurityTest:   dF.getSecurityTestConfig("npmaudit"),
+			SafetySecurityTest:     dF.getSecurityTestConfig("safety"),
 		}
 	})
 }

--- a/api/context/context_test.go
+++ b/api/context/context_test.go
@@ -360,6 +360,15 @@ var _ = Describe("Context", func() {
 						Default:          fakeCaller.expectedBoolFromConfig,
 						TimeOutInSeconds: fakeCaller.expectedIntFromConfig,
 					},
+					GitAuthorsSecurityTest: &types.SecurityTest{
+						Name:             fakeCaller.expectedStringFromConfig,
+						Image:            fakeCaller.expectedStringFromConfig,
+						Cmd:              fakeCaller.expectedStringFromConfig,
+						Type:             fakeCaller.expectedStringFromConfig,
+						Language:         fakeCaller.expectedStringFromConfig,
+						Default:          fakeCaller.expectedBoolFromConfig,
+						TimeOutInSeconds: fakeCaller.expectedIntFromConfig,
+					},
 					GosecSecurityTest: &types.SecurityTest{
 						Name:             fakeCaller.expectedStringFromConfig,
 						Image:            fakeCaller.expectedStringFromConfig,

--- a/api/log/messagecodes.go
+++ b/api/log/messagecodes.go
@@ -66,6 +66,7 @@ var MsgCode = map[int]string{
 	1032: "Internal error mapping codes: ",
 	1033: "Internal error running Safety: ",
 	1034: "Internal error running Npmaudit: ",
+	1035: "Could not Unmarshall the following gitAuthorsOutput: ",
 
 	// MongoDB infos
 	21: "Connecting to MongoDB.",

--- a/api/securitytest/gitauthors.go
+++ b/api/securitytest/gitauthors.go
@@ -1,0 +1,41 @@
+// Copyright 2019 Globo.com authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package securitytest
+
+import (
+	"encoding/json"
+
+	"github.com/globocom/huskyCI/api/log"
+)
+
+// GitAuthorsOutput is the struct that holds all commit authors from a branch.
+type GitAuthorsOutput struct {
+	Authors []string `json:"authors"`
+}
+
+func analyzeGitAuthors(gitAuthorsScan *SecTestScanInfo) error {
+
+	gitAuthorsOutput := GitAuthorsOutput{}
+	gitAuthorsScan.FinalOutput = gitAuthorsOutput
+
+	// Unmarshall rawOutput into finalOutput, that is a GitAuthors struct.
+	if err := json.Unmarshal([]byte(gitAuthorsScan.Container.COutput), &gitAuthorsOutput); err != nil {
+		log.Error("analyzeGitAuthors", "GITAUTHORS", 1002, gitAuthorsScan.Container.COutput, err)
+		gitAuthorsScan.ErrorFound = err
+		gitAuthorsScan.prepareContainerAfterScan()
+		return err
+	}
+	gitAuthorsScan.FinalOutput = gitAuthorsOutput
+
+	// check if authors is empty (master branch was probably sent)
+	if len(gitAuthorsOutput.Authors) == 0 {
+		gitAuthorsScan.CommitAuthorsNotFound = true
+		gitAuthorsScan.prepareContainerAfterScan()
+	}
+
+	gitAuthorsScan.CommitAuthors = gitAuthorsOutput
+	gitAuthorsScan.prepareContainerAfterScan()
+	return nil
+}

--- a/api/securitytest/gosec.go
+++ b/api/securitytest/gosec.go
@@ -39,6 +39,7 @@ type GosecStats struct {
 func analyzeGosec(gosecScan *SecTestScanInfo) error {
 
 	goSecOutput := GosecOutput{}
+	gosecScan.FinalOutput = goSecOutput
 
 	// nil cOutput states that no Issues were found.
 	if gosecScan.Container.COutput == "" {

--- a/api/securitytest/run.go
+++ b/api/securitytest/run.go
@@ -11,6 +11,7 @@ type RunAllInfo struct {
 	RID            string
 	Status         string
 	Containers     []types.Container
+	CommitAuthors  []string
 	Codes          []Code
 	FinalResult    string
 	ErrorFound     error
@@ -52,6 +53,9 @@ func (results *RunAllInfo) runGenericScans(enryScan SecTestScanInfo) error {
 				return err
 			}
 			results.Containers = append(results.Containers, newGenericScan.Container)
+			if genericTest.Name == "gitauthors" {
+				results.CommitAuthors = newGenericScan.CommitAuthors.Authors
+			}
 		}
 	}
 

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -36,6 +36,7 @@ type Analysis struct {
 	RID            string         `bson:"RID" json:"RID"`
 	URL            string         `bson:"repositoryURL" json:"repositoryURL"`
 	Branch         string         `bson:"repositoryBranch" json:"repositoryBranch"`
+	CommitAuthors  []string       `bson:"commitAuthors" json:"commitAuthors"`
 	Status         string         `bson:"status" json:"status"`
 	Result         string         `bson:"result,omitempty" json:"result"`
 	ErrorFound     error          `bson:"errorsRunning,omitempty" json:"errorsRunning"`

--- a/api/util/api/api.go
+++ b/api/util/api/api.go
@@ -136,7 +136,7 @@ func (cH *CheckUtils) checkMongoDB() error {
 }
 
 func (cH *CheckUtils) checkEachSecurityTest(configAPI *apiContext.APIConfig) error {
-	securityTests := []string{"enry", "gosec", "brakeman", "bandit", "npmaudit", "safety"}
+	securityTests := []string{"enry", "gitauthors", "gosec", "brakeman", "bandit", "npmaudit", "safety"}
 	for _, securityTest := range securityTests {
 		if err := checkSecurityTest(securityTest, configAPI); err != nil {
 			errMsg := fmt.Sprintf("%s %s", securityTest, err)
@@ -172,6 +172,8 @@ func checkSecurityTest(securityTestName string, configAPI *apiContext.APIConfig)
 	switch securityTestName {
 	case "enry":
 		securityTestConfig = *configAPI.EnrySecurityTest
+	case "gitauthors":
+		securityTestConfig = *configAPI.GitAuthorsSecurityTest
 	case "gosec":
 		securityTestConfig = *configAPI.GosecSecurityTest
 	case "brakeman":

--- a/deployments/dockerfiles/gitauthors/Dockerfile
+++ b/deployments/dockerfiles/gitauthors/Dockerfile
@@ -1,0 +1,7 @@
+# Dockerfile used to create "husyci/gitauthors" image
+# https://hub.docker.com/r/huskyci/gitauthors/
+
+FROM alpine:3.8
+
+RUN apk update && apk upgrade \
+	&& apk add --update --no-cache git openssh-client


### PR DESCRIPTION
## Closes #286 

This PR will: 

* Add `WaitContainer` into docker flow to proper handle empty `cOutput`.
* Set `FinalOutput` as `gosecOutput` to avoid segmentation violaion bugs.
* Add GitAuthors into Analysis Struct by adding a new generic securityTest

![image](https://user-images.githubusercontent.com/8943477/63644885-269c1480-c6c9-11e9-8ae8-fa8be1919c3b.png)

