### PR TITLE
Fix broken tests, client RID validation and client cert pool

### DIFF
--- a/api/util/api/api_suite_test.go
+++ b/api/util/api/api_suite_test.go
@@ -3,11 +3,31 @@ package util_test
 import (
 	"testing"
 
+	apiContext "github.com/globocom/huskyCI/api/context"
+	"github.com/globocom/huskyCI/api/log"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 func TestApi(t *testing.T) {
 	RegisterFailHandler(Fail)
+	TestInitLog(t)
 	RunSpecs(t, "Api Suite")
+}
+
+func TestInitLog(t *testing.T) {
+	apiContext.APIConfiguration = &apiContext.APIConfig{
+		GraylogConfig: &apiContext.GraylogConfig{
+			DevelopmentEnv: true,
+			AppName:        "log_test",
+			Tag:            "log_test",
+		},
+	}
+
+	log.InitLog()
+
+	if log.Logger == nil {
+		t.Error("expected logger to be initialized, but it wasn't")
+		return
+	}
 }

--- a/api/util/util.go
+++ b/api/util/util.go
@@ -153,7 +153,7 @@ func CheckMaliciousRepoBranch(repositoryBranch string, c echo.Context) error {
 
 // CheckMaliciousRID verifies if a given RID is "malicious" or not
 func CheckMaliciousRID(RID string, c echo.Context) error {
-	regexpRID := `^[a-zA-Z0-9]*$`
+	regexpRID := `^[-a-zA-Z0-9]*$`
 	valid, err := regexp.MatchString(regexpRID, RID)
 	if err != nil {
 		log.Error("GetAnalysis", "ANALYSIS", 1008, "RID regexp ", err)

--- a/client/util/util.go
+++ b/client/util/util.go
@@ -11,18 +11,14 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"strings"
-)
-
-const (
-	// ClientCertFile contains the address for the certificate which the ca certificate will be extracted
-	ClientCertFile = "/etc/ssl/cert.pem"
 )
 
 // NewClient returns an http client.
 func NewClient(httpsEnable bool) (*http.Client, error) {
-
 	if httpsEnable {
+		ClientCertFile := os.Getenv("HUSKYCI_CLIENT_CRT_PATH")
 		// Tries to find system's certificate pool
 		caCertPool, _ := x509.SystemCertPool() // #nosec - SystemCertPool tries to get local cert pool, if it fails, a new cer pool is created
 		if caCertPool == nil {

--- a/client/util/util.go
+++ b/client/util/util.go
@@ -8,18 +8,15 @@ import (
 	"bufio"
 	"crypto/tls"
 	"crypto/x509"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
-
-	"github.com/globocom/huskyCI/api/log"
 )
 
 const (
-	// CertFile contains the address for the API's TLS certificate.
-	CertFile = "api/api-tls-cert.pem"
-	// KeyFile contains the address for the API's TLS certificate key file.
-	KeyFile = "api/api-tls-key.pem"
+	// ClientCertFile contains the address for the certificate which the ca certificate will be extracted
+	ClientCertFile = "/etc/ssl/cert.pem"
 )
 
 // NewClient returns an http client.
@@ -32,12 +29,12 @@ func NewClient(httpsEnable bool) (*http.Client, error) {
 			caCertPool = x509.NewCertPool()
 		}
 
-		cert, err := ioutil.ReadFile(CertFile)
+		cert, err := ioutil.ReadFile(ClientCertFile)
 		if err != nil {
-			log.Error("NewClientTLS", "UTIL", 4001, err)
+			fmt.Println("[HUSKYCI][ERROR] Could not read certificate file: ", err)
 		}
 		if ok := caCertPool.AppendCertsFromPEM(cert); !ok {
-			log.Error("NewClientTLS", "UTIL", 4002, err)
+			fmt.Println("[HUSKYCI][ERROR] Could not append ceritificates: ", err)
 		}
 
 		tlsConfig := &tls.Config{

--- a/client/util/util.go
+++ b/client/util/util.go
@@ -8,29 +8,17 @@ import (
 	"bufio"
 	"crypto/tls"
 	"crypto/x509"
-	"fmt"
-	"io/ioutil"
 	"net/http"
-	"os"
 	"strings"
 )
 
 // NewClient returns an http client.
 func NewClient(httpsEnable bool) (*http.Client, error) {
 	if httpsEnable {
-		ClientCertFile := os.Getenv("HUSKYCI_CLIENT_CRT_PATH")
 		// Tries to find system's certificate pool
 		caCertPool, _ := x509.SystemCertPool() // #nosec - SystemCertPool tries to get local cert pool, if it fails, a new cer pool is created
 		if caCertPool == nil {
 			caCertPool = x509.NewCertPool()
-		}
-
-		cert, err := ioutil.ReadFile(ClientCertFile)
-		if err != nil {
-			fmt.Println("[HUSKYCI][ERROR] Could not read certificate file: ", err)
-		}
-		if ok := caCertPool.AppendCertsFromPEM(cert); !ok {
-			fmt.Println("[HUSKYCI][ERROR] Could not append ceritificates: ", err)
 		}
 
 		tlsConfig := &tls.Config{


### PR DESCRIPTION
This PR aims to fix broken tests and to fix the validation of the somehow changed RID pattern.

The error trying to execute analyses through HTTPS was linked to a hardcoded certfile path. I think we don't really need that configuration since this line looks sufficient:

`caCertPool, _ := x509.SystemCertPool() // #nosec - SystemCertPool tries to get local cert pool, if it fails, a new cer pool is created`
