### PR TITLE
Fix yarnaudit execution and output too large

### DIFF
--- a/api/config.yaml
+++ b/api/config.yaml
@@ -206,7 +206,7 @@ yarnaudit:
     git clone -b %GIT_BRANCH% --single-branch %GIT_REPO% code --quiet 2> /tmp/errorGitCloneYarnAudit
     if [ $? -eq 0 ]; then
         cd code
-        pathLock=$(dirname "$(find . -name "yarn.lock")")
+        pathLock=$(dirname "$(find . -name 'yarn.lock')")
         if [ $? -eq 0 ]; then
             cd $pathLock
             yarn audit --json > /tmp/results.json 2> /tmp/errorYarnAudit

--- a/api/config.yaml
+++ b/api/config.yaml
@@ -205,22 +205,24 @@ yarnaudit:
     echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config &&
     git clone -b %GIT_BRANCH% --single-branch %GIT_REPO% code --quiet 2> /tmp/errorGitCloneYarnAudit
     if [ $? -eq 0 ]; then
-      cd code
-      if [ -f yarn.lock ]; then
-        yarn audit --json > /tmp/results.json 2> /tmp/errorYarnAudit
+        cd code
+        pathLock=$(dirname "$(find . -name "yarn.lock")")
         if [ $? -eq 0 ]; then
-          jq -c -M -j --slurp '{advisories: (. | map(select(.type == "auditAdvisory") | .data.advisory)), metadata: (. | map(select(.type == "auditSummary") | .data) | add)}' /tmp/results.json > /tmp/output.json
-          cat /tmp/output.json
+            cd $pathLock
+            yarn audit --json > /tmp/results.json 2> /tmp/errorYarnAudit
+            if [ ! -s /tmp/errorYarnAudit ]; then
+                jq -c -M -j --slurp '{advisories: (. | map(select(.type == "auditAdvisory") | .data.advisory)), metadata: (. | map(select(.type == "auditSummary") | .data) | add)}' /tmp/results.json > /tmp/output.json
+                cat /tmp/output.json
+            else
+                echo -n 'ERROR_RUNNING_YARN_AUDIT'
+                cat /tmp/errorYarnAudit
+            fi
         else
-          echo -n 'ERROR_RUNNING_YARN_AUDIT - '
-          cat /tmp/errorYarnAudit
+            echo 'ERROR_YARN_LOCK_NOT_FOUND'
         fi
-      else
-        echo 'ERROR_YARN_LOCK_NOT_FOUND'
-      fi
     else
-      echo "ERROR_CLONING"
-      cat /tmp/errorGitCloneYarnAudit
+        echo "ERROR_CLONING"
+        cat /tmp/errorGitCloneYarnAudit
     fi
   type: Language
   language: JavaScript

--- a/api/securitytest/securitytest.go
+++ b/api/securitytest/securitytest.go
@@ -110,10 +110,16 @@ func (scanInfo *SecTestScanInfo) analyze() error {
 
 func (scanInfo *SecTestScanInfo) prepareContainerAfterScan() {
 
+	cOutputMaxSize := 1000000
 	scanInfo.Container.FinishedAt = time.Now()
 	scanInfo.Container.CInfo = "No issues found."
 	scanInfo.Container.CResult = "passed"
 	scanInfo.Container.CStatus = "finished"
+
+	// change scanInfo.Container.COutput to prevent error writing to MongoDB
+	if len(scanInfo.Container.COutput) > cOutputMaxSize {
+		scanInfo.Container.COutput = "Container Output is too large."
+	}
 
 	if scanInfo.ErrorFound != nil {
 		scanInfo.Container.CInfo = "Error found running container"

--- a/api/securitytest/yarnaudit.go
+++ b/api/securitytest/yarnaudit.go
@@ -125,6 +125,7 @@ func (yarnAuditScan *SecTestScanInfo) prepareYarnAuditVulns() {
 		yarnauditVuln.Details = issue.Overview
 		yarnauditVuln.VunerableBelow = issue.VulnerableVersions
 		yarnauditVuln.Code = issue.ModuleName
+		yarnauditVuln.Occurrences = 1
 		for _, findings := range issue.Findings {
 			yarnauditVuln.Version = findings.Version
 		}
@@ -132,22 +133,43 @@ func (yarnAuditScan *SecTestScanInfo) prepareYarnAuditVulns() {
 		switch issue.Severity {
 		case "info":
 			yarnauditVuln.Severity = "low"
-			huskyCIyarnauditResults.LowVulns = append(huskyCIyarnauditResults.LowVulns, yarnauditVuln)
+			if !vulnListContains(huskyCIyarnauditResults.LowVulns, yarnauditVuln) {
+				huskyCIyarnauditResults.LowVulns = append(huskyCIyarnauditResults.LowVulns, yarnauditVuln)
+			}
 		case "low":
 			yarnauditVuln.Severity = "low"
-			huskyCIyarnauditResults.LowVulns = append(huskyCIyarnauditResults.LowVulns, yarnauditVuln)
+			if !vulnListContains(huskyCIyarnauditResults.LowVulns, yarnauditVuln) {
+				huskyCIyarnauditResults.LowVulns = append(huskyCIyarnauditResults.LowVulns, yarnauditVuln)
+			}
 		case "moderate":
 			yarnauditVuln.Severity = "medium"
-			huskyCIyarnauditResults.MediumVulns = append(huskyCIyarnauditResults.MediumVulns, yarnauditVuln)
+			if !vulnListContains(huskyCIyarnauditResults.MediumVulns, yarnauditVuln) {
+				huskyCIyarnauditResults.MediumVulns = append(huskyCIyarnauditResults.MediumVulns, yarnauditVuln)
+			}
 		case "high":
 			yarnauditVuln.Severity = "high"
-			huskyCIyarnauditResults.HighVulns = append(huskyCIyarnauditResults.HighVulns, yarnauditVuln)
+			if !vulnListContains(huskyCIyarnauditResults.HighVulns, yarnauditVuln) {
+				huskyCIyarnauditResults.HighVulns = append(huskyCIyarnauditResults.HighVulns, yarnauditVuln)
+			}
 		case "critical":
 			yarnauditVuln.Severity = "high"
-			huskyCIyarnauditResults.HighVulns = append(huskyCIyarnauditResults.HighVulns, yarnauditVuln)
+			if !vulnListContains(huskyCIyarnauditResults.HighVulns, yarnauditVuln) {
+				huskyCIyarnauditResults.HighVulns = append(huskyCIyarnauditResults.HighVulns, yarnauditVuln)
+			}
 		}
 
 	}
 
 	yarnAuditScan.Vulnerabilities = huskyCIyarnauditResults
+}
+
+// vulnListContains increments the occurrence counter in case a vulnerability is found again
+func vulnListContains(vulnList []types.HuskyCIVulnerability, vuln types.HuskyCIVulnerability) bool {
+	for i := range vulnList {
+		if vulnList[i].Details == vuln.Details && vulnList[i].Code == vuln.Code {
+			vulnList[i].Occurrences = vulnList[i].Occurrences + 1
+			return true
+		}
+	}
+	return false
 }

--- a/client/analysis/output.go
+++ b/client/analysis/output.go
@@ -323,5 +323,6 @@ func printSTDOUTOutputYarnAudit(issues []types.HuskyCIVulnerability) {
 			fmt.Printf("[HUSKYCI][!] Vulnerable Below: %s\n", issue.VunerableBelow)
 		}
 		fmt.Printf("[HUSKYCI][!] Details: %s\n", issue.Details)
+		fmt.Printf("[HUSKYCI][!] Occurrences: %d\n", issue.Occurrences)
 	}
 }


### PR DESCRIPTION
This PR aims to fix huskyCI's yarn audit container.

The yarn audit container now finds the `yarn.lock` file inside the project and then proceeds to change directory before executing `yarn audit --json`.

After the execution, if the output was too large, an error could occur trying to write the output to MongoDB. There is now a limit of 1 million characters in the container output if the container output is larger than that the string `Container output is too large.` is written to the MongoDB. 

In the yarn audit case, the same vulnerability can be found in multiple files. To clean up the final report we summarize each vulnerability counting the number of occurrences. This reduces the output and makes easier for the user to find what can be prioritized to fix more vulnerabilities.