### PR TITLE
[FIX] yarnaudit output size

### DIFF
--- a/api/config.yaml
+++ b/api/config.yaml
@@ -224,7 +224,7 @@ yarnaudit:
     if [ $? -eq 0 ]; then
         cd code
         if [ -f yarn.lock ]; then
-            yarn audit --groups dependencies --json > /tmp/results.json 2> /tmp/errorYarnAudit
+            yarn audit --level moderate --prod --groups dependencies --json > /tmp/results.json 2> /tmp/errorYarnAudit
             if [ ! -s /tmp/errorYarnAudit ]; then
                 jq -c -M -j --slurp '{advisories: (. | map(select(.type == "auditAdvisory") | .data.advisory)), metadata: (. | map(select(.type == "auditSummary") | .data) | add)}' /tmp/results.json > /tmp/output.json
                 cat /tmp/output.json


### PR DESCRIPTION
This PR aims to reduce the output produced by huskyCI's `yarnaudit` container.

Since we don't block on `low` vulnerabilities and it can cause the output to grow to MBs of text. I think it is a good idea to remove the low vulnerabilities from `yarnaudit` while it can't be configured/controlled by users. **We should enable this again once the huskyCI's configuration is done**.

The negative aspect is that we lose track of `low` vulnerabilities as it is now. The container still outputs the low vulnerabilities count but no details about it.

As a bonus effect, this reduces the container runtime.