### PR TITLE
Fix brakeman security test

### DIFF
--- a/api/config.yaml
+++ b/api/config.yaml
@@ -109,11 +109,16 @@ brakeman:
     chmod 600 ~/.ssh/huskyci_id_rsa &&
     echo "IdentityFile ~/.ssh/huskyci_id_rsa" >> /etc/ssh/ssh_config &&
     echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config &&
-    mkdir app
-    git clone -b %GIT_BRANCH% --single-branch %GIT_REPO% ./app/code --quiet 2> /tmp/errorGitCloneBrakeman
+    git clone -b %GIT_BRANCH% --single-branch %GIT_REPO% code --quiet 2> /tmp/errorGitCloneBrakeman
     if [ $? -eq 0 ]; then
-      brakeman -q -o results.json .
-      jq -j -M -c . results.json
+      if [ -d /code/app ]; then
+        brakeman -q -o results.json /code
+        jq -j -M -c . results.json
+      else
+        mv code app
+        brakeman -q -o results.json .
+        jq -j -M -c . results.json
+      fi
     else
       echo "ERROR_CLONING"
       cat /tmp/errorGitCloneBrakeman


### PR DESCRIPTION
Brakeman needs an app folder to execute. Since our security test cmd were creating an app folder and cloning our target repository inside, the brakeman security test wasn't finding Rails configuration files (like Gemfile) from where it extracts information about the project dependencies.

HuskyCI's result before the changes:
![Screen Shot 2019-10-08 at 3 45 43 PM](https://user-images.githubusercontent.com/11424945/66424781-ae718000-e9e4-11e9-9cf5-d4a6ef609490.png)

The Cross-Site Request Forgery vulnerability is a false positive. As we can see from the screenshot, there are 2 app folders `app/app` and Brakeman expects to find all the necessary code inside the first `app` folder. There isn't a Gemfile inside that folder so it cannot verify that the project's Rails version is 6.0.0 and by default, any project that uses Rails 5.2+ has `protect_from_forgery` enabled.

HuskyCI's result after the changes:
![Screen Shot 2019-10-08 at 3 51 38 PM](https://user-images.githubusercontent.com/11424945/66424824-c1845000-e9e4-11e9-987f-93855f4e0e31.png)