### PR TITLE
Modify tfsec severity outuput to fit into the high/medium/low standard

### DIFF
--- a/api/securitytest/tfsec.go
+++ b/api/securitytest/tfsec.go
@@ -78,10 +78,13 @@ func (tfsecScan *SecTestScanInfo) prepareTFSecVulns() {
 
 		switch tfsecVuln.Severity {
 		case "INFO":
+			tfsecVuln.Severity = "Low"
 			huskyCItfsecResults.LowVulns = append(huskyCItfsecResults.LowVulns, tfsecVuln)
 		case "WARNING":
+			tfsecVuln.Severity = "Medium"
 			huskyCItfsecResults.MediumVulns = append(huskyCItfsecResults.MediumVulns, tfsecVuln)
 		case "ERROR":
+			tfsecVuln.Severity = "High"
 			huskyCItfsecResults.HighVulns = append(huskyCItfsecResults.HighVulns, tfsecVuln)
 		}
 	}


### PR DESCRIPTION
### Description

Closes #484

### Proposed Changes

Modify TfSec's severity output to better fit huskyCI's. After these changes, huskyCI's output should look like this:

![image](https://user-images.githubusercontent.com/40367872/82695081-c7106c80-9c3a-11ea-9298-b027a6905d07.png)

### Testing

```
make install
```

Modify .env to point huskyCI's target branch to poc-iac-tfsec:

```
export HUSKYCI_CLIENT_REPO_URL=https://github.com/globocom/huskyCI.git
export HUSKYCI_CLIENT_REPO_BRANCH=poc-hcl-tfsec
```

```
make run-client
```
