### PR TITLE
Add huskyCI API stats routes

### DIFF
--- a/api/db/huskystats.go
+++ b/api/db/huskystats.go
@@ -1,0 +1,212 @@
+// Copyright 2019 Globo.com authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package db
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	mongoHuskyCI "github.com/globocom/huskyCI/api/db/mongo"
+	"github.com/globocom/huskyCI/api/util"
+	"gopkg.in/mgo.v2/bson"
+)
+
+var runCountAggregations = map[string]interface{}{
+	"today":      generateTBAggr(-1, 0),
+	"yesterday":  generateTBAggr(-2, -1),
+	"last7days":  generateTBAggr(-7, 0),
+	"last30days": generateTBAggr(-30, 0),
+}
+
+// AnalysisCountMetric returns predefined stats about huskyCI runs.
+func AnalysisCountMetric(timeRange string) (interface{}, error) {
+	if !validTimeRange(timeRange) {
+		return nil, errors.New("invalid time_range type")
+	}
+	aggr := runCountAggregations[timeRange].([]bson.M)
+	return mongoHuskyCI.Conn.Aggregation(aggr, mongoHuskyCI.AnalysisCollection)
+}
+
+// LanguageCountMetric returns the counter for each language scanned.
+func LanguageCountMetric() (interface{}, error) {
+	return mongoHuskyCI.Conn.Aggregation(generateSimpleAggr("codes", "language", "codes.language"), mongoHuskyCI.AnalysisCollection)
+}
+
+// RepositoryCountMetric returns the counter for each repository scanned.
+func RepositoryCountMetric() (interface{}, error) {
+	var repositoryCountAggr = []bson.M{
+		bson.M{
+			"$match": bson.M{
+				"repositoryURL": bson.M{
+					"$exists": true,
+				},
+			},
+		},
+		bson.M{
+			"$match": bson.M{
+				"repositoryBranch": bson.M{
+					"$exists": true,
+				},
+			},
+		},
+		bson.M{
+			"$group": bson.M{
+				"_id": bson.M{
+					"repositoryBranch": "$repositoryBranch",
+					"repositoryURL":    "$repositoryURL",
+				},
+			},
+		},
+		bson.M{
+			"$group": bson.M{
+				"_id": bson.M{
+					"repositoryURL": "$_id.repositoryURL",
+				},
+				"branches": bson.M{
+					"$sum": 1,
+				},
+			},
+		},
+		bson.M{
+			"$group": bson.M{
+				"_id": "repositories",
+				"totalBranches": bson.M{
+					"$sum": "$branches",
+				},
+				"totalRepositories": bson.M{
+					"$sum": 1,
+				},
+			},
+		},
+	}
+	return mongoHuskyCI.Conn.Aggregation(repositoryCountAggr, mongoHuskyCI.AnalysisCollection)
+}
+
+// AuthorCountMetric returns the counter for each author from repositories scanned.
+func AuthorCountMetric() (interface{}, error) {
+	var AuthorCountAggr = []bson.M{
+		bson.M{
+			"$project": bson.M{
+				"commitAuthors": 1,
+			},
+		},
+		bson.M{
+			"$unwind": "$commitAuthors",
+		},
+		bson.M{
+			"$group": bson.M{
+				"_id": "$commitAuthors",
+			},
+		},
+		bson.M{
+			"$group": bson.M{
+				"_id": "commitAuthors",
+				"totalAuthors": bson.M{
+					"$sum": 1,
+				},
+			},
+		},
+	}
+	return mongoHuskyCI.Conn.Aggregation(AuthorCountAggr, mongoHuskyCI.AnalysisCollection)
+}
+
+// ContainerCountMetric returns the counter for each container deployed.
+func ContainerCountMetric() (interface{}, error) {
+	return mongoHuskyCI.Conn.Aggregation(generateSimpleAggr("containers", "container", "containers.securityTest.name"), mongoHuskyCI.AnalysisCollection)
+}
+
+// validTimeRange returns if a user inputted type is valid.
+func validTimeRange(timeRange string) bool {
+	for tRange := range runCountAggregations {
+		if timeRange == tRange {
+			return true
+		}
+	}
+	return false
+}
+
+// generateSimpleAggr generates an aggregation that counts each field group.
+func generateSimpleAggr(field, finalName, groupID string) []bson.M {
+	return []bson.M{
+		bson.M{
+			"$project": bson.M{
+				field: 1,
+			},
+		},
+		bson.M{
+			"$unwind": fmt.Sprintf("$%s", field),
+		},
+		bson.M{
+			"$group": bson.M{
+				"_id": fmt.Sprintf("$%s", groupID),
+				"count": bson.M{
+					"$sum": 1,
+				},
+			},
+		},
+		bson.M{
+			"$project": bson.M{
+				finalName: "$_id",
+				"count":   1,
+			},
+		},
+	}
+}
+
+// generateTBAggr generates a time based aggregation in the given time range in days.
+func generateCountAggr(field, groupID string) []bson.M {
+	return []bson.M{
+		bson.M{
+			"$project": bson.M{
+				field: 1,
+			},
+		},
+		bson.M{
+			"$match": bson.M{
+				field: bson.M{
+					"$exists": true,
+				},
+			},
+		},
+		bson.M{
+			"$group": bson.M{
+				"_id": groupID,
+				"count": bson.M{
+					"$sum": bson.M{
+						"$size": fmt.Sprintf("$%s", field),
+					},
+				},
+			},
+		},
+	}
+}
+
+// generateTBAggr generates a time based aggregation in the given time range in days.
+func generateTBAggr(rangeInitDays, rangeEndDays int) []bson.M {
+	return []bson.M{
+		bson.M{
+			"$match": bson.M{
+				"finishedAt": bson.M{
+					"$gte": util.BeginningOfTheDay(time.Now().AddDate(0, 0, rangeInitDays)),
+					"$lte": util.EndOfTheDay(time.Now().AddDate(0, 0, rangeEndDays)),
+				},
+			},
+		}, bson.M{
+			"$group": bson.M{
+				"_id": "$result",
+				"count": bson.M{
+					"$sum": 1,
+				},
+			},
+		},
+		bson.M{
+			"$project": bson.M{
+				"count":  1,
+				"result": "$_id",
+			},
+		},
+	}
+}

--- a/api/db/mongo/mongo.go
+++ b/api/db/mongo/mongo.go
@@ -149,6 +149,20 @@ func (db *DB) Search(query bson.M, selectors []string, collection string, obj in
 	return err
 }
 
+// Aggregation prepares a pipeline to aggregate.
+func (db *DB) Aggregation(aggregation []bson.M, collection string) (interface{}, error) {
+	session := db.Session.Clone()
+	defer session.Close()
+	c := session.DB("").C(collection)
+
+	pipe := c.Pipe(aggregation)
+	resp := []bson.M{}
+	iter := pipe.Iter()
+	err := iter.All(&resp)
+
+	return resp, err
+}
+
 // SearchOne searchs for the first element that matchs with the given query.
 func (db *DB) SearchOne(query bson.M, selectors []string, collection string, obj interface{}) error {
 	session := db.Session.Clone()

--- a/api/log/messagecodes.go
+++ b/api/log/messagecodes.go
@@ -30,7 +30,8 @@ var MsgCode = map[int]string{
 	108: "Received an invalid security Test JSON: ",
 	109: "The following security test is already in MongoDB: ",
 	110: "The following repository is already in MongoDB: ",
-	111: "Invalid user input for AnalysisCount time range: ",
+	111: "Invalid user input for time range query string parameter: ",
+	112: "Invalid user input for metric type: ",
 
 	// HuskyCI API errors
 	1001: "Error(s) found when starting HuskyCI API: ",
@@ -98,7 +99,7 @@ var MsgCode = map[int]string{
 	2014: "Could not find an analysis using the following RID: ",
 	2015: "Could not create a new repository: ",
 	2016: "Could not create a new securityTest: ",
-	2017: "Error running the following MongoDB aggregation: ",
+	2017: "Error running the MongoDB aggregation for the following metric: ",
 
 	// Docker API info
 	31: "Waiting pull image...",

--- a/api/log/messagecodes.go
+++ b/api/log/messagecodes.go
@@ -30,6 +30,7 @@ var MsgCode = map[int]string{
 	108: "Received an invalid security Test JSON: ",
 	109: "The following security test is already in MongoDB: ",
 	110: "The following repository is already in MongoDB: ",
+	111: "Invalid user input for AnalysisCount time range: ",
 
 	// HuskyCI API errors
 	1001: "Error(s) found when starting HuskyCI API: ",
@@ -97,6 +98,7 @@ var MsgCode = map[int]string{
 	2014: "Could not find an analysis using the following RID: ",
 	2015: "Could not create a new repository: ",
 	2016: "Could not create a new securityTest: ",
+	2017: "Error running the following MongoDB aggregation: ",
 
 	// Docker API info
 	31: "Waiting pull image...",

--- a/api/routes/stats.go
+++ b/api/routes/stats.go
@@ -1,0 +1,76 @@
+// Copyright 2019 Globo.com authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package routes
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/globocom/huskyCI/api/db"
+	"github.com/globocom/huskyCI/api/log"
+	"github.com/labstack/echo"
+)
+
+// AnalysisCount is the endpoint that returns data about HuskyCI scans.
+func AnalysisCount(c echo.Context) error {
+	timeRange := strings.ToLower(c.Param("time_range"))
+	result, err := db.AnalysisCountMetric(timeRange)
+	if err != nil {
+		if err == errors.New("invalid time_range type") {
+			log.Warning("AnalysisCount", "STATS", 111, err, timeRange)
+			reply := map[string]interface{}{"success": false, "error": "invalid time_range type"}
+			return c.JSON(http.StatusBadRequest, reply)
+		}
+		log.Error("AnalysisCount", "STATS", 2017, "AnalysisCount", err)
+		reply := map[string]interface{}{"success": false, "error": "internal error"}
+		return c.JSON(http.StatusInternalServerError, reply)
+	}
+	return c.JSON(http.StatusOK, result)
+}
+
+// LanguageCount is the endpoint that returns the counter for each language scanned.
+func LanguageCount(c echo.Context) error {
+	result, err := db.LanguageCountMetric()
+	if err != nil {
+		log.Error("LanguageCount", "STATS", 2017, "LanguageCount", err)
+		reply := map[string]interface{}{"success": false, "error": "internal error"}
+		return c.JSON(http.StatusInternalServerError, reply)
+	}
+	return c.JSON(http.StatusOK, result)
+}
+
+// RepositoryCount is the endpoint that returns the counter for each repository scanned.
+func RepositoryCount(c echo.Context) error {
+	result, err := db.RepositoryCountMetric()
+	if err != nil {
+		log.Error("RepositoryCount", "STATS", 2017, "RepositoryCount", err)
+		reply := map[string]interface{}{"success": false, "error": "internal error"}
+		return c.JSON(http.StatusInternalServerError, reply)
+	}
+	return c.JSON(http.StatusOK, result)
+}
+
+// AuthorCount is the endpoint that returns the counter for each author from repositories scanned.
+func AuthorCount(c echo.Context) error {
+	result, err := db.AuthorCountMetric()
+	if err != nil {
+		log.Error("AuthorCount", "STATS", 2017, "AuthorCount", err)
+		reply := map[string]interface{}{"success": false, "error": "internal error"}
+		return c.JSON(http.StatusInternalServerError, reply)
+	}
+	return c.JSON(http.StatusOK, result)
+}
+
+// ContainerCount is the endpoint that returns the counter for each container deployed.
+func ContainerCount(c echo.Context) error {
+	result, err := db.ContainerCountMetric()
+	if err != nil {
+		log.Error("ContainerCount", "STATS", 2017, "ContainerCount", err)
+		reply := map[string]interface{}{"success": false, "error": "internal error"}
+		return c.JSON(http.StatusInternalServerError, reply)
+	}
+	return c.JSON(http.StatusOK, result)
+}

--- a/api/server.go
+++ b/api/server.go
@@ -69,11 +69,7 @@ func main() {
 	// echoInstance.DELETE("/analysis/:id", routes.DeleteAnalysis)
 
 	// stats routes
-	echoInstance.GET("/stats/analysis_count/:time_range", routes.AnalysisCount)
-	echoInstance.GET("/stats/language_count", routes.LanguageCount)
-	echoInstance.GET("/stats/repository_count", routes.RepositoryCount)
-	echoInstance.GET("/stats/author_count", routes.AuthorCount)
-	echoInstance.GET("/stats/container_count", routes.ContainerCount)
+	echoInstance.GET("/stats/:metric_type", routes.GetMetric)
 
 	// securityTest routes
 	// echoInstance.GET("securityTest/:securityTestName", routes.GetSecurityTest)

--- a/api/server.go
+++ b/api/server.go
@@ -68,6 +68,13 @@ func main() {
 	// echoInstance.PUT("/analysis/:id", routes.UpdateAnalysis)
 	// echoInstance.DELETE("/analysis/:id", routes.DeleteAnalysis)
 
+	// stats routes
+	echoInstance.GET("/stats/analysis_count/:time_range", routes.AnalysisCount)
+	echoInstance.GET("/stats/language_count", routes.LanguageCount)
+	echoInstance.GET("/stats/repository_count", routes.RepositoryCount)
+	echoInstance.GET("/stats/author_count", routes.AuthorCount)
+	echoInstance.GET("/stats/container_count", routes.ContainerCount)
+
 	// securityTest routes
 	// echoInstance.GET("securityTest/:securityTestName", routes.GetSecurityTest)
 	// echoInstance.POST("/securitytest", routes.CreateNewSecurityTest)

--- a/api/util/util.go
+++ b/api/util/util.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"time"
 
 	"errors"
 	"fmt"
@@ -177,4 +178,16 @@ func AdjustWarningMessage(warningRaw string) string {
 	}
 
 	return warningRaw
+}
+
+// EndOfTheDay returns the the time at the end of the day t.
+func EndOfTheDay(t time.Time) time.Time {
+	year, month, day := t.Date()
+	return time.Date(year, month, day, 23, 59, 59, 0, t.Location())
+}
+
+// BeginningOfTheDay returns the the time at the beginning of the day t.
+func BeginningOfTheDay(t time.Time) time.Time {
+	year, month, day := t.Date()
+	return time.Date(year, month, day, 0, 0, 0, 0, t.Location())
 }

--- a/api/util/util.go
+++ b/api/util/util.go
@@ -220,3 +220,13 @@ func VerifyNoHusky(code string, lineNumber int, securityTool string) bool {
 	}
 	return false
 }
+
+// SliceContains returns true if a given value is present on the given slice
+func SliceContains(slice []string, str string) bool {
+	for _, value := range slice {
+		if value == str {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Closes #337 

This PR adds `/stats/:metric?time_rage=:period` route to extract stats about huskyCI usage. If `time_range` is empty, the default value is retrieving data since the beginning. 

The `metric` options are: 

* `analysis`: Returns the number of analyses made in the given time range grouped by status (result)
* `language`: Returns the total number of languages verified (and how many times).
* `repository`:  Returns the distinct count of repositories and branches verified.
* `author`: Returns the distinct count of commit authors.
* `container`: Returns the total count of each container used grouped by type (bandit, gosec, brakeman, etc.).

The `period` options are: 

* `today`
* `yesterday`
* `last7days`
* `last30days`

Examples: 

 - /stats/analysis?time_range=today: 
    ```[{"_id":"failed","count":2,"result":"failed"}]```

 - /stats/analysis?time_range=last30days: 
    ```[{"_id":"failed","count":2,"result":"failed"}]```

 - /stats/language: 
    ```[{"_id":"HTML+ERB","count":1,"language":"HTML+ERB"},{"_id":"Makefile","count":1,"language":"Makefile"},{"_id":"Ruby","count":1,"language":"Ruby"},{"_id":"Go","count":1,"language":"Go"},{"_id":"CSS","count":1,"language":"CSS"},{"_id":"HTML","count":1,"language":"HTML"}]```

 - /stats/language?time_range=last7days: 
    ```[{"_id":"HTML+ERB","count":1,"language":"HTML+ERB"},{"_id":"Makefile","count":1,"language":"Makefile"},{"_id":"Ruby","count":1,"language":"Ruby"},{"_id":"Go","count":1,"language":"Go"},{"_id":"CSS","count":1,"language":"CSS"},{"_id":"HTML","count":1,"language":"HTML"}]```

 - /stats/language?time_range=yesterday: 
    ```[]```

 - /stats/language?time_range=dontExist:
    ```{"error":"internal error","success":false}```

 - /stats/repository:
    ```[{"_id":"repositories","totalBranches":2,"totalRepositories":1}]```

 - /stats/author:
    ```[{"_id":"commitAuthors","totalAuthors":2}]```

 - /stats/container:
    ```[{"_id":"brakeman","container":"brakeman","count":1},{"_id":"gosec","container":"gosec","count":1},{"_id":"gitauthors","container":"gitauthors","count":2}]```