### PR TITLE
Ensure js projects have package-lock.json or yarn.lock

### DIFF
--- a/api/config.yaml
+++ b/api/config.yaml
@@ -190,7 +190,9 @@ npmaudit:
         npm audit --only=prod --json > /tmp/results.json 2> /tmp/errorNpmaudit
         jq -j -M -c . /tmp/results.json
       else
-        echo 'ERROR_PACKAGE_LOCK_NOT_FOUND'
+        if [ ! -f yarn.lock ]; then
+          echo 'ERROR_PACKAGE_LOCK_NOT_FOUND'
+        fi
       fi
     else
       echo "ERROR_CLONING"
@@ -224,7 +226,9 @@ yarnaudit:
                 cat /tmp/errorYarnAudit
             fi
         else
-            echo 'ERROR_YARN_LOCK_NOT_FOUND'
+            if [ ! -f package-lock.json ]; then
+                echo 'ERROR_YARN_LOCK_NOT_FOUND'
+            fi
         fi
     else
         echo "ERROR_CLONING"


### PR DESCRIPTION
On js analysed projects we don`t have to create issue of missing yarn.lock file when project use package.lock and same when project use yarn.lock