### PR TITLE
Avoid multiples yarn.locks file in YarnAudit Logic

### DIFF
--- a/api/config.yaml
+++ b/api/config.yaml
@@ -206,7 +206,7 @@ yarnaudit:
     git clone -b %GIT_BRANCH% --single-branch %GIT_REPO% code --quiet 2> /tmp/errorGitCloneYarnAudit
     if [ $? -eq 0 ]; then
         cd code
-        pathLock=$(dirname "$(find . -name 'yarn.lock')")
+        pathLock=$(dirname "$(find . -name 'yarn.lock' | grep -v vendor)")
         if [ $? -eq 0 ]; then
             cd $pathLock
             yarn audit --json > /tmp/results.json 2> /tmp/errorYarnAudit


### PR DESCRIPTION
This PR will avoid a bug found where a single repository has multiple `yarn.lock` files! 