### PR TITLE
Add Gitleaks Timeout Logic and fix multiple bugs found

### DIFF
--- a/api/config.yaml
+++ b/api/config.yaml
@@ -308,7 +308,8 @@ gitleaks:
     git clone -b %GIT_BRANCH% --single-branch %GIT_REPO% code --quiet 2> /tmp/errorGitCloneGitleaks
     if [ $? -eq 0 ]; then
         touch /tmp/results.json
-        $(which gitleaks) --log=warn --report=/tmp/results.json --repo-path=./code --branch=%GIT_BRANCH% --repo-config > /tmp/errorGitleaks
+        timeout -t 300 $(which gitleaks) --log=warn --report=/tmp/results.json --repo-path=./code --branch=%GIT_BRANCH% --repo-config > /tmp/errorGitleaks ||
+        echo "ERROR_TIMEOUT_GITLEAKS"
         if [ $? -eq 2 ]; then
             echo -n 'ERROR_RUNNING_GITLEAKS'
             cat /tmp/errorGitleaks

--- a/api/securitytest/enry.go
+++ b/api/securitytest/enry.go
@@ -21,7 +21,7 @@ type EnryOutput struct {
 func analyzeEnry(enryScan *SecTestScanInfo) error {
 	// Unmarshall rawOutput into finalOutput, that is a EnryOutput struct.
 	if err := json.Unmarshal([]byte(enryScan.Container.COutput), &enryScan.FinalOutput); err != nil {
-		log.Error("analyzeEnry", "ENRY", 1002, enryScan.Container.COutput, err)
+		log.Error("analyzeEnry", "ENRY", 1003, enryScan.Container.COutput, err)
 		enryScan.ErrorFound = err
 		return err
 	}

--- a/api/securitytest/gitleaks.go
+++ b/api/securitytest/gitleaks.go
@@ -51,7 +51,7 @@ func analyseGitleaks(gitleaksScan *SecTestScanInfo) error {
 		return nil
 	}
 
-	gitleaksErrorRunning := strings.Contains(gitleaksScan.Container.COutput, "ERROR_RUNNING_YARN_AUDIT")
+	gitleaksErrorRunning := strings.Contains(gitleaksScan.Container.COutput, "ERROR_RUNNING_GITLEAKS")
 	if gitleaksErrorRunning {
 		gitleaksScan.GitleaksErrorRunning = true
 		gitleaksScan.prepareGitleaksVulns()
@@ -84,9 +84,9 @@ func (gitleaksScan *SecTestScanInfo) prepareGitleaksVulns() {
 		gitleaksVuln.Language = "Generic"
 		gitleaksVuln.SecurityTool = "Gitleaks"
 		gitleaksVuln.Severity = "nosec"
-		gitleaksVuln.Details = "It looks like your project has too many commits. Gitleaks was enable to run during huskyCI scan."
+		gitleaksVuln.Details = "It looks like your project is too big and huskyCI was not able to run Gitleaks."
 
-		gitleaksScan.Vulnerabilities.LowVulns = append(gitleaksScan.Vulnerabilities.NoSecVulns, gitleaksVuln)
+		gitleaksScan.Vulnerabilities.NoSecVulns = append(gitleaksScan.Vulnerabilities.NoSecVulns, gitleaksVuln)
 		return
 	}
 
@@ -97,7 +97,7 @@ func (gitleaksScan *SecTestScanInfo) prepareGitleaksVulns() {
 		gitleaksVuln.Severity = "nosec"
 		gitleaksVuln.Details = "Internal error running Gitleaks."
 
-		gitleaksScan.Vulnerabilities.LowVulns = append(gitleaksScan.Vulnerabilities.NoSecVulns, gitleaksVuln)
+		gitleaksScan.Vulnerabilities.NoSecVulns = append(gitleaksScan.Vulnerabilities.NoSecVulns, gitleaksVuln)
 		return
 	}
 

--- a/api/securitytest/gitleaks.go
+++ b/api/securitytest/gitleaks.go
@@ -42,7 +42,7 @@ func analyseGitleaks(gitleaksScan *SecTestScanInfo) error {
 		return nil
 	}
 
-	// if gitleaks timeout, a warning will be generated as a low vuln
+	// if gitleaks timeout, a warning will be generated as a nosec vuln
 	gitleaksTimeout := strings.Contains(gitleaksScan.Container.COutput, "ERROR_TIMEOUT_GITLEAKS")
 	if gitleaksTimeout {
 		gitleaksScan.GitleaksTimeout = true

--- a/api/securitytest/gosec.go
+++ b/api/securitytest/gosec.go
@@ -88,7 +88,7 @@ func (gosecScan *SecTestScanInfo) prepareGosecVulns() {
 		}
 	}
 
-	for i := 0; i <= gosecOutput.GosecStats.Nosec; i++ {
+	for i := 0; i < gosecOutput.GosecStats.Nosec; i++ {
 		gosecVuln := types.HuskyCIVulnerability{}
 		huskyCIgosecResults.NoSecVulns = append(huskyCIgosecResults.NoSecVulns, gosecVuln)
 	}

--- a/api/securitytest/run.go
+++ b/api/securitytest/run.go
@@ -275,7 +275,7 @@ func (results *RunAllInfo) setVulns(securityTestScan SecTestScanInfo) {
 		case safety:
 			results.HuskyCIResults.PythonResults.HuskyCISafetyOutput.NoSecVulns = append(results.HuskyCIResults.PythonResults.HuskyCISafetyOutput.NoSecVulns, noSec)
 		case gosec:
-			results.HuskyCIResults.GoResults.HuskyCIGosecOutput.NoSecVulns = append(results.HuskyCIResults.GoResults.HuskyCIGosecOutput.LowVulns, noSec)
+			results.HuskyCIResults.GoResults.HuskyCIGosecOutput.NoSecVulns = append(results.HuskyCIResults.GoResults.HuskyCIGosecOutput.NoSecVulns, noSec)
 		case npmaudit:
 			results.HuskyCIResults.JavaScriptResults.HuskyCINpmAuditOutput.NoSecVulns = append(results.HuskyCIResults.JavaScriptResults.HuskyCINpmAuditOutput.NoSecVulns, noSec)
 		case yarnaudit:
@@ -283,7 +283,7 @@ func (results *RunAllInfo) setVulns(securityTestScan SecTestScanInfo) {
 		case spotbugs:
 			results.HuskyCIResults.JavaResults.HuskyCISpotBugsOutput.NoSecVulns = append(results.HuskyCIResults.JavaResults.HuskyCISpotBugsOutput.NoSecVulns, noSec)
 		case gitleaks:
-			results.HuskyCIResults.GenericResults.HuskyCIGitleaksOutput.NoSecVulns = append(results.HuskyCIResults.GenericResults.HuskyCIGitleaksOutput.LowVulns, noSec)
+			results.HuskyCIResults.GenericResults.HuskyCIGitleaksOutput.NoSecVulns = append(results.HuskyCIResults.GenericResults.HuskyCIGitleaksOutput.NoSecVulns, noSec)
 		}
 	}
 }

--- a/api/securitytest/securitytest.go
+++ b/api/securitytest/securitytest.go
@@ -37,6 +37,8 @@ type SecTestScanInfo struct {
 	PackageNotFound       bool
 	YarnLockNotFound      bool
 	YarnErrorRunning      bool
+	GitleaksErrorRunning  bool
+	GitleaksTimeout       bool
 	CommitAuthorsNotFound bool
 	CommitAuthors         GitAuthorsOutput
 	Codes                 []types.Code

--- a/client/analysis/output.go
+++ b/client/analysis/output.go
@@ -86,7 +86,7 @@ func prepareAllSummary(analysis types.Analysis) {
 	outputJSON.Summary.GosecSummary.LowVuln = len(outputJSON.GoResults.HuskyCIGosecOutput.LowVulns)
 	outputJSON.Summary.GosecSummary.MediumVuln = len(outputJSON.GoResults.HuskyCIGosecOutput.MediumVulns)
 	outputJSON.Summary.GosecSummary.HighVuln = len(outputJSON.GoResults.HuskyCIGosecOutput.HighVulns)
-	if len(outputJSON.GoResults.HuskyCIGosecOutput.LowVulns) > 0 {
+	if len(outputJSON.GoResults.HuskyCIGosecOutput.LowVulns) > 0 || len(outputJSON.GoResults.HuskyCIGosecOutput.NoSecVulns) > 0 {
 		outputJSON.Summary.GosecSummary.FoundInfo = true
 	}
 	if len(outputJSON.GoResults.HuskyCIGosecOutput.MediumVulns) > 0 || len(outputJSON.GoResults.HuskyCIGosecOutput.HighVulns) > 0 {
@@ -98,7 +98,7 @@ func prepareAllSummary(analysis types.Analysis) {
 	outputJSON.Summary.BanditSummary.LowVuln = len(outputJSON.PythonResults.HuskyCIBanditOutput.LowVulns)
 	outputJSON.Summary.BanditSummary.MediumVuln = len(outputJSON.PythonResults.HuskyCIBanditOutput.MediumVulns)
 	outputJSON.Summary.BanditSummary.HighVuln = len(outputJSON.PythonResults.HuskyCIBanditOutput.HighVulns)
-	if len(outputJSON.PythonResults.HuskyCIBanditOutput.LowVulns) > 0 {
+	if len(outputJSON.PythonResults.HuskyCIBanditOutput.LowVulns) > 0 || len(outputJSON.PythonResults.HuskyCIBanditOutput.NoSecVulns) > 0 {
 		outputJSON.Summary.BanditSummary.FoundInfo = true
 	}
 	if len(outputJSON.PythonResults.HuskyCIBanditOutput.MediumVulns) > 0 || len(outputJSON.PythonResults.HuskyCIBanditOutput.HighVulns) > 0 {
@@ -109,7 +109,7 @@ func prepareAllSummary(analysis types.Analysis) {
 	outputJSON.Summary.SafetySummary.LowVuln = len(outputJSON.PythonResults.HuskyCISafetyOutput.LowVulns)
 	outputJSON.Summary.SafetySummary.MediumVuln = len(outputJSON.PythonResults.HuskyCISafetyOutput.MediumVulns)
 	outputJSON.Summary.SafetySummary.HighVuln = len(outputJSON.PythonResults.HuskyCISafetyOutput.HighVulns)
-	if len(outputJSON.PythonResults.HuskyCISafetyOutput.LowVulns) > 0 {
+	if len(outputJSON.PythonResults.HuskyCISafetyOutput.LowVulns) > 0 || len(outputJSON.PythonResults.HuskyCISafetyOutput.NoSecVulns) > 0 {
 		outputJSON.Summary.SafetySummary.FoundInfo = true
 	}
 	if len(outputJSON.PythonResults.HuskyCISafetyOutput.MediumVulns) > 0 || len(outputJSON.PythonResults.HuskyCISafetyOutput.HighVulns) > 0 {
@@ -120,7 +120,7 @@ func prepareAllSummary(analysis types.Analysis) {
 	outputJSON.Summary.BrakemanSummary.LowVuln = len(outputJSON.RubyResults.HuskyCIBrakemanOutput.LowVulns)
 	outputJSON.Summary.BrakemanSummary.MediumVuln = len(outputJSON.RubyResults.HuskyCIBrakemanOutput.MediumVulns)
 	outputJSON.Summary.BrakemanSummary.HighVuln = len(outputJSON.RubyResults.HuskyCIBrakemanOutput.HighVulns)
-	if len(outputJSON.RubyResults.HuskyCIBrakemanOutput.LowVulns) > 0 {
+	if len(outputJSON.RubyResults.HuskyCIBrakemanOutput.LowVulns) > 0 || len(outputJSON.RubyResults.HuskyCIBrakemanOutput.NoSecVulns) > 0 {
 		outputJSON.Summary.BrakemanSummary.FoundInfo = true
 	}
 	if len(outputJSON.RubyResults.HuskyCIBrakemanOutput.MediumVulns) > 0 || len(outputJSON.RubyResults.HuskyCIBrakemanOutput.HighVulns) > 0 {
@@ -131,7 +131,7 @@ func prepareAllSummary(analysis types.Analysis) {
 	outputJSON.Summary.NpmAuditSummary.LowVuln = len(outputJSON.JavaScriptResults.HuskyCINpmAuditOutput.LowVulns)
 	outputJSON.Summary.NpmAuditSummary.MediumVuln = len(outputJSON.JavaScriptResults.HuskyCINpmAuditOutput.MediumVulns)
 	outputJSON.Summary.NpmAuditSummary.HighVuln = len(outputJSON.JavaScriptResults.HuskyCINpmAuditOutput.HighVulns)
-	if len(outputJSON.JavaScriptResults.HuskyCINpmAuditOutput.LowVulns) > 0 {
+	if len(outputJSON.JavaScriptResults.HuskyCINpmAuditOutput.LowVulns) > 0 || len(outputJSON.JavaScriptResults.HuskyCINpmAuditOutput.NoSecVulns) > 0 {
 		outputJSON.Summary.NpmAuditSummary.FoundInfo = true
 	}
 	if len(outputJSON.JavaScriptResults.HuskyCINpmAuditOutput.MediumVulns) > 0 || len(outputJSON.JavaScriptResults.HuskyCINpmAuditOutput.HighVulns) > 0 {
@@ -142,7 +142,7 @@ func prepareAllSummary(analysis types.Analysis) {
 	outputJSON.Summary.YarnAuditSummary.LowVuln = len(outputJSON.JavaScriptResults.HuskyCIYarnAuditOutput.LowVulns)
 	outputJSON.Summary.YarnAuditSummary.MediumVuln = len(outputJSON.JavaScriptResults.HuskyCIYarnAuditOutput.MediumVulns)
 	outputJSON.Summary.YarnAuditSummary.HighVuln = len(outputJSON.JavaScriptResults.HuskyCIYarnAuditOutput.HighVulns)
-	if len(outputJSON.JavaScriptResults.HuskyCIYarnAuditOutput.LowVulns) > 0 {
+	if len(outputJSON.JavaScriptResults.HuskyCIYarnAuditOutput.LowVulns) > 0 || len(outputJSON.JavaScriptResults.HuskyCIYarnAuditOutput.NoSecVulns) > 0 {
 		outputJSON.Summary.YarnAuditSummary.FoundInfo = true
 	}
 	if len(outputJSON.JavaScriptResults.HuskyCIYarnAuditOutput.MediumVulns) > 0 || len(outputJSON.JavaScriptResults.HuskyCIYarnAuditOutput.HighVulns) > 0 {
@@ -153,7 +153,7 @@ func prepareAllSummary(analysis types.Analysis) {
 	outputJSON.Summary.SpotBugsSummary.LowVuln = len(outputJSON.JavaResults.HuskyCISpotBugsOutput.LowVulns)
 	outputJSON.Summary.SpotBugsSummary.MediumVuln = len(outputJSON.JavaResults.HuskyCISpotBugsOutput.MediumVulns)
 	outputJSON.Summary.SpotBugsSummary.HighVuln = len(outputJSON.JavaResults.HuskyCISpotBugsOutput.HighVulns)
-	if len(outputJSON.JavaResults.HuskyCISpotBugsOutput.LowVulns) > 0 {
+	if len(outputJSON.JavaResults.HuskyCISpotBugsOutput.LowVulns) > 0 || len(outputJSON.JavaResults.HuskyCISpotBugsOutput.NoSecVulns) > 0 {
 		outputJSON.Summary.SpotBugsSummary.FoundInfo = true
 	}
 	if len(outputJSON.JavaResults.HuskyCISpotBugsOutput.MediumVulns) > 0 || len(outputJSON.JavaResults.HuskyCISpotBugsOutput.HighVulns) > 0 {
@@ -164,7 +164,7 @@ func prepareAllSummary(analysis types.Analysis) {
 	outputJSON.Summary.GitleaksSummary.LowVuln = len(outputJSON.GenericResults.HuskyCIGitleaksOutput.LowVulns)
 	outputJSON.Summary.GitleaksSummary.MediumVuln = len(outputJSON.GenericResults.HuskyCIGitleaksOutput.MediumVulns)
 	outputJSON.Summary.GitleaksSummary.HighVuln = len(outputJSON.GenericResults.HuskyCIGitleaksOutput.HighVulns)
-	if len(outputJSON.GenericResults.HuskyCIGitleaksOutput.LowVulns) > 0 {
+	if len(outputJSON.GenericResults.HuskyCIGitleaksOutput.LowVulns) > 0 || len(outputJSON.GenericResults.HuskyCIGitleaksOutput.NoSecVulns) > 0 {
 		outputJSON.Summary.GitleaksSummary.FoundInfo = true
 	}
 	if len(outputJSON.GenericResults.HuskyCIGitleaksOutput.MediumVulns) > 0 || len(outputJSON.GenericResults.HuskyCIGitleaksOutput.HighVulns) > 0 {

--- a/client/analysis/output.go
+++ b/client/analysis/output.go
@@ -180,9 +180,12 @@ func prepareAllSummary(analysis types.Analysis) {
 		types.FoundInfo = true
 	}
 
-	totalNoSec = outputJSON.Summary.BanditSummary.NoSecVuln + outputJSON.Summary.GosecSummary.NoSecVuln
+	totalNoSec = outputJSON.Summary.BanditSummary.NoSecVuln + outputJSON.Summary.GosecSummary.NoSecVuln + outputJSON.Summary.GitleaksSummary.NoSecVuln
+
 	totalLow = outputJSON.Summary.BrakemanSummary.LowVuln + outputJSON.Summary.SafetySummary.LowVuln + outputJSON.Summary.BanditSummary.LowVuln + outputJSON.Summary.GosecSummary.LowVuln + outputJSON.Summary.NpmAuditSummary.LowVuln + outputJSON.Summary.YarnAuditSummary.LowVuln + outputJSON.Summary.GitleaksSummary.LowVuln + outputJSON.Summary.SpotBugsSummary.LowVuln
+
 	totalMedium = outputJSON.Summary.BrakemanSummary.MediumVuln + outputJSON.Summary.SafetySummary.MediumVuln + outputJSON.Summary.BanditSummary.MediumVuln + outputJSON.Summary.GosecSummary.MediumVuln + outputJSON.Summary.NpmAuditSummary.MediumVuln + outputJSON.Summary.YarnAuditSummary.MediumVuln + outputJSON.Summary.GitleaksSummary.MediumVuln + outputJSON.Summary.SpotBugsSummary.MediumVuln
+
 	totalHigh = outputJSON.Summary.BrakemanSummary.HighVuln + outputJSON.Summary.SafetySummary.HighVuln + outputJSON.Summary.BanditSummary.HighVuln + outputJSON.Summary.GosecSummary.HighVuln + outputJSON.Summary.NpmAuditSummary.HighVuln + outputJSON.Summary.YarnAuditSummary.HighVuln + outputJSON.Summary.GitleaksSummary.HighVuln + outputJSON.Summary.SpotBugsSummary.HighVuln
 
 	outputJSON.Summary.TotalSummary.HighVuln = totalHigh
@@ -241,6 +244,7 @@ func printAllSummary(analysis types.Analysis) {
 		fmt.Printf("[HUSKYCI][SUMMARY] High: %d\n", outputJSON.Summary.SafetySummary.HighVuln)
 		fmt.Printf("[HUSKYCI][SUMMARY] Medium: %d\n", outputJSON.Summary.SafetySummary.MediumVuln)
 		fmt.Printf("[HUSKYCI][SUMMARY] Low: %d\n", outputJSON.Summary.SafetySummary.LowVuln)
+		fmt.Printf("[HUSKYCI][SUMMARY] NoSecHusky: %d\n", outputJSON.Summary.SafetySummary.NoSecVuln)
 	}
 
 	if outputJSON.Summary.BrakemanSummary.FoundVuln || outputJSON.Summary.BrakemanSummary.FoundInfo {
@@ -249,6 +253,7 @@ func printAllSummary(analysis types.Analysis) {
 		fmt.Printf("[HUSKYCI][SUMMARY] High: %d\n", outputJSON.Summary.BrakemanSummary.HighVuln)
 		fmt.Printf("[HUSKYCI][SUMMARY] Medium: %d\n", outputJSON.Summary.BrakemanSummary.MediumVuln)
 		fmt.Printf("[HUSKYCI][SUMMARY] Low: %d\n", outputJSON.Summary.BrakemanSummary.LowVuln)
+		fmt.Printf("[HUSKYCI][SUMMARY] NoSecHusky: %d\n", outputJSON.Summary.BrakemanSummary.NoSecVuln)
 	}
 
 	if outputJSON.Summary.NpmAuditSummary.FoundVuln || outputJSON.Summary.NpmAuditSummary.FoundInfo {
@@ -257,6 +262,7 @@ func printAllSummary(analysis types.Analysis) {
 		fmt.Printf("[HUSKYCI][SUMMARY] High: %d\n", outputJSON.Summary.NpmAuditSummary.HighVuln)
 		fmt.Printf("[HUSKYCI][SUMMARY] Medium: %d\n", outputJSON.Summary.NpmAuditSummary.MediumVuln)
 		fmt.Printf("[HUSKYCI][SUMMARY] Low: %d\n", outputJSON.Summary.NpmAuditSummary.LowVuln)
+		fmt.Printf("[HUSKYCI][SUMMARY] NoSecHusky: %d\n", outputJSON.Summary.NpmAuditSummary.NoSecVuln)
 	}
 
 	if outputJSON.Summary.YarnAuditSummary.FoundVuln || outputJSON.Summary.YarnAuditSummary.FoundInfo {
@@ -265,6 +271,7 @@ func printAllSummary(analysis types.Analysis) {
 		fmt.Printf("[HUSKYCI][SUMMARY] High: %d\n", outputJSON.Summary.YarnAuditSummary.HighVuln)
 		fmt.Printf("[HUSKYCI][SUMMARY] Medium: %d\n", outputJSON.Summary.YarnAuditSummary.MediumVuln)
 		fmt.Printf("[HUSKYCI][SUMMARY] Low: %d\n", outputJSON.Summary.YarnAuditSummary.LowVuln)
+		fmt.Printf("[HUSKYCI][SUMMARY] NoSecHusky: %d\n", outputJSON.Summary.YarnAuditSummary.NoSecVuln)
 	}
 
 	if outputJSON.Summary.SpotBugsSummary.FoundVuln || outputJSON.Summary.SpotBugsSummary.FoundInfo {
@@ -273,6 +280,7 @@ func printAllSummary(analysis types.Analysis) {
 		fmt.Printf("[HUSKYCI][SUMMARY] High: %d\n", outputJSON.Summary.SpotBugsSummary.HighVuln)
 		fmt.Printf("[HUSKYCI][SUMMARY] Medium: %d\n", outputJSON.Summary.SpotBugsSummary.MediumVuln)
 		fmt.Printf("[HUSKYCI][SUMMARY] Low: %d\n", outputJSON.Summary.SpotBugsSummary.LowVuln)
+		fmt.Printf("[HUSKYCI][SUMMARY] NoSecHusky: %d\n", outputJSON.Summary.SpotBugsSummary.NoSecVuln)
 	}
 
 	if outputJSON.Summary.GitleaksSummary.FoundVuln || outputJSON.Summary.GitleaksSummary.FoundInfo {
@@ -281,6 +289,7 @@ func printAllSummary(analysis types.Analysis) {
 		fmt.Printf("[HUSKYCI][SUMMARY] High: %d\n", outputJSON.Summary.GitleaksSummary.HighVuln)
 		fmt.Printf("[HUSKYCI][SUMMARY] Medium: %d\n", outputJSON.Summary.GitleaksSummary.MediumVuln)
 		fmt.Printf("[HUSKYCI][SUMMARY] Low: %d\n", outputJSON.Summary.GitleaksSummary.LowVuln)
+		fmt.Printf("[HUSKYCI][SUMMARY] NoSecHusky: %d\n", outputJSON.Summary.GitleaksSummary.NoSecVuln)
 	}
 
 	if outputJSON.Summary.TotalSummary.FoundVuln || outputJSON.Summary.TotalSummary.FoundInfo {

--- a/client/analysis/output.go
+++ b/client/analysis/output.go
@@ -161,6 +161,7 @@ func prepareAllSummary(analysis types.Analysis) {
 	}
 
 	// GitLeaks summary
+	outputJSON.Summary.GitleaksSummary.NoSecVuln = len(outputJSON.GenericResults.HuskyCIGitleaksOutput.NoSecVulns)
 	outputJSON.Summary.GitleaksSummary.LowVuln = len(outputJSON.GenericResults.HuskyCIGitleaksOutput.LowVulns)
 	outputJSON.Summary.GitleaksSummary.MediumVuln = len(outputJSON.GenericResults.HuskyCIGitleaksOutput.MediumVulns)
 	outputJSON.Summary.GitleaksSummary.HighVuln = len(outputJSON.GenericResults.HuskyCIGitleaksOutput.HighVulns)


### PR DESCRIPTION
## Closes #435

This PR aims to add a new timeout check in the Gitleaks instructions. By doing that, huskyCI will not fail anymore the whole analysis if this particular securityTest takes too long to finish. The initial timeout set is 5 minutes.

### Changes

* API: Add a new `ERROR_TIMEOUT_GITLEAKS` message check logic.
* Client: Add the `NoSecHusky` output.

### Bugs fixed

* API: Fix `NoSecVulns` output instead of `LowVulns` in `api/securitytest/run.go`.
* API: Log error message in `api/securitytest/enry.go`.
* API: Fix loop when number of nosec is 0 in `api/securitytest/gosec.go`.
* Client: Add an `OR` statement for cases where only `nosec` vulnerabilities are found in `client/analysis/output.go`.