### PR TITLE
Add GIT_TERMINAL_PROMPT=0 before git clone commands 

### DIFF
--- a/api/config.yaml
+++ b/api/config.yaml
@@ -8,7 +8,7 @@ enry:
     chmod 600 ~/.ssh/huskyci_id_rsa &&
     echo "IdentityFile ~/.ssh/huskyci_id_rsa" >> /etc/ssh/ssh_config &&
     echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config &&
-    git clone -b %GIT_BRANCH% --single-branch %GIT_REPO% code --quiet 2> /tmp/errorGitCloneEnry
+    GIT_TERMINAL_PROMPT=0 git clone -b %GIT_BRANCH% --single-branch %GIT_REPO% code --quiet 2> /tmp/errorGitCloneEnry
     if [ $? -eq 0 ]; then
       cd code
       enry --json | tr -d '\r\n'
@@ -30,7 +30,7 @@ gitauthors:
     chmod 600 ~/.ssh/huskyci_id_rsa &&
     echo "IdentityFile ~/.ssh/huskyci_id_rsa" >> /etc/ssh/ssh_config &&
     echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config &&
-    git clone %GIT_REPO% code --quiet 2> /tmp/errorGitCloneEnry
+    GIT_TERMINAL_PROMPT=0 git clone %GIT_REPO% code --quiet 2> /tmp/errorGitCloneEnry
     cd code
     git branch -a | egrep 'remotes/origin/master' 1> /dev/null 2> /dev/null
     if [ $? -ne 0 ]; then
@@ -65,7 +65,7 @@ gosec:
     echo "IdentityFile ~/.ssh/huskyci_id_rsa" >> /etc/ssh/ssh_config &&
     echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config &&
     cd src
-    git clone -b %GIT_BRANCH% --single-branch %GIT_REPO% code --quiet 2> /tmp/errorGitCloneGosec
+    GIT_TERMINAL_PROMPT=0 git clone -b %GIT_BRANCH% --single-branch %GIT_REPO% code --quiet 2> /tmp/errorGitCloneGosec
     if [ $? -eq 0 ]; then
       cd code
       touch results.json
@@ -90,7 +90,7 @@ bandit:
      chmod 600 ~/.ssh/huskyci_id_rsa &&
      echo "IdentityFile ~/.ssh/huskyci_id_rsa" >> /etc/ssh/ssh_config &&
      echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config &&
-     git clone -b %GIT_BRANCH% --single-branch %GIT_REPO% code --quiet 2> /tmp/errorGitCloneBandit
+     GIT_TERMINAL_PROMPT=0 git clone -b %GIT_BRANCH% --single-branch %GIT_REPO% code --quiet 2> /tmp/errorGitCloneBandit
      if [ $? -eq 0 ]; then
        cd code
        chmod +x /usr/local/bin/husky-file-ignore.sh
@@ -116,7 +116,7 @@ brakeman:
     chmod 600 ~/.ssh/huskyci_id_rsa &&
     echo "IdentityFile ~/.ssh/huskyci_id_rsa" >> /etc/ssh/ssh_config &&
     echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config &&
-    git clone -b %GIT_BRANCH% --single-branch %GIT_REPO% code --quiet 2> /tmp/errorGitCloneBrakeman
+    GIT_TERMINAL_PROMPT=0 git clone -b %GIT_BRANCH% --single-branch %GIT_REPO% code --quiet 2> /tmp/errorGitCloneBrakeman
     if [ $? -eq 0 ]; then
       if [ -d /code/app ]; then
         brakeman -q -o results.json /code
@@ -145,7 +145,7 @@ safety:
     chmod 600 ~/.ssh/huskyci_id_rsa &&
     echo "IdentityFile ~/.ssh/huskyci_id_rsa" >> /etc/ssh/ssh_config &&
     echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config &&
-    git clone -b %GIT_BRANCH% --single-branch %GIT_REPO% code --quiet 2> /tmp/errorGitCloneSafety
+    GIT_TERMINAL_PROMPT=0 git clone -b %GIT_BRANCH% --single-branch %GIT_REPO% code --quiet 2> /tmp/errorGitCloneSafety
     if [ $? -eq 0 ]; then
       cd code
       if [ -f Pipfile.lock ]; then
@@ -191,7 +191,7 @@ npmaudit:
     chmod 600 ~/.ssh/huskyci_id_rsa &&
     echo "IdentityFile ~/.ssh/huskyci_id_rsa" >> /etc/ssh/ssh_config &&
     echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config &&
-    git clone -b %GIT_BRANCH% --single-branch %GIT_REPO% code --quiet 2> /tmp/errorGitCloneNpmAudit
+    GIT_TERMINAL_PROMPT=0 git clone -b %GIT_BRANCH% --single-branch %GIT_REPO% code --quiet 2> /tmp/errorGitCloneNpmAudit
     if [ $? -eq 0 ]; then
       cd code
       if [ -f package-lock.json ]; then
@@ -221,7 +221,7 @@ yarnaudit:
     chmod 600 ~/.ssh/huskyci_id_rsa &&
     echo "IdentityFile ~/.ssh/huskyci_id_rsa" >> /etc/ssh/ssh_config &&
     echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config &&
-    git clone -b %GIT_BRANCH% --single-branch %GIT_REPO% code --quiet 2> /tmp/errorGitCloneYarnAudit
+    GIT_TERMINAL_PROMPT=0 git clone -b %GIT_BRANCH% --single-branch %GIT_REPO% code --quiet 2> /tmp/errorGitCloneYarnAudit
     if [ $? -eq 0 ]; then
         cd code
         if [ -f yarn.lock ]; then
@@ -257,7 +257,7 @@ spotbugs:
     chmod 600 ~/.ssh/huskyci_id_rsa &&
     echo "IdentityFile ~/.ssh/huskyci_id_rsa" >> /etc/ssh/ssh_config &&
     echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config &&
-    git clone -b %GIT_BRANCH% --single-branch %GIT_REPO% code --quiet 2> /tmp/errorGitCloneSpotBugs
+    GIT_TERMINAL_PROMPT=0 git clone -b %GIT_BRANCH% --single-branch %GIT_REPO% code --quiet 2> /tmp/errorGitCloneSpotBugs
     if [ $? -eq 0 ]; then
        cd code
        if [ -f "pom.xml" ]; then
@@ -313,7 +313,7 @@ gitleaks:
     chmod 600 ~/.ssh/huskyci_id_rsa &&
     echo "IdentityFile ~/.ssh/huskyci_id_rsa" >> /etc/ssh/ssh_config &&
     echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config &&
-    git clone -b %GIT_BRANCH% --single-branch %GIT_REPO% code --quiet 2> /tmp/errorGitCloneGitleaks
+    GIT_TERMINAL_PROMPT=0 git clone -b %GIT_BRANCH% --single-branch %GIT_REPO% code --quiet 2> /tmp/errorGitCloneGitleaks
     if [ $? -eq 0 ]; then
         touch /tmp/results.json
         timeout -t 360 $(which gitleaks) --log=warn --report=/tmp/results.json --repo-path=./code --branch=%GIT_BRANCH% --repo-config &> /tmp/errorGitleaks

--- a/api/securitytest/securitytest.go
+++ b/api/securitytest/securitytest.go
@@ -99,9 +99,9 @@ func (scanInfo *SecTestScanInfo) dockerRun(timeOutInSeconds int) error {
 }
 
 func (scanInfo *SecTestScanInfo) analyze() error {
-	errorClonning := strings.Contains(scanInfo.Container.COutput, "ERROR_CLONING")
-	if errorClonning {
-		errorMsg := errors.New("error clonning")
+	errorCloning := strings.Contains(scanInfo.Container.COutput, "ERROR_CLONING")
+	if errorCloning {
+		errorMsg := errors.New("error cloning")
 		log.Error("analyze", "SECURITYTEST", 1031, scanInfo.URL, scanInfo.Branch, errorMsg)
 		scanInfo.ErrorFound = errorMsg
 		return errorMsg


### PR DESCRIPTION
### Description

Suppose you want to run HuskyCI in a private repository, but forget to setup `HUSKYCI_API_GIT_PRIVATE_SSH_KEY`. Currently, the analysis container is blocked when the `git clone` command asks for credentials, waiting for the user to input them in the terminal. The analysis does not fail and keep running indefinetely.

### Proposed Changes

Add `GIT_TERMINAL_PROMPT=0` before `git clone` commands executed in analysis containers, such as Enry. This prevents `git` to prompt for credentials, and the [command fails](https://serverfault.com/questions/544156/git-clone-fail-instead-of-prompting-for-credentials) if such credentials are required but not present.

### Testing

Run HuskyCI pointing to a private repository without setting up a private key. After `make install`, set a private repository as the analysis target in the `.env` file:
```sh
export HUSKYCI_CLIENT_REPO_URL="git@github.com:gustavocovas/bullet-journal.git"
export HUSKYCI_CLIENT_REPO_BRANCH="master"
```

Run the analysis with `make run-client`, and it should fail:
```
[HUSKYCI][*] master -> git@github.com:gustavocovas/bullet-journal.git
[HUSKYCI][*] huskyCI analysis started! 2THwYG302267ojOjhKggUeHdJGmSoOzD
[HUSKYCI][ERROR] Monitoring analysis 2THwYG302267ojOjhKggUeHdJGmSoOzD: huskyCI encountered an error trying to execute this analysis: error cloning
make: *** [run-client] Error 1
```

