### PR TITLE
FIX gitleaks timeout output

### DIFF
--- a/api/config.yaml
+++ b/api/config.yaml
@@ -308,10 +308,12 @@ gitleaks:
     git clone -b %GIT_BRANCH% --single-branch %GIT_REPO% code --quiet 2> /tmp/errorGitCloneGitleaks
     if [ $? -eq 0 ]; then
         touch /tmp/results.json
-        timeout -t 300 $(which gitleaks) --log=warn --report=/tmp/results.json --repo-path=./code --branch=%GIT_BRANCH% --repo-config > /tmp/errorGitleaks ||
-        echo "ERROR_TIMEOUT_GITLEAKS"
-        if [ $? -eq 2 ]; then
-            echo -n 'ERROR_RUNNING_GITLEAKS'
+        timeout -t 360 $(which gitleaks) --log=warn --report=/tmp/results.json --repo-path=./code --branch=%GIT_BRANCH% --repo-config &> /tmp/errorGitleaks
+        if [[ $? -eq 124 || $? -eq 143 ]]; then #timeout exit codes
+            echo 'ERROR_TIMEOUT_GITLEAKS'
+            cat /tmp/errorGitleaks
+        elif [ $? -eq 2 ]; then
+            echo 'ERROR_RUNNING_GITLEAKS'
             cat /tmp/errorGitleaks
         else
             jq -j -M -c . /tmp/results.json


### PR DESCRIPTION
This PR aims to fix gitleaks output when there is a timeout.

The timeout command returns 124 or 143 (depending on the command version) when the timeout occurs. Added an IF checking for that exit code and fixed the container output.