### PR TITLE
Increase huskyCI's client timeout to 1 hour

### DIFF
--- a/client/analysis/analysis.go
+++ b/client/analysis/analysis.go
@@ -119,7 +119,7 @@ func GetAnalysis(RID string) (types.Analysis, error) {
 func MonitorAnalysis(RID string) (types.Analysis, error) {
 
 	analysis := types.Analysis{}
-	timeout := time.After(15 * time.Minute)
+	timeout := time.After(60 * time.Minute)
 	retryTick := time.NewTicker(60 * time.Second)
 
 	for {


### PR DESCRIPTION
After some testing with GitLeaks, I believe that increasing huskyCI's client timeout to something bigger than 15 minutes would be great, as the security test usually takes longer to finish.

## Changes:

### Client:
* `client/analysis/analysis.go`: Increase client timeout to 60 minutes.