### PR TITLE
add a simple test to log package

### DIFF
--- a/api/log/log.go
+++ b/api/log/log.go
@@ -11,6 +11,16 @@ import (
 	apiContext "github.com/globocom/huskyCI/api/context"
 )
 
+// Logger implements the logger interface.
+// By calling InitLog, it is initialized as a glbgelf.Logger. If one wants to change that
+// and log differently (say, JSON logging for their huskyCI execution) it can be replaced
+// very easily by implementing the logger interface.
+var Logger logger
+
+type logger interface {
+	SendLog(extra map[string]interface{}, loglevel string, messages ...interface{}) error
+}
+
 // InitLog starts glbgelf logging.
 func InitLog() {
 	graylogConfig := apiContext.APIConfiguration.GraylogConfig
@@ -20,11 +30,13 @@ func InitLog() {
 	appName := graylogConfig.AppName
 	tag := graylogConfig.Tag
 	glbgelf.InitLogger(graylogAddr, appName, tag, isDev, gralogProto)
+
+	Logger = glbgelf.Logger
 }
 
 // Info sends an info type log using glbgelf.
 func Info(action, info string, msgCode int, message ...interface{}) {
-	if err := glbgelf.Logger.SendLog(map[string]interface{}{
+	if err := Logger.SendLog(map[string]interface{}{
 		"action": action,
 		"info":   info},
 		"INFO", MsgCode[msgCode], message); err != nil {
@@ -34,7 +46,7 @@ func Info(action, info string, msgCode int, message ...interface{}) {
 
 // Warning sends a warning type log using glbgelf.
 func Warning(action, info string, msgCode int, message ...interface{}) {
-	if err := glbgelf.Logger.SendLog(map[string]interface{}{
+	if err := Logger.SendLog(map[string]interface{}{
 		"action": action,
 		"info":   info},
 		"WARNING", MsgCode[msgCode], message); err != nil {
@@ -44,7 +56,7 @@ func Warning(action, info string, msgCode int, message ...interface{}) {
 
 // Error sends an error type log using glbgelf.
 func Error(action, info string, msgCode int, message ...interface{}) {
-	if err := glbgelf.Logger.SendLog(map[string]interface{}{
+	if err := Logger.SendLog(map[string]interface{}{
 		"action": action,
 		"info":   info},
 		"ERROR", MsgCode[msgCode], message); err != nil {

--- a/api/log/log_test.go
+++ b/api/log/log_test.go
@@ -1,0 +1,83 @@
+package log_test
+
+import (
+	"bufio"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/globocom/glbgelf"
+	apiContext "github.com/globocom/huskyCI/api/context"
+
+	"github.com/globocom/huskyCI/api/log"
+)
+
+func startGelfServer(t *testing.T, wg *sync.WaitGroup, msgCount int) {
+	defer wg.Done()
+
+	// set apiContext vars
+	listener, err := net.Listen("tcp", ":12201")
+	if err != nil {
+		t.Errorf("expected to listening server, but failed: %s", err)
+		return
+	}
+	// We could use ExampleInitLog, however, I think it is better if we read it from the stream.
+	conn, err := listener.Accept()
+	if err != nil {
+		t.Errorf("could not accept messages: %s", err)
+		return
+	}
+	var gotMsgs int
+	conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	reader := bufio.NewReader(conn)
+	for {
+		b, err := reader.ReadByte()
+		if err != nil {
+			t.Errorf("could not read bytes from conn: %s", err)
+			return
+		}
+		if b == '\u0000' { // as per gelf docs: a message is finished when it is NUL terminated
+			gotMsgs++
+		}
+		if gotMsgs == msgCount {
+			break
+		}
+	}
+	if gotMsgs != msgCount {
+		t.Errorf("expected %d msgs, but got %d", msgCount, gotMsgs)
+		return
+	}
+	conn.Close()
+}
+
+func TestLog(t *testing.T) {
+	apiContext.APIConfiguration = &apiContext.APIConfig{
+		GraylogConfig: &apiContext.GraylogConfig{
+			DevelopmentEnv: false,
+			Address:        "localhost:12201",
+			Protocol:       "tcp",
+			AppName:        "log_test",
+			Tag:            "log_test",
+		},
+	}
+
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	go startGelfServer(t,
+		wg,
+		5, // logging to stdout, starting husky, logging to localhost, info, warning, error.
+	)
+	log.InitLog()
+
+	if glbgelf.Logger == nil {
+		t.Error("expected logger to be initialized, but it wasn't")
+		return
+	}
+
+	// Try to send a simple message to our mock server
+	log.Info("action", "info", 11, "infoTest")
+	log.Warning("action", "info", 101, "warnTest")
+	log.Error("action", "info", 1006, "errorTest")
+	wg.Wait()
+}


### PR DESCRIPTION
we can improve this further if we can add some kind of synchronization to log messages coming to the server, so we can be 100% sure of the order they're arriving.

this is the most simple implementation: it simply asserts how many log messages arrived, based on the methods called. this is ready to be further improved so we can read the messages as if we were a gelf server.