### PR TITLE
Add #nohusky tag to Bandit security test

### DIFF
--- a/api/securitytest/run.go
+++ b/api/securitytest/run.go
@@ -132,6 +132,21 @@ func (results *RunAllInfo) setVulns(securityTestScan SecTestScanInfo) {
 			results.HuskyCIResults.JavaScriptResults.HuskyCINpmAuditOutput.LowVulns = append(results.HuskyCIResults.JavaScriptResults.HuskyCINpmAuditOutput.LowVulns, lowVuln)
 		}
 	}
+
+	for _, noSec := range securityTestScan.Vulnerabilities.NoSecVulns {
+		switch securityTestScan.SecurityTestName {
+		case "bandit":
+			results.HuskyCIResults.PythonResults.HuskyCIBanditOutput.NoSecVulns = append(results.HuskyCIResults.PythonResults.HuskyCIBanditOutput.NoSecVulns, noSec)
+		case "brakeman":
+			results.HuskyCIResults.RubyResults.HuskyCIBrakemanOutput.NoSecVulns = append(results.HuskyCIResults.RubyResults.HuskyCIBrakemanOutput.NoSecVulns, noSec)
+		case "safety":
+			results.HuskyCIResults.PythonResults.HuskyCISafetyOutput.NoSecVulns = append(results.HuskyCIResults.PythonResults.HuskyCISafetyOutput.NoSecVulns, noSec)
+		case "gosec":
+			results.HuskyCIResults.GoResults.HuskyCIGosecOutput.NoSecVulns = append(results.HuskyCIResults.GoResults.HuskyCIGosecOutput.LowVulns, noSec)
+		case "npmaudit":
+			results.HuskyCIResults.JavaScriptResults.HuskyCINpmAuditOutput.NoSecVulns = append(results.HuskyCIResults.JavaScriptResults.HuskyCINpmAuditOutput.NoSecVulns, noSec)
+		}
+	}
 }
 
 func (results *RunAllInfo) setToAnalysis() {

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -125,6 +125,7 @@ type RubyResults struct {
 
 // HuskyCISecurityTestOutput stores all Low, Medium and High vulnerabilities for a sec test
 type HuskyCISecurityTestOutput struct {
+	NoSecVulns  []HuskyCIVulnerability `bson:"nosecvulns,omitempty" json:"nosecvulns,omitempty"`
 	LowVulns    []HuskyCIVulnerability `bson:"lowvulns,omitempty" json:"lowvulns,omitempty"`
 	MediumVulns []HuskyCIVulnerability `bson:"mediumvulns,omitempty" json:"mediumvulns,omitempty"`
 	HighVulns   []HuskyCIVulnerability `bson:"highvulns,omitempty" json:"highvulns,omitempty"`

--- a/api/util/util.go
+++ b/api/util/util.go
@@ -178,3 +178,14 @@ func AdjustWarningMessage(warningRaw string) string {
 
 	return warningRaw
 }
+
+// CountDigits returns the number of digits in an integer.
+func CountDigits(i int) int {
+	count := 0
+	for i != 0 {
+		i /= 10
+		count = count + 1
+	}
+
+	return count
+}

--- a/api/util/util_test.go
+++ b/api/util/util_test.go
@@ -144,4 +144,26 @@ Line4`
 			})
 		})
 	})
+
+	Describe("CountDigits", func() {
+
+		rawSliceInteger := []int{-1, 0, 10}
+		expected := []int{0, 1, 2}
+
+		Context("When rawSliceInteger is greater than zero", func() {
+			It("Should return the expected integer.", func() {
+				Expect(util.CountDigits(rawSliceInteger[2])).To(Equal(expected[2]))
+			})
+		})
+		Context("When rawSliceInteger is less than zero", func() {
+			It("Should return the expected integer.", func() {
+				Expect(util.CountDigits(rawSliceInteger[0])).To(Equal(expected[1]))
+			})
+		})
+		Context("When rawSliceInteger is zero", func() {
+			It("Should return the expected integer.", func() {
+				Expect(util.CountDigits(rawSliceInteger[1])).To(Equal(expected[0]))
+			})
+		})
+	})
 })

--- a/client/analysis/output.go
+++ b/client/analysis/output.go
@@ -58,7 +58,7 @@ func printSTDOUTOutput() {
 
 // prepareAllSummary prepares how many low, medium and high vulnerabilites were found.
 func prepareAllSummary(analysis types.Analysis) {
-	var totalLow, totalMedium, totalHigh int
+	var totalNoSec, totalLow, totalMedium, totalHigh int
 
 	outputJSON.GoResults = analysis.HuskyCIResults.GoResults
 	outputJSON.JavaScriptResults = analysis.HuskyCIResults.JavaScriptResults
@@ -77,6 +77,7 @@ func prepareAllSummary(analysis types.Analysis) {
 	}
 
 	// Bandit summary
+	outputJSON.Summary.BanditSummary.NoSecVuln = len(outputJSON.PythonResults.HuskyCIBanditOutput.NoSecVulns)
 	outputJSON.Summary.BanditSummary.LowVuln = len(outputJSON.PythonResults.HuskyCIBanditOutput.LowVulns)
 	outputJSON.Summary.BanditSummary.MediumVuln = len(outputJSON.PythonResults.HuskyCIBanditOutput.MediumVulns)
 	outputJSON.Summary.BanditSummary.HighVuln = len(outputJSON.PythonResults.HuskyCIBanditOutput.HighVulns)
@@ -129,6 +130,7 @@ func prepareAllSummary(analysis types.Analysis) {
 		types.FoundInfo = true
 	}
 
+	totalNoSec = outputJSON.Summary.BanditSummary.NoSecVuln
 	totalLow = outputJSON.Summary.BrakemanSummary.LowVuln + outputJSON.Summary.SafetySummary.LowVuln + outputJSON.Summary.BanditSummary.LowVuln + outputJSON.Summary.GosecSummary.LowVuln + outputJSON.Summary.NpmAuditSummary.LowVuln
 	totalMedium = outputJSON.Summary.BrakemanSummary.MediumVuln + outputJSON.Summary.SafetySummary.MediumVuln + outputJSON.Summary.BanditSummary.MediumVuln + outputJSON.Summary.GosecSummary.MediumVuln + outputJSON.Summary.NpmAuditSummary.MediumVuln
 	totalHigh = outputJSON.Summary.BrakemanSummary.HighVuln + outputJSON.Summary.SafetySummary.HighVuln + outputJSON.Summary.BanditSummary.HighVuln + outputJSON.Summary.GosecSummary.HighVuln + outputJSON.Summary.NpmAuditSummary.HighVuln
@@ -136,6 +138,7 @@ func prepareAllSummary(analysis types.Analysis) {
 	outputJSON.Summary.TotalSummary.HighVuln = totalHigh
 	outputJSON.Summary.TotalSummary.MediumVuln = totalMedium
 	outputJSON.Summary.TotalSummary.LowVuln = totalLow
+	outputJSON.Summary.TotalSummary.NoSecVuln = totalNoSec
 
 }
 
@@ -155,6 +158,7 @@ func printAllSummary() {
 		fmt.Printf("[HUSKYCI][SUMMARY] High: %d\n", outputJSON.Summary.BanditSummary.HighVuln)
 		fmt.Printf("[HUSKYCI][SUMMARY] Medium: %d\n", outputJSON.Summary.BanditSummary.MediumVuln)
 		fmt.Printf("[HUSKYCI][SUMMARY] Low: %d\n", outputJSON.Summary.BanditSummary.LowVuln)
+		fmt.Printf("[HUSKYCI][SUMMARY] NoSecHusky: %d\n", outputJSON.Summary.BanditSummary.NoSecVuln)
 	}
 
 	if outputJSON.Summary.SafetySummary.FoundVuln || outputJSON.Summary.SafetySummary.FoundInfo {
@@ -187,6 +191,7 @@ func printAllSummary() {
 		fmt.Printf("[HUSKYCI][SUMMARY] High: %d\n", outputJSON.Summary.TotalSummary.HighVuln)
 		fmt.Printf("[HUSKYCI][SUMMARY] Medium: %d\n", outputJSON.Summary.TotalSummary.MediumVuln)
 		fmt.Printf("[HUSKYCI][SUMMARY] Low: %d\n", outputJSON.Summary.TotalSummary.LowVuln)
+		fmt.Printf("[HUSKYCI][SUMMARY] NoSecHusky: %d\n", outputJSON.Summary.TotalSummary.NoSecVuln)
 	}
 
 	fmt.Println()

--- a/client/types/types.go
+++ b/client/types/types.go
@@ -126,6 +126,7 @@ type RubyResults struct {
 
 // HuskyCISecurityTestOutput stores all Low, Medium and High vulnerabilities for a sec test
 type HuskyCISecurityTestOutput struct {
+	NoSecVulns  []HuskyCIVulnerability `bson:"nosecvulns,omitempty" json:"nosecvulns,omitempty"`
 	LowVulns    []HuskyCIVulnerability `bson:"lowvulns,omitempty" json:"lowvulns,omitempty"`
 	MediumVulns []HuskyCIVulnerability `bson:"mediumvulns,omitempty" json:"mediumvulns,omitempty"`
 	HighVulns   []HuskyCIVulnerability `bson:"highvulns,omitempty" json:"highvulns,omitempty"`
@@ -148,6 +149,7 @@ type Summary struct {
 type HuskyCISummary struct {
 	FoundVuln  bool `json:"foundvuln,omitempty"`
 	FoundInfo  bool `json:"foundinfo,omitempty"`
+	NoSecVuln  int  `json:"nosecvuln,omitempty"`
 	LowVuln    int  `json:"lowvuln,omitempty"`
 	MediumVuln int  `json:"mediumvuln,omitempty"`
 	HighVuln   int  `json:"highvuln,omitempty"`


### PR DESCRIPTION
## Closes #339 

This PR aims to add the `#nohusky` tag to avoid huskyCI from outputting a line of code as a vulnerability. Note that it should only be used when the developer is sure that the security tool, in this case, Bandit, is producing false-positive results.

### Changes:
#### API:
* `api/securitytest/bandit.go`: Adds logic to search for `#nohusky` in the tool's result.
* `api/securitytest/run.go`: Appends `nosec` results so it gets written in the database.
* `api/types/types.go`: Add new `nosec` type.
* `api/util/util.go`: Add method to count digits in a given number.
* `api/util/util_test.go`: Add test to `CountDigits` method.

#### Client:
* `client/analysis/output.go`: Add logic to display `nosec` on hukyCI's output.
* `client/types/types.go`: Add new `nosec` type.