### PR TITLE
Add the new Open Source URL into README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Developers can set up a new stage into their CI pipelines to check for vulnerabi
 
 <p align="center"><img src="huskyCI-stage.png"/></p>
 
-If security issues are found in the code, the severity, the confidence, the file, the line, and many more useful information can be shown, as exemplified: 
+If security issues are found in the code, the severity, the confidence, the file, the line, and many more useful information can be shown, as exemplified:
 
 ```
 [HUSKYCI][*] poc-python-bandit -> https://github.com/globocom/huskyCI.git
@@ -34,9 +34,9 @@ If security issues are found in the code, the severity, the confidence, the file
 [HUSKYCI][!] File: ./main.py
 [HUSKYCI][!] Line: 7
 [HUSKYCI][!] Code:
-6 
+6
 7 exec(command)
-8 
+8
 
 [HUSKYCI][SUMMARY] Python -> huskyci/bandit:1.6.2
 [HUSKYCI][SUMMARY] High: 0
@@ -56,11 +56,11 @@ ERROR: Job failed: exit code 1
 
 ## Getting Started
 
-You can try huskyCI by setting up a local environment using Docker Compose following [this guide](http://husky.ci/docs/development/set-up-environment).
+You can try huskyCI by setting up a local environment using Docker Compose following [this guide](https://huskyci.opensource.globo.com/docs/development/set-up-environment).
 
 ## Documentation
 
-All guides and the full documentation can be found in the [official documentation page](http://husky.ci/docs/quickstart/overview).
+All guides and the full documentation can be found in the [official documentation page](https://huskyci.opensource.globo.com/docs/quickstart/overview).
 
 ## Contributing
 


### PR DESCRIPTION
### Description

We have now a new URL for our product site: https://huskyci.opensource.globo.com

### Proposed Changes

Replace the old http://huky.ci into https://huskyci.opensource.globo.com/

### Testing

Just visit the following URLs: 

- https://huskyci.opensource.globo.com/docs/quickstart/overview
- https://huskyci.opensource.globo.com/docs/development/set-up-environment