### PR TITLE
Ignore files/directories in Bandit analyses

### DIFF
--- a/api/config.yaml
+++ b/api/config.yaml
@@ -89,7 +89,7 @@ bandit:
      if [ $? -eq 0 ]; then
        cd code
        chmod +x /usr/local/bin/husky-file-ignore.sh
-       bash /usr/local/bin/husky-file-ignore.sh
+       husky-file-ignore.sh 2> /tmp/errorBanditIgnoreScript 1> /dev/null
        bandit -r . -f json 2> /dev/null > results.json
        jq -j -M -c . results.json
      else

--- a/api/config.yaml
+++ b/api/config.yaml
@@ -78,7 +78,7 @@ gosec:
 bandit:
   name: bandit
   image: huskyci/bandit
-  imageTag: "1.6.2"
+  imageTag: "dev"
   cmd: |+
      mkdir -p ~/.ssh &&
      echo 'GIT_PRIVATE_SSH_KEY' > ~/.ssh/huskyci_id_rsa &&
@@ -88,6 +88,8 @@ bandit:
      git clone -b %GIT_BRANCH% --single-branch %GIT_REPO% code --quiet 2> /tmp/errorGitCloneBandit
      if [ $? -eq 0 ]; then
        cd code
+       chmod +x /usr/local/bin/husky-file-ignore.sh
+       bash /usr/local/bin/husky-file-ignore.sh
        bandit -r . -f json 2> /dev/null > results.json
        jq -j -M -c . results.json
      else

--- a/deployments/dockerfiles/bandit/Dockerfile
+++ b/deployments/dockerfiles/bandit/Dockerfile
@@ -12,6 +12,7 @@ FROM python:3.6-alpine
 
 COPY --from=builder /usr/local/lib/python3.6 /usr/local/lib/python3.6
 COPY --from=builder /usr/local/bin/bandit /usr/local/bin/bandit
+COPY husky-file-ignore.sh /usr/local/bin/husky-file-ignore.sh
 
 # Add packages that we need in the final image on runtime
 RUN apk add --no-cache git jq bash openssh-client 

--- a/deployments/dockerfiles/bandit/husky-file-ignore.sh
+++ b/deployments/dockerfiles/bandit/husky-file-ignore.sh
@@ -8,15 +8,68 @@
 #
 
 huskyCIFile=".huskyci"
+codePath="/code/"
+
+isHuskyIgnore(){
+    line=$1
+
+    if echo "$line" | grep -q "huskyCI-Ignore"; then
+        return 0
+    fi
+
+    return 1
+}
+
+isCommented(){
+    line=$1
+    commentRegexp='^[[:space:]]*#'
+
+    if echo "$line" | grep -Eq "$commentRegexp"; then
+        return 0
+    fi
+
+    return 1
+}
+
+isEmpty(){
+    line=$1
+
+    if [ ! "$line" ]; then
+        return 0
+    fi
+
+    return 1
+}
+
+leavesCodePath(){
+    line=$1
+
+    if echo "$line" | grep -qF "../"; then
+        return 0
+    fi
+
+    return 1
+}
+
+wouldRemoveCurrentWorkdir() {
+    line=$1
+
+    if echo "$codePath$line" | grep -qF "//"; then
+        return 0
+    fi
+
+    return 1
+}
 
 if [ -f "$huskyCIFile" ]; then
+
     while IFS= read -r line; do
-	commentRegexp='^[[:space:]]*#'
-        if echo "$line" | grep -q "huskyCI-Ignore" || echo "$line" | grep -Eq "$commentRegexp" || [ ! "$line" ]; then
+	    
+        if isHuskyIgnore $line || isCommented $line || isEmpty $line || leavesCodePath $line || wouldRemoveCurrentWorkdir $line; then
             continue
         fi
 
-        rm -rf $line
+        rm -rf "$codePath$line"
 
     done < "$huskyCIFile"
 fi

--- a/deployments/dockerfiles/bandit/husky-file-ignore.sh
+++ b/deployments/dockerfiles/bandit/husky-file-ignore.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # Copyright 2020 Globo.com authors. All rights reserved.
 # Use of this source code is governed by a BSD-style
@@ -12,7 +12,7 @@ huskyCIFile=".huskyci"
 if [ -f "$huskyCIFile" ]; then
     while IFS= read -r line; do
 	commentRegexp='^[[:space:]]*#'
-        if [[ "$line" =~ "huskyCI-Ignore" ]] || [[ $line =~ $commentRegexp]] || [["$line" =~ "" ]]; then
+        if echo "$line" | grep -q "huskyCI-Ignore" || echo "$line" | grep -Eq "$commentRegexp" || [ ! "$line" ]; then
             continue
         fi
 

--- a/deployments/dockerfiles/bandit/husky-file-ignore.sh
+++ b/deployments/dockerfiles/bandit/husky-file-ignore.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# Copyright 2020 Globo.com authors. All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+#
+# This script will exclude folders and files written in .huskyci from the root of the cloned repository.
+#
+
+huskyCIFile=".huskyci"
+
+if [ -f "$huskyCIFile" ]; then
+    while IFS= read -r line; do
+	commentRegexp='^[[:space:]]*#'
+        if [[ "$line" =~ "huskyCI-Ignore" ]] || [[ $line =~ $commentRegexp]] || [["$line" =~ "" ]]; then
+            continue
+        fi
+
+        rm -rf $line
+
+    done < "$huskyCIFile"
+fi


### PR DESCRIPTION
This PR aims to add the functionality to ignore files and/or directories in a huskyCI analysis through a POC using the **Bandit** security test.

To have huskyCI ignore a file or directory, simply create a `.huskyci` file in your project's root directory with the following content:
``` text
[huskyCI-Ignore]
# Bandit Ignore
tests/
example.py
```

To test this proof of concept, the `huskyci/bandit:dev` image has been updated to contain the `husky-file-ignore.sh` script. As a test repository, use https://github.com/Krlier/huskyCI with the `poc-python-bandit` branch.

### Changes:

* `api/config.yaml`: Add commands to run the `husky-file-ignore.sh` script. **Note**: The `imageTag` attribute has been changed to the `dev` tag.
* `deployments/dockerfiles/bandit/Dockerfile`: Add logic to add the script to the container's image.
* `deployments/dockerfiles/bandit/husky-file-ignore.sh`: Add script to ignore directories/files.
