### PR TITLE
Set Spotbugs as non default securityTest

### DIFF
--- a/api/config.yaml
+++ b/api/config.yaml
@@ -292,7 +292,7 @@ spotbugs:
     fi
   type: Language
   language: Java
-  default: true
+  default: false
   timeOutInSeconds: 3600
 
 gitleaks:


### PR DESCRIPTION
This PR will disable Spotbugs securityTest for now. We are facing a few issues and, when we overcome them, we will set it as true again.