### PR TITLE
Add #nohusky tag to Gosec

### DIFF
--- a/api/config.yaml
+++ b/api/config.yaml
@@ -64,7 +64,7 @@ gosec:
     if [ $? -eq 0 ]; then
       cd code
       touch results.json
-      $(which gosec) -quiet -fmt=json -log=log.txt -out=results.json ./... 2> /dev/null
+      $(which gosec) -quiet -fmt=json -nosec-tag nohusky -log=log.txt -out=results.json ./... 2> /dev/null
       jq -j -M -c . results.json
     else
       echo "ERROR_CLONING"

--- a/api/securitytest/gosec.go
+++ b/api/securitytest/gosec.go
@@ -88,5 +88,10 @@ func (gosecScan *SecTestScanInfo) prepareGosecVulns() {
 		}
 	}
 
+	for i := 0; i <= gosecOutput.GosecStats.Nosec; i++ {
+		gosecVuln := types.HuskyCIVulnerability{}
+		huskyCIgosecResults.NoSecVulns = append(huskyCIgosecResults.NoSecVulns, gosecVuln)
+	}
+
 	gosecScan.Vulnerabilities = huskyCIgosecResults
 }

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -160,3 +160,6 @@ type DBToken struct {
 	Salt       string    `bson:"salt" json:"salt"`
 	UUID       string    `bson:"uuid" json:"uuid"`
 }
+
+// NohuskyFunction represents all the #nohusky verifier methods.
+type NohuskyFunction func(string, int) bool

--- a/api/util/util.go
+++ b/api/util/util.go
@@ -207,21 +207,28 @@ func CountDigits(i int) int {
 	return count
 }
 
-// VerifyNoHusky verifies if the code string is marked with the #nohusky tag.
-func VerifyNoHusky(code string, lineNumber int, securityTool string) bool {
-	if securityTool == "Bandit" {
-		lineNumberLength := CountDigits(lineNumber)
-		splitCode := strings.Split(code, "\n")
-		for _, codeLine := range splitCode {
-			if len(codeLine) > 0 {
-				codeLineNumber := codeLine[:lineNumberLength]
-				if strings.Contains(codeLine, "#nohusky") && (codeLineNumber == strconv.Itoa(lineNumber)) {
-					return true
-				}
+func banditCase(code string, lineNumber int) bool {
+	lineNumberLength := CountDigits(lineNumber)
+	splitCode := strings.Split(code, "\n")
+	for _, codeLine := range splitCode {
+		if len(codeLine) > 0 {
+			codeLineNumber := codeLine[:lineNumberLength]
+			if strings.Contains(codeLine, "#nohusky") && (codeLineNumber == strconv.Itoa(lineNumber)) {
+				return true
 			}
 		}
 	}
 	return false
+}
+
+// VerifyNoHusky verifies if the code string is marked with the #nohusky tag.
+func VerifyNoHusky(code string, lineNumber int, securityTool string) bool {
+	m := map[string]types.NohuskyFunction{
+		"Bandit": banditCase,
+	}
+
+	return m[securityTool](code, lineNumber)
+
 }
 
 // SliceContains returns true if a given value is present on the given slice

--- a/client/analysis/output.go
+++ b/client/analysis/output.go
@@ -82,6 +82,7 @@ func prepareAllSummary(analysis types.Analysis) {
 	outputJSON.GenericResults = analysis.HuskyCIResults.GenericResults
 
 	// GoSec summary
+	outputJSON.Summary.GosecSummary.NoSecVuln = len(outputJSON.GoResults.HuskyCIGosecOutput.NoSecVulns)
 	outputJSON.Summary.GosecSummary.LowVuln = len(outputJSON.GoResults.HuskyCIGosecOutput.LowVulns)
 	outputJSON.Summary.GosecSummary.MediumVuln = len(outputJSON.GoResults.HuskyCIGosecOutput.MediumVulns)
 	outputJSON.Summary.GosecSummary.HighVuln = len(outputJSON.GoResults.HuskyCIGosecOutput.HighVulns)
@@ -179,7 +180,7 @@ func prepareAllSummary(analysis types.Analysis) {
 		types.FoundInfo = true
 	}
 
-	totalNoSec = outputJSON.Summary.BanditSummary.NoSecVuln
+	totalNoSec = outputJSON.Summary.BanditSummary.NoSecVuln + outputJSON.Summary.GosecSummary.NoSecVuln
 	totalLow = outputJSON.Summary.BrakemanSummary.LowVuln + outputJSON.Summary.SafetySummary.LowVuln + outputJSON.Summary.BanditSummary.LowVuln + outputJSON.Summary.GosecSummary.LowVuln + outputJSON.Summary.NpmAuditSummary.LowVuln + outputJSON.Summary.YarnAuditSummary.LowVuln + outputJSON.Summary.GitleaksSummary.LowVuln + outputJSON.Summary.SpotBugsSummary.LowVuln
 	totalMedium = outputJSON.Summary.BrakemanSummary.MediumVuln + outputJSON.Summary.SafetySummary.MediumVuln + outputJSON.Summary.BanditSummary.MediumVuln + outputJSON.Summary.GosecSummary.MediumVuln + outputJSON.Summary.NpmAuditSummary.MediumVuln + outputJSON.Summary.YarnAuditSummary.MediumVuln + outputJSON.Summary.GitleaksSummary.MediumVuln + outputJSON.Summary.SpotBugsSummary.MediumVuln
 	totalHigh = outputJSON.Summary.BrakemanSummary.HighVuln + outputJSON.Summary.SafetySummary.HighVuln + outputJSON.Summary.BanditSummary.HighVuln + outputJSON.Summary.GosecSummary.HighVuln + outputJSON.Summary.NpmAuditSummary.HighVuln + outputJSON.Summary.YarnAuditSummary.HighVuln + outputJSON.Summary.GitleaksSummary.HighVuln + outputJSON.Summary.SpotBugsSummary.HighVuln
@@ -222,6 +223,7 @@ func printAllSummary(analysis types.Analysis) {
 		fmt.Printf("[HUSKYCI][SUMMARY] High: %d\n", outputJSON.Summary.GosecSummary.HighVuln)
 		fmt.Printf("[HUSKYCI][SUMMARY] Medium: %d\n", outputJSON.Summary.GosecSummary.MediumVuln)
 		fmt.Printf("[HUSKYCI][SUMMARY] Low: %d\n", outputJSON.Summary.GosecSummary.LowVuln)
+		fmt.Printf("[HUSKYCI][SUMMARY] NoSecHusky: %d\n", outputJSON.Summary.GosecSummary.NoSecVuln)
 	}
 
 	if outputJSON.Summary.BanditSummary.FoundVuln || outputJSON.Summary.BanditSummary.FoundInfo {


### PR DESCRIPTION
## Closes #341 

This PR aims to add the possibility of the user marking false positives with the `#nohusky` tag, by doing this the output won't be shown in the results.

### Changes
#### API:
* `api/config.yaml`: Adds `nohusky` flag to `gosec` command.
* `api/securitytest/gosec.go`: Adds logic to handle `nosec` tags from `Gosec` as `nohusky`.
* `api/types/types.go`: Creates a new type to be used on a map of `string` to `function` in `util.go`.
* `api/util/util.go`: Adds a map of `string` to `function`, making it easier to add new `nohusky` verifier methods now that all that needs doing is to create it and add a new key to the map.

#### Client:
* `client/analysis/output.go`: Adds logic to output the `nohusky` results.

