### PR TITLE
Change FE docker-compose port

### DIFF
--- a/deployments/docker-compose.yml
+++ b/deployments/docker-compose.yml
@@ -80,7 +80,7 @@ services:
         environment:
             REACT_APP_HUSKYCI_FE_API_ADDRESS: "http://127.0.0.1:8888"
         ports:
-          - "8080:80"
+          - "10080:80"
         networks:
             - huskyCI_net
     


### PR DESCRIPTION
This PR will change the FE port to `10080` instead of `8080` as this port may conflict with other services, like Burp Suite.