### PR TITLE
Remove container from Docker API when it finishes

### DIFF
--- a/api/dockers/huskydocker.go
+++ b/api/dockers/huskydocker.go
@@ -42,16 +42,24 @@ func DockerRun(containerImage, cmd string, timeOutInSeconds int) (string, string
 	}
 	log.Info("DockerRun", "HUSKYDOCKER", 32, containerImage, d.CID)
 
-	// step 5: read container's output when it finishes
+	// step 5: wait container finish
 	if err := d.WaitContainer(timeOutInSeconds); err != nil {
 		log.Error("DockerRun", "HUSKYDOCKER", 3016, err)
 		return "", "", err
 	}
+
+	// step 6: read container's output when it finishes
 	cOutput, err := d.ReadOutput()
 	if err != nil {
 		return "", "", err
 	}
 	log.Info("DockerRun", "HUSKYDOCKER", 34, containerImage, d.CID)
+
+	// step 7: remove container from docker API
+	if err := d.RemoveContainer(); err != nil {
+		log.Error("DockerRun", "HUSKYDOCKER", 3027, err)
+		return "", "", err
+	}
 
 	return CID, cOutput, nil
 }

--- a/api/log/messagecodes.go
+++ b/api/log/messagecodes.go
@@ -139,6 +139,7 @@ var MsgCode = map[int]string{
 	3024: "Could not call die containers: ",
 	3025: "Could not update listed containers: ",
 	3026: "Could not initialize default configurations: ",
+	3027: "Could not remove container via huskyCI: ",
 
 	// Util package errors
 	4001: "Could not read certificate file: ",


### PR DESCRIPTION
This PR will add a new step into the `DockerRun` function to remove the container from Docker API after is finishes.

By doing so, huskyCI Docker API won't need to store tons of data from each container anymore.  