### PR TITLE
Run Yarn on root folder only

### DIFF
--- a/api/config.yaml
+++ b/api/config.yaml
@@ -210,9 +210,7 @@ yarnaudit:
     git clone -b %GIT_BRANCH% --single-branch %GIT_REPO% code --quiet 2> /tmp/errorGitCloneYarnAudit
     if [ $? -eq 0 ]; then
         cd code
-        pathLock=$(dirname "$(find . -name 'yarn.lock' | grep -v vendor)")
-        if [ $? -eq 0 ]; then
-            cd $pathLock
+        if [ -f yarn.lock ]; then
             yarn audit --json > /tmp/results.json 2> /tmp/errorYarnAudit
             if [ ! -s /tmp/errorYarnAudit ]; then
                 jq -c -M -j --slurp '{advisories: (. | map(select(.type == "auditAdvisory") | .data.advisory)), metadata: (. | map(select(.type == "auditSummary") | .data) | add)}' /tmp/results.json > /tmp/output.json


### PR DESCRIPTION
Recently I came across a repository with more than one `Yarn.lock` file, one in the `root` directory of the project and another inside a folder, which caused some issues when running huskyCI.

I believe that in the future it would be nice if huskyCI could find all `Yarn.lock` files in a project and run an analysis on each and every one of them, which will be addressed in this [issue](https://github.com/globocom/huskyCI/issues/427). 

For now, my proposal is that huskyCI searches only in the project's `root` directory for the `Yarn.lock` file.

## Changes:

### API:
* `api/config.yaml`: Add verification for `Yarn.lock` in the project's `root` directory only.