### PR TITLE
Fix HuskyCI execution should fail gracefully

### DIFF
--- a/api/config.yaml
+++ b/api/config.yaml
@@ -29,9 +29,10 @@ gitauthors:
     echo "IdentityFile ~/.ssh/huskyci_id_rsa" >> /etc/ssh/ssh_config &&
     echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config &&
     git clone %GIT_REPO% code --quiet 2> /tmp/errorGitCloneEnry
+    cd code
+    git checkout %GIT_BRANCH% --quiet
     if [ $? -eq 0 ]; then
-      cd code
-      for i in $(git log origin/master..origin/%GIT_BRANCH% --pretty="%ae" | sort -u); do
+      for i in $(git log origin/master.. --pretty="%ae" | sort -u); do
         jsonMiddle="\"$i\",$jsonMiddle"
       done
       length=${#jsonMiddle}
@@ -199,7 +200,13 @@ yarnaudit:
       cd code
       if [ -f yarn.lock ]; then
         yarn audit --json > /tmp/results.json 2> /tmp/errorYarnAudit
-        jq -c -M -j --slurp '{advisories: (. | map(select(.type == "auditAdvisory") | .data.advisory)), metadata: (. | map(select(.type == "auditSummary") | .data) | add)}' /tmp/results.json
+        if [ $? -eq 0 ]; then
+          jq -c -M -j --slurp '{advisories: (. | map(select(.type == "auditAdvisory") | .data.advisory)), metadata: (. | map(select(.type == "auditSummary") | .data) | add)}' /tmp/results.json > /tmp/output.json
+          cat /tmp/output.json
+        else
+          echo -n 'ERROR_RUNNING_YARN_AUDIT - '
+          cat /tmp/errorYarnAudit
+        fi
       else
         echo 'ERROR_YARN_LOCK_NOT_FOUND'
       fi

--- a/api/dockers/huskydocker.go
+++ b/api/dockers/huskydocker.go
@@ -66,7 +66,6 @@ func pullImage(d *Docker, image string) error {
 			timeOutErr := errors.New("timeout")
 			log.Error("pullImage", "HUSKYDOCKER", 3013, timeOutErr)
 			return timeOutErr
-		// TODO: verify if this makes sense
 		case <-retryTick:
 			log.Info("pullImage", "DOCKERRUN", 31, image)
 			if d.ImageIsLoaded(image) {

--- a/api/dockers/huskydocker.go
+++ b/api/dockers/huskydocker.go
@@ -63,9 +63,10 @@ func pullImage(d *Docker, image string) error {
 	for {
 		select {
 		case <-timeout:
-			timeOutErr := errors.New("time out")
+			timeOutErr := errors.New("timeout")
 			log.Error("pullImage", "HUSKYDOCKER", 3013, timeOutErr)
 			return timeOutErr
+		// TODO: verify if this makes sense
 		case <-retryTick:
 			log.Info("pullImage", "DOCKERRUN", 31, image)
 			if d.ImageIsLoaded(image) {

--- a/api/securitytest/run.go
+++ b/api/securitytest/run.go
@@ -162,13 +162,11 @@ func (results *RunAllInfo) runLanguageScans(enryScan SecTestScanInfo) error {
 					return
 				}
 			}
-			// if err := newLanguageScan.Start(); err == nil {
 			if err := newLanguageScan.Start(); err != nil {
 				results.Containers = append(results.Containers, newLanguageScan.Container)
 				select {
 				case <-syncChan:
 					return
-					// case errChan <- errors.New("ERRROR"):
 				case errChan <- err:
 					return
 				}

--- a/api/securitytest/securitytest.go
+++ b/api/securitytest/securitytest.go
@@ -34,6 +34,7 @@ type SecTestScanInfo struct {
 	WarningFound          bool
 	PackageNotFound       bool
 	YarnLockNotFound      bool
+	YarnErrorRunning      bool
 	CommitAuthorsNotFound bool
 	CommitAuthors         GitAuthorsOutput
 	Codes                 []Code
@@ -75,6 +76,7 @@ func (scanInfo *SecTestScanInfo) Start() error {
 		scanInfo.prepareContainerAfterScan()
 		return err
 	}
+	scanInfo.prepareContainerAfterScan()
 	return nil
 }
 

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -39,7 +39,7 @@ type Analysis struct {
 	CommitAuthors  []string       `bson:"commitAuthors" json:"commitAuthors"`
 	Status         string         `bson:"status" json:"status"`
 	Result         string         `bson:"result,omitempty" json:"result"`
-	ErrorFound     error          `bson:"errorsRunning,omitempty" json:"errorsRunning"`
+	ErrorFound     string         `bson:"errorFound,omitempty" json:"errorFound"`
 	Containers     []Container    `bson:"containers" json:"containers"`
 	StartedAt      time.Time      `bson:"startedAt" json:"startedAt"`
 	FinishedAt     time.Time      `bson:"finishedAt" json:"finishedAt"`

--- a/client/analysis/analysis.go
+++ b/client/analysis/analysis.go
@@ -133,6 +133,8 @@ func MonitorAnalysis(RID string) (types.Analysis, error) {
 			}
 			if analysis.Status == "finished" {
 				return analysis, nil
+			} else if analysis.Status == "error running" {
+				return analysis, fmt.Errorf("huskyCI encountered an error trying to execute this analysis: %v", analysis.ErrorFound)
 			}
 			if !types.IsJSONoutput {
 				fmt.Println("[HUSKYCI][!] Hold on! huskyCI is still running...")

--- a/client/types/types.go
+++ b/client/types/types.go
@@ -35,6 +35,7 @@ type Analysis struct {
 	Status         string         `bson:"status" json:"status"`
 	Result         string         `bson:"result" json:"result"`
 	Containers     []Container    `bson:"containers" json:"containers"`
+	ErrorFound     string         `bson:"errorFound" json:"errorFound"`
 	StartedAt      time.Time      `bson:"startedAt" json:"startedAt"`
 	FinishedAt     time.Time      `bson:"finishedAt" json:"finishedAt"`
 	Codes          []Code         `bson:"codes" json:"codes"`


### PR DESCRIPTION
This PR aims to permit huskyCI to fail gracefully. The first error generated during any container execution now should be properly stored in the database and update the analysis status.

Errors held analyses in a running state and were preventing new analyses (the same repository and branch) from executing.