### PR TITLE
Check only prod dependencies in Yarn Audit

### DIFF
--- a/api/config.yaml
+++ b/api/config.yaml
@@ -217,7 +217,7 @@ yarnaudit:
     if [ $? -eq 0 ]; then
         cd code
         if [ -f yarn.lock ]; then
-            yarn audit --json > /tmp/results.json 2> /tmp/errorYarnAudit
+            yarn audit --groups dependencies --json > /tmp/results.json 2> /tmp/errorYarnAudit
             if [ ! -s /tmp/errorYarnAudit ]; then
                 jq -c -M -j --slurp '{advisories: (. | map(select(.type == "auditAdvisory") | .data.advisory)), metadata: (. | map(select(.type == "auditSummary") | .data) | add)}' /tmp/results.json > /tmp/output.json
                 cat /tmp/output.json


### PR DESCRIPTION
As Yarn allows us only to skip dev dependencies, this PR will add a new flag to the yarn audit command. 