### PR TITLE
Add golangci-lint into Makefile and CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,7 @@ jobs:
       - run:
           command: |
             make test
+            make lint
             make check-sec
             mv coverage.html /tmp/artifacts
             $GOPATH/bin/goveralls -coverprofile=c.out -service=circle-ci -repotoken=$COVERALLS_TOKEN

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ GO ?= go
 GOROOT ?= $(shell $(GO) env GOROOT)
 GOPATH ?= $(shell $(GO) env GOPATH)
 GOBIN ?= $(GOPATH)/bin
+GOCILINT ?= $(GOBIN)/golangci-lint
 GOLINT ?= $(GOBIN)/golint
 GOSEC ?= $(GOBIN)/gosec
 GINKGO ?= $(GOBIN)/ginkgo
@@ -86,12 +87,24 @@ generate-passwords:
 	chmod +x deployments/scripts/generate-env.sh
 	./deployments/scripts/generate-env.sh
 
+## Gets all link dependencies
+get-lint-deps:
+	$(GO) get -u github.com/golangci/golangci-lint/cmd/golangci-lint
+
 ## Gets all go test dependencies
 get-test-deps:
 	$(GO) get -u golang.org/x/lint/golint
 	$(GO) get -u github.com/onsi/ginkgo/ginkgo
 	$(GO) get -u github.com/onsi/gomega/...
 	$(GO) get -u github.com/mattn/goveralls
+
+## Runs go lint
+golint:
+	$(GOLINT) $(shell $(GO) list ./...)
+
+## Runs Golangci-lint
+golangci-lint:
+	$(GOCILINT) run
 
 ## Runs ginkgo
 ginkgo:
@@ -114,9 +127,8 @@ help:
 ## Installs a development environment using docker-compose
 install: create-certs compose generate-passwords generate-local-token
 
-## Runs lint
-lint:
-	$(GOLINT) $(shell $(GO) list ./...)
+## Runs all huskyCI lint
+lint: get-lint-deps golint golangci-lint
 
 ## Push securityTest containers to hub.docker
 push-containers:

--- a/api/util/api/api.go
+++ b/api/util/api/api.go
@@ -168,7 +168,7 @@ func (cH *CheckUtils) checkDefaultUser(configAPI *apiContext.APIConfig) error {
 
 func checkSecurityTest(securityTestName string, configAPI *apiContext.APIConfig) error {
 
-	securityTestConfig := types.SecurityTest{}
+	var securityTestConfig types.SecurityTest
 
 	switch securityTestName {
 	case "enry":


### PR DESCRIPTION
Follow on https://github.com/globocom/huskyCI/pull/391#pullrequestreview-298772730
Including a linter to make static check in source code. 

When an issue is found, the CI will exit with [error](https://circleci.com/gh/globocom/huskyCI/674) status:
![image](https://user-images.githubusercontent.com/7620947/66563382-0ec30780-eb34-11e9-8cc1-707e1eb53f30.png)
