### PR TITLE
Add error metric to the stats route

### DIFF
--- a/api/db/huskystats.go
+++ b/api/db/huskystats.go
@@ -181,18 +181,7 @@ var statsQueryBase = map[string][]bson.M{
 							},
 						},
 						"then": "passed",
-						"else": bson.M{
-							"$cond": bson.M{
-								"if": bson.M{
-									"$eq": []string{
-										"$result",
-										"error",
-									},
-								},
-								"then": "failed",
-								"else": "$result",
-							},
-						},
+						"else": "$result",
 					},
 				},
 				"finishedAt": 1,


### PR DESCRIPTION
This PR will allow us to set a new line to huskyCI-dashboard showing which analysis failed via error, not vulnerability.