### PR TITLE
[FIX] Revert gitleaks version to 2.1.0

### DIFF
--- a/api/config.yaml
+++ b/api/config.yaml
@@ -305,7 +305,7 @@ spotbugs:
 gitleaks:
   name: gitleaks
   image: huskyci/gitleaks
-  imageTag: "v4.0.1"
+  imageTag: "2.1.0"
   cmd: |+
     mkdir -p ~/.ssh &&
     echo 'GIT_PRIVATE_SSH_KEY' > ~/.ssh/huskyci_id_rsa &&


### PR DESCRIPTION
The latest version of `huskyci/gitleaks/v4.0.1` is instable and not returning the expected results. 

This PR will revert gitleaks version to 2.1.0 until we fix it.