### PR TITLE
Added Docker Multistage Build for Gosec Image

### DIFF
--- a/deployments/dockerfiles/gosec/Dockerfile
+++ b/deployments/dockerfiles/gosec/Dockerfile
@@ -1,7 +1,4 @@
-# Dockerfile used to create "husyci/gosec" image
-# https://hub.docker.com/r/huskyci/gosec/
-
-FROM golang:alpine 
+FROM golang:alpine as builder
 
 RUN apk update && apk upgrade \
 	&& apk add --no-cache alpine-sdk git \
@@ -9,3 +6,10 @@ RUN apk update && apk upgrade \
 
 RUN go get github.com/securego/gosec/cmd/gosec/...
 
+FROM alpine:latest
+
+RUN apk --no-cache add ca-certificates
+WORKDIR /go
+
+COPY --from=builder /go/bin/gosec /go/bin/gosec
+ENV PATH=/go/bin:$PATH


### PR DESCRIPTION
This is the solution to #374 . This Dockerfile uses a [multi stage](https://docs.docker.com/develop/develop-images/multistage-build/) build to create an image that is only 15mb in size. 

```
REPOSITORY                       TAG                 IMAGE ID            CREATED             SIZE
gosec                            latest              29bf5f79107c        8 minutes ago       15MB
```