### PR TITLE
Add configuration to set securityTest's containers tag

### DIFF
--- a/api/config.yaml
+++ b/api/config.yaml
@@ -1,6 +1,7 @@
 enry:
   name: enry
   image: huskyci/enry
+  imageTag: dev-6ccf0b6
   cmd: |+
     mkdir -p ~/.ssh &&
     echo 'GIT_PRIVATE_SSH_KEY' > ~/.ssh/huskyci_id_rsa &&
@@ -22,6 +23,7 @@ enry:
 gitauthors:
   name: gitauthors
   image: huskyci/gitauthors
+  imageTag: "2.18.1"
   cmd: |+
     mkdir -p ~/.ssh &&
     echo 'GIT_PRIVATE_SSH_KEY' > ~/.ssh/huskyci_id_rsa &&
@@ -50,6 +52,7 @@ gitauthors:
 gosec:
   name: gosec
   image: huskyci/gosec
+  imageTag: "2.0.0"
   cmd: |+
     mkdir -p ~/.ssh &&
     echo 'GIT_PRIVATE_SSH_KEY' > ~/.ssh/huskyci_id_rsa &&
@@ -75,6 +78,7 @@ gosec:
 bandit:
   name: bandit
   image: huskyci/bandit
+  imageTag: "1.6.0"
   cmd: |+
      mkdir -p ~/.ssh &&
      echo 'GIT_PRIVATE_SSH_KEY' > ~/.ssh/huskyci_id_rsa &&
@@ -98,6 +102,7 @@ bandit:
 brakeman:
   name: brakeman
   image: huskyci/brakeman
+  imageTag: "4.5.1"
   cmd: |+
     mkdir -p ~/.ssh &&
     echo 'GIT_PRIVATE_SSH_KEY' > ~/.ssh/huskyci_id_rsa &&
@@ -121,6 +126,7 @@ brakeman:
 safety:
   name: safety
   image: huskyci/safety
+  imageTag: "1.8.5"
   cmd: |+
     mkdir -p ~/.ssh &&
     echo 'GIT_PRIVATE_SSH_KEY' > ~/.ssh/huskyci_id_rsa &&
@@ -162,6 +168,7 @@ safety:
 npmaudit:
   name: npmaudit
   image: huskyci/npmaudit
+  imageTag: "6.9.0"
   cmd: |+
     mkdir -p ~/.ssh &&
     echo 'GIT_PRIVATE_SSH_KEY' > ~/.ssh/huskyci_id_rsa &&
@@ -188,7 +195,8 @@ npmaudit:
 
 yarnaudit:
   name: yarnaudit
-  image: huskyci/npmaudit
+  image: huskyci/yarnaudit
+  imageTag: "6.9.0"
   cmd: |+
     mkdir -p ~/.ssh &&
     echo 'GIT_PRIVATE_SSH_KEY' > ~/.ssh/huskyci_id_rsa &&

--- a/api/context/context.go
+++ b/api/context/context.go
@@ -282,6 +282,7 @@ func (dF DefaultConfig) getSecurityTestConfig(securityTestName string) *types.Se
 	return &types.SecurityTest{
 		Name:             dF.Caller.GetStringFromConfigFile(fmt.Sprintf("%s.name", securityTestName)),
 		Image:            dF.Caller.GetStringFromConfigFile(fmt.Sprintf("%s.image", securityTestName)),
+		ImageTag:         dF.Caller.GetStringFromConfigFile(fmt.Sprintf("%s.imageTag", securityTestName)),
 		Cmd:              dF.Caller.GetStringFromConfigFile(fmt.Sprintf("%s.cmd", securityTestName)),
 		Type:             dF.Caller.GetStringFromConfigFile(fmt.Sprintf("%s.type", securityTestName)),
 		Language:         dF.Caller.GetStringFromConfigFile(fmt.Sprintf("%s.language", securityTestName)),

--- a/api/context/context_test.go
+++ b/api/context/context_test.go
@@ -355,6 +355,7 @@ var _ = Describe("Context", func() {
 					EnrySecurityTest: &types.SecurityTest{
 						Name:             fakeCaller.expectedStringFromConfig,
 						Image:            fakeCaller.expectedStringFromConfig,
+						ImageTag:         fakeCaller.expectedStringFromConfig,
 						Cmd:              fakeCaller.expectedStringFromConfig,
 						Type:             fakeCaller.expectedStringFromConfig,
 						Language:         fakeCaller.expectedStringFromConfig,
@@ -364,6 +365,7 @@ var _ = Describe("Context", func() {
 					GitAuthorsSecurityTest: &types.SecurityTest{
 						Name:             fakeCaller.expectedStringFromConfig,
 						Image:            fakeCaller.expectedStringFromConfig,
+						ImageTag:         fakeCaller.expectedStringFromConfig,
 						Cmd:              fakeCaller.expectedStringFromConfig,
 						Type:             fakeCaller.expectedStringFromConfig,
 						Language:         fakeCaller.expectedStringFromConfig,
@@ -373,6 +375,7 @@ var _ = Describe("Context", func() {
 					GosecSecurityTest: &types.SecurityTest{
 						Name:             fakeCaller.expectedStringFromConfig,
 						Image:            fakeCaller.expectedStringFromConfig,
+						ImageTag:         fakeCaller.expectedStringFromConfig,
 						Cmd:              fakeCaller.expectedStringFromConfig,
 						Type:             fakeCaller.expectedStringFromConfig,
 						Language:         fakeCaller.expectedStringFromConfig,
@@ -382,6 +385,7 @@ var _ = Describe("Context", func() {
 					BanditSecurityTest: &types.SecurityTest{
 						Name:             fakeCaller.expectedStringFromConfig,
 						Image:            fakeCaller.expectedStringFromConfig,
+						ImageTag:         fakeCaller.expectedStringFromConfig,
 						Cmd:              fakeCaller.expectedStringFromConfig,
 						Type:             fakeCaller.expectedStringFromConfig,
 						Language:         fakeCaller.expectedStringFromConfig,
@@ -391,6 +395,7 @@ var _ = Describe("Context", func() {
 					BrakemanSecurityTest: &types.SecurityTest{
 						Name:             fakeCaller.expectedStringFromConfig,
 						Image:            fakeCaller.expectedStringFromConfig,
+						ImageTag:         fakeCaller.expectedStringFromConfig,
 						Cmd:              fakeCaller.expectedStringFromConfig,
 						Type:             fakeCaller.expectedStringFromConfig,
 						Language:         fakeCaller.expectedStringFromConfig,
@@ -400,6 +405,7 @@ var _ = Describe("Context", func() {
 					NpmAuditSecurityTest: &types.SecurityTest{
 						Name:             fakeCaller.expectedStringFromConfig,
 						Image:            fakeCaller.expectedStringFromConfig,
+						ImageTag:         fakeCaller.expectedStringFromConfig,
 						Cmd:              fakeCaller.expectedStringFromConfig,
 						Type:             fakeCaller.expectedStringFromConfig,
 						Language:         fakeCaller.expectedStringFromConfig,
@@ -409,6 +415,7 @@ var _ = Describe("Context", func() {
 					YarnAuditSecurityTest: &types.SecurityTest{
 						Name:             fakeCaller.expectedStringFromConfig,
 						Image:            fakeCaller.expectedStringFromConfig,
+						ImageTag:         fakeCaller.expectedStringFromConfig,
 						Cmd:              fakeCaller.expectedStringFromConfig,
 						Type:             fakeCaller.expectedStringFromConfig,
 						Language:         fakeCaller.expectedStringFromConfig,
@@ -418,6 +425,7 @@ var _ = Describe("Context", func() {
 					SafetySecurityTest: &types.SecurityTest{
 						Name:             fakeCaller.expectedStringFromConfig,
 						Image:            fakeCaller.expectedStringFromConfig,
+						ImageTag:         fakeCaller.expectedStringFromConfig,
 						Cmd:              fakeCaller.expectedStringFromConfig,
 						Type:             fakeCaller.expectedStringFromConfig,
 						Language:         fakeCaller.expectedStringFromConfig,

--- a/api/dockers/huskydocker.go
+++ b/api/dockers/huskydocker.go
@@ -13,7 +13,7 @@ import (
 )
 
 // DockerRun starts a new container and returns its output and an error.
-func DockerRun(containerImage, cmd string, timeOutInSeconds int) (string, string, error) {
+func DockerRun(fullContainerImage, cmd string, timeOutInSeconds int) (string, string, error) {
 
 	// step 1: create a new docker API client
 	d, err := NewDocker()
@@ -22,14 +22,14 @@ func DockerRun(containerImage, cmd string, timeOutInSeconds int) (string, string
 	}
 
 	// step 2: pull image if it is not there yet
-	if !d.ImageIsLoaded(containerImage) {
-		if err := pullImage(d, containerImage); err != nil {
+	if !d.ImageIsLoaded(fullContainerImage) {
+		if err := pullImage(d, fullContainerImage); err != nil {
 			return "", "", err
 		}
 	}
 
 	// step 3: create a new container given an image and it's cmd
-	CID, err := d.CreateContainer(containerImage, cmd)
+	CID, err := d.CreateContainer(fullContainerImage, cmd)
 	if err != nil {
 		return "", "", err
 	}
@@ -40,7 +40,7 @@ func DockerRun(containerImage, cmd string, timeOutInSeconds int) (string, string
 		log.Error("DockerRun", "HUSKYDOCKER", 3015, err)
 		return "", "", err
 	}
-	log.Info("DockerRun", "HUSKYDOCKER", 32, containerImage, d.CID)
+	log.Info("DockerRun", "HUSKYDOCKER", 32, fullContainerImage, d.CID)
 
 	// step 5: read container's output when it finishes
 	if err := d.WaitContainer(timeOutInSeconds); err != nil {
@@ -51,7 +51,7 @@ func DockerRun(containerImage, cmd string, timeOutInSeconds int) (string, string
 	if err != nil {
 		return "", "", err
 	}
-	log.Info("DockerRun", "HUSKYDOCKER", 34, containerImage, d.CID)
+	log.Info("DockerRun", "HUSKYDOCKER", 34, fullContainerImage, d.CID)
 
 	return CID, cOutput, nil
 }

--- a/api/securitytest/securitytest.go
+++ b/api/securitytest/securitytest.go
@@ -2,6 +2,7 @@ package securitytest
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -82,9 +83,11 @@ func (scanInfo *SecTestScanInfo) Start() error {
 
 func (scanInfo *SecTestScanInfo) dockerRun(timeOutInSeconds int) error {
 	image := scanInfo.Container.SecurityTest.Image
+	imageTag := scanInfo.Container.SecurityTest.ImageTag
+	fullContainerImage := fmt.Sprintf("%s:%s", image, imageTag)
 	cmd := util.HandleCmd(scanInfo.URL, scanInfo.Branch, scanInfo.Container.SecurityTest.Cmd)
 	finalCMD := util.HandlePrivateSSHKey(cmd)
-	CID, cOutput, err := huskydocker.DockerRun(image, finalCMD, timeOutInSeconds)
+	CID, cOutput, err := huskydocker.DockerRun(fullContainerImage, finalCMD, timeOutInSeconds)
 	if err != nil {
 		return err
 	}

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -23,6 +23,7 @@ type SecurityTest struct {
 	ID               bson.ObjectId `bson:"_id,omitempty"`
 	Name             string        `bson:"name" json:"name"`
 	Image            string        `bson:"image" json:"image"`
+	ImageTag         string        `bson:"imageTag" json:"imageTag"`
 	Cmd              string        `bson:"cmd" json:"cmd"`
 	Type             string        `bson:"type" json:"type"`
 	Language         string        `bson:"language" json:"language"`

--- a/client/analysis/analysis.go
+++ b/client/analysis/analysis.go
@@ -154,7 +154,7 @@ func PrintResults(formatOutput string, analysis types.Analysis) error {
 			return err
 		}
 	} else {
-		printSTDOUTOutput()
+		printSTDOUTOutput(analysis)
 	}
 
 	return nil

--- a/client/analysis/output.go
+++ b/client/analysis/output.go
@@ -26,7 +26,7 @@ func printJSONOutput() error {
 }
 
 // printSTDOUTOutput prints the analysis output in STDOUT using printfs
-func printSTDOUTOutput() {
+func printSTDOUTOutput(analysis types.Analysis) {
 
 	// gosec
 	printSTDOUTOutputGosec(outputJSON.GoResults.HuskyCIGosecOutput.LowVulns)
@@ -58,7 +58,7 @@ func printSTDOUTOutput() {
 	printSTDOUTOutputYarnAudit(outputJSON.JavaScriptResults.HuskyCIYarnAuditOutput.MediumVulns)
 	printSTDOUTOutputYarnAudit(outputJSON.JavaScriptResults.HuskyCIYarnAuditOutput.HighVulns)
 
-	printAllSummary()
+	printAllSummary(analysis)
 }
 
 // prepareAllSummary prepares how many low, medium and high vulnerabilites were found.
@@ -158,11 +158,30 @@ func prepareAllSummary(analysis types.Analysis) {
 
 }
 
-func printAllSummary() {
+func printAllSummary(analysis types.Analysis) {
+
+	var gosecVersion, banditVersion, safetyVersion, brakemanVersion, npmauditVersion, yarnauditVersion string
+
+	for _, container := range analysis.Containers {
+		switch container.SecurityTest.Name {
+		case "gosec":
+			gosecVersion = fmt.Sprintf("%s:%s", container.SecurityTest.Image, container.SecurityTest.ImageTag)
+		case "bandit":
+			banditVersion = fmt.Sprintf("%s:%s", container.SecurityTest.Image, container.SecurityTest.ImageTag)
+		case "safety":
+			safetyVersion = fmt.Sprintf("%s:%s", container.SecurityTest.Image, container.SecurityTest.ImageTag)
+		case "brakeman":
+			brakemanVersion = fmt.Sprintf("%s:%s", container.SecurityTest.Image, container.SecurityTest.ImageTag)
+		case "npmaudit":
+			npmauditVersion = fmt.Sprintf("%s:%s", container.SecurityTest.Image, container.SecurityTest.ImageTag)
+		case "yarnaudit":
+			yarnauditVersion = fmt.Sprintf("%s:%s", container.SecurityTest.Image, container.SecurityTest.ImageTag)
+		}
+	}
 
 	if outputJSON.Summary.GosecSummary.FoundVuln || outputJSON.Summary.GosecSummary.FoundInfo {
 		fmt.Println()
-		fmt.Printf("[HUSKYCI][SUMMARY] Go -> GoSec\n")
+		fmt.Printf("[HUSKYCI][SUMMARY] Go -> %s\n", gosecVersion)
 		fmt.Printf("[HUSKYCI][SUMMARY] High: %d\n", outputJSON.Summary.GosecSummary.HighVuln)
 		fmt.Printf("[HUSKYCI][SUMMARY] Medium: %d\n", outputJSON.Summary.GosecSummary.MediumVuln)
 		fmt.Printf("[HUSKYCI][SUMMARY] Low: %d\n", outputJSON.Summary.GosecSummary.LowVuln)
@@ -170,7 +189,7 @@ func printAllSummary() {
 
 	if outputJSON.Summary.BanditSummary.FoundVuln || outputJSON.Summary.BanditSummary.FoundInfo {
 		fmt.Println()
-		fmt.Printf("[HUSKYCI][SUMMARY] Python -> Bandit\n")
+		fmt.Printf("[HUSKYCI][SUMMARY] Python -> %s\n", banditVersion)
 		fmt.Printf("[HUSKYCI][SUMMARY] High: %d\n", outputJSON.Summary.BanditSummary.HighVuln)
 		fmt.Printf("[HUSKYCI][SUMMARY] Medium: %d\n", outputJSON.Summary.BanditSummary.MediumVuln)
 		fmt.Printf("[HUSKYCI][SUMMARY] Low: %d\n", outputJSON.Summary.BanditSummary.LowVuln)
@@ -179,7 +198,7 @@ func printAllSummary() {
 
 	if outputJSON.Summary.SafetySummary.FoundVuln || outputJSON.Summary.SafetySummary.FoundInfo {
 		fmt.Println()
-		fmt.Printf("[HUSKYCI][SUMMARY] Python -> Safety\n")
+		fmt.Printf("[HUSKYCI][SUMMARY] Python -> %s\n", safetyVersion)
 		fmt.Printf("[HUSKYCI][SUMMARY] High: %d\n", outputJSON.Summary.SafetySummary.HighVuln)
 		fmt.Printf("[HUSKYCI][SUMMARY] Medium: %d\n", outputJSON.Summary.SafetySummary.MediumVuln)
 		fmt.Printf("[HUSKYCI][SUMMARY] Low: %d\n", outputJSON.Summary.SafetySummary.LowVuln)
@@ -187,7 +206,7 @@ func printAllSummary() {
 
 	if outputJSON.Summary.BrakemanSummary.FoundVuln || outputJSON.Summary.BrakemanSummary.FoundInfo {
 		fmt.Println()
-		fmt.Printf("[HUSKYCI][SUMMARY] Ruby -> Brakeman\n")
+		fmt.Printf("[HUSKYCI][SUMMARY] Ruby -> %s\n", brakemanVersion)
 		fmt.Printf("[HUSKYCI][SUMMARY] High: %d\n", outputJSON.Summary.BrakemanSummary.HighVuln)
 		fmt.Printf("[HUSKYCI][SUMMARY] Medium: %d\n", outputJSON.Summary.BrakemanSummary.MediumVuln)
 		fmt.Printf("[HUSKYCI][SUMMARY] Low: %d\n", outputJSON.Summary.BrakemanSummary.LowVuln)
@@ -195,7 +214,7 @@ func printAllSummary() {
 
 	if outputJSON.Summary.NpmAuditSummary.FoundVuln || outputJSON.Summary.NpmAuditSummary.FoundInfo {
 		fmt.Println()
-		fmt.Printf("[HUSKYCI][SUMMARY] JavaScript -> Npm Audit\n")
+		fmt.Printf("[HUSKYCI][SUMMARY] JavaScript -> %s\n", npmauditVersion)
 		fmt.Printf("[HUSKYCI][SUMMARY] High: %d\n", outputJSON.Summary.NpmAuditSummary.HighVuln)
 		fmt.Printf("[HUSKYCI][SUMMARY] Medium: %d\n", outputJSON.Summary.NpmAuditSummary.MediumVuln)
 		fmt.Printf("[HUSKYCI][SUMMARY] Low: %d\n", outputJSON.Summary.NpmAuditSummary.LowVuln)
@@ -203,7 +222,7 @@ func printAllSummary() {
 
 	if outputJSON.Summary.YarnAuditSummary.FoundVuln || outputJSON.Summary.YarnAuditSummary.FoundInfo {
 		fmt.Println()
-		fmt.Printf("[HUSKYCI][SUMMARY] JavaScript -> Yarn Audit\n")
+		fmt.Printf("[HUSKYCI][SUMMARY] JavaScript -> %s\n", yarnauditVersion)
 		fmt.Printf("[HUSKYCI][SUMMARY] High: %d\n", outputJSON.Summary.YarnAuditSummary.HighVuln)
 		fmt.Printf("[HUSKYCI][SUMMARY] Medium: %d\n", outputJSON.Summary.YarnAuditSummary.MediumVuln)
 		fmt.Printf("[HUSKYCI][SUMMARY] Low: %d\n", outputJSON.Summary.YarnAuditSummary.LowVuln)

--- a/client/types/types.go
+++ b/client/types/types.go
@@ -31,7 +31,6 @@ type Analysis struct {
 	RID            string         `bson:"RID" json:"RID"`
 	URL            string         `bson:"repositoryURL" json:"repositoryURL"`
 	Branch         string         `bson:"repositoryBranch" json:"repositoryBranch"`
-	SecurityTests  []SecurityTest `bson:"securityTests" json:"securityTests"`
 	Status         string         `bson:"status" json:"status"`
 	Result         string         `bson:"result" json:"result"`
 	Containers     []Container    `bson:"containers" json:"containers"`
@@ -73,6 +72,7 @@ type SecurityTest struct {
 	ID               bson.ObjectId `bson:"_id,omitempty"`
 	Name             string        `bson:"name" json:"name"`
 	Image            string        `bson:"image" json:"image"`
+	ImageTag         string        `bson:"imageTag" json:"imageTag"`
 	Cmd              string        `bson:"cmd" json:"cmd"`
 	Language         string        `bson:"language" json:"language"`
 	Default          bool          `bson:"default" json:"default"`


### PR DESCRIPTION
## Closes #259 

This PR adds the possibility for huskyCI users to define which version of the securityTest container will be used. This config can be set at `config.yaml` file via the `imageTag` field: 

![image](https://user-images.githubusercontent.com/8943477/65378491-73a2e480-dc8f-11e9-8240-a55b229b6e1b.png)

Developers can now see which version of the securityTest tool was used to find a particular vulnerability: 

![image](https://user-images.githubusercontent.com/8943477/65378511-bbc20700-dc8f-11e9-9434-89bed3f71956.png)
