### PR TITLE
Replace "success" to "passed" into cResult

### DIFF
--- a/api/securitytest/run.go
+++ b/api/securitytest/run.go
@@ -152,7 +152,7 @@ func (results *RunAllInfo) setVulns(securityTestScan SecTestScanInfo) {
 func (results *RunAllInfo) setToAnalysis() {
 
 	results.Status = "finished"
-	results.FinalResult = "success"
+	results.FinalResult = "passed"
 
 	if results.ErrorFound != nil {
 		results.Status = "error running"

--- a/api/securitytest/securitytest.go
+++ b/api/securitytest/securitytest.go
@@ -105,7 +105,7 @@ func (scanInfo *SecTestScanInfo) prepareContainerAfterScan() {
 
 	scanInfo.Container.FinishedAt = time.Now()
 	scanInfo.Container.CInfo = "No issues found."
-	scanInfo.Container.CResult = "success"
+	scanInfo.Container.CResult = "passed"
 	scanInfo.Container.CStatus = "finished"
 
 	if scanInfo.ErrorFound != nil {
@@ -129,7 +129,6 @@ func (scanInfo *SecTestScanInfo) prepareContainerAfterScan() {
 
 	if scanInfo.CommitAuthorsNotFound {
 		scanInfo.Container.CInfo = "Could not get authors. Probably master branch is being analyzed."
-		scanInfo.Container.CResult = "warning"
 		return
 	}
 


### PR DESCRIPTION
This PR will also remove `warning` when `gitAuthor` securityTest runs in the master branch.