### PR TITLE
Add a new check for repos without a master branch

### DIFF
--- a/api/config.yaml
+++ b/api/config.yaml
@@ -32,6 +32,11 @@ gitauthors:
     echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config &&
     git clone %GIT_REPO% code --quiet 2> /tmp/errorGitCloneEnry
     cd code
+    git branch -a | egrep 'remotes/origin/master' 1> /dev/null 2> /dev/null
+    if [ $? -ne 0 ]; then
+      echo "{\"authors\":[]}"
+      exit 0
+    fi
     git checkout %GIT_BRANCH% --quiet
     if [ $? -eq 0 ]; then
       for i in $(git log origin/master.. --pretty="%ae" | sort -u); do

--- a/api/securitytest/gitauthors.go
+++ b/api/securitytest/gitauthors.go
@@ -22,7 +22,7 @@ func analyzeGitAuthors(gitAuthorsScan *SecTestScanInfo) error {
 
 	// Unmarshall rawOutput into finalOutput, that is a GitAuthors struct.
 	if err := json.Unmarshal([]byte(gitAuthorsScan.Container.COutput), &gitAuthorsOutput); err != nil {
-		log.Error("analyzeGitAuthors", "GITAUTHORS", 1002, gitAuthorsScan.Container.COutput, err)
+		log.Error("analyzeGitAuthors", "GITAUTHORS", 1035, gitAuthorsScan.Container.COutput, err)
 		gitAuthorsScan.ErrorFound = err
 		gitAuthorsScan.prepareContainerAfterScan()
 		return err


### PR DESCRIPTION
## Description

We have encountered an error in repositories that do not have a `master` branch. 

The security test `gitauthors` was failing because the following command is being used to get the diff from `master` and the branch being analyzed: 

```sh
git log origin/master.. --pretty="%ae" | sort -u)
```

This PR will add a new check for these particular cases and also adjust the log error message. 

## Testing 

To test this PR, a POC repository without a master branch has been created ([https://github.com/rafaveira3/huskyci-author-poc](https://github.com/rafaveira3/huskyci-author-poc)):

```sh
make install
```

```sh
vim .env
```

```sh
export HUSKYCI_CLIENT_REPO_URL="https://github.com/rafaveira3/huskyci-author-poc.git"
export HUSKYCI_CLIENT_REPO_BRANCH="develop"
```

```sh
make run-client
```