### PR TITLE
Create a smaller safety container image

### DIFF
--- a/deployments/dockerfiles/safety/Dockerfile
+++ b/deployments/dockerfiles/safety/Dockerfile
@@ -1,17 +1,25 @@
 # Dockerfile used to create "husyci/safety" image
 # https://hub.docker.com/r/huskyci/safety/
 
-FROM python:3.6-alpine
+FROM python:3.6-alpine as builder
 
+# Copy JSON Values from Safety
 COPY ./script.sh /
 RUN chmod +x /script.sh
 
-RUN apk update && apk upgrade \
-	&& apk add --no-cache alpine-sdk bash openssh-client \
-	&& apk add git
+# Install and compile safety + its dependencies
+RUN apk add --no-cache jq alpine-sdk bash openssh-client \
+    && pip install safety
 
-RUN pip3 install safety
+# Build a fresh container, copying across the compiled pieces
+FROM python:3.6-alpine
 
-RUN wget -O jq https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64
-RUN chmod +x ./jq
-RUN cp jq /usr/bin
+COPY --from=builder /usr/local/lib/python3.6 /usr/local/lib/python3.6
+COPY --from=builder /usr/local/bin/safety /usr/local/bin/safety
+
+# Copy JSON Values from Safety
+COPY ./script.sh /
+RUN chmod +x /script.sh
+
+# Add packages that we need in the final image on runtime
+RUN apk add --no-cache git jq bash openssh-client 

--- a/deployments/dockerfiles/safety/Dockerfile
+++ b/deployments/dockerfiles/safety/Dockerfile
@@ -3,10 +3,6 @@
 
 FROM python:3.6-alpine as builder
 
-# Copy JSON Values from Safety
-COPY ./script.sh /
-RUN chmod +x /script.sh
-
 # Install and compile safety + its dependencies
 RUN apk add --no-cache jq alpine-sdk bash openssh-client \
     && pip install safety


### PR DESCRIPTION
## Closes #377 

Reopening #379  because git is fucking hard and i fuck up. Hopefully this is okay.

Hello @rafaveira3 ,

by using a multi-stage build, i got the image down to 192MB. I think this is the best we can do on a python image. I applied the same principals as in #382 

This needs to be tested as i was not able to figure out the workflow for 'safety'