### PR TITLE
Severity stats route

### DIFF
--- a/api/routes/stats.go
+++ b/api/routes/stats.go
@@ -5,7 +5,6 @@
 package routes
 
 import (
-	"errors"
 	"net/http"
 	"strings"
 
@@ -27,12 +26,12 @@ func GetMetric(c echo.Context) error {
 }
 
 func checkError(err error, metricType string) (int, map[string]interface{}) {
-	switch err {
-	case errors.New("invalid time_range query string param"):
+	switch err.Error() {
+	case "invalid time_range query string param":
 		log.Warning("GetMetric", "STATS", 111, err)
 		reply := map[string]interface{}{"success": false, "error": "invalid time_range type"}
 		return http.StatusBadRequest, reply
-	case errors.New("invalid metric type"):
+	case "invalid metric type":
 		log.Warning("GetMetric", "STATS", 112, metricType, err)
 		reply := map[string]interface{}{"success": false, "error": "invalid metric type"}
 		return http.StatusBadRequest, reply


### PR DESCRIPTION
This PR aims to add a new metric type `severity`. This new metric type will return metrics about the severity levels found by huskyCI.

```sh
curl localhost:8888/stats/severity
[{"_id":"mediumvulns","count":2,"severity":"mediumvulns"},{"_id":"lowvulns","count":1,"severity":"lowvulns"}]
```

For now, it will return the severity level as it was saved to the database ("lowvulns" instead of "low", etc.).

Bonus: fixed the error returned by the API in case the metric wasn't in our whitelist or the time_range query string parameter wasn't in our whitelist.