### PR TITLE
Add title in HuskyCIVulnerability and update each tool title.

### DIFF
--- a/api/securitytest/bandit.go
+++ b/api/securitytest/bandit.go
@@ -69,7 +69,7 @@ func (banditScan *SecTestScanInfo) prepareBanditVulns() {
 		}
 		banditVuln.Severity = issue.IssueSeverity
 		banditVuln.Confidence = issue.IssueConfidence
-		banditVuln.Title = "Test Name: " + issue.TestName + " Test ID: " + issue.TestID
+		banditVuln.Title = issue.IssueText
 		banditVuln.Details = issue.IssueText
 		banditVuln.File = issue.Filename
 		banditVuln.Line = strconv.Itoa(issue.LineNumber)

--- a/api/securitytest/bandit.go
+++ b/api/securitytest/bandit.go
@@ -69,6 +69,7 @@ func (banditScan *SecTestScanInfo) prepareBanditVulns() {
 		}
 		banditVuln.Severity = issue.IssueSeverity
 		banditVuln.Confidence = issue.IssueConfidence
+		banditVuln.Title = "Test Name: " + issue.TestName + " Test ID: " + issue.TestID
 		banditVuln.Details = issue.IssueText
 		banditVuln.File = issue.Filename
 		banditVuln.Line = strconv.Itoa(issue.LineNumber)

--- a/api/securitytest/brakeman.go
+++ b/api/securitytest/brakeman.go
@@ -6,6 +6,7 @@ package securitytest
 
 import (
 	"encoding/json"
+	"fmt"
 	"strconv"
 
 	"github.com/globocom/huskyCI/api/log"
@@ -61,8 +62,8 @@ func (brakemanScan *SecTestScanInfo) prepareBrakemanVulns() {
 		brakemanVuln.Language = "Ruby"
 		brakemanVuln.SecurityTool = "Brakeman"
 		brakemanVuln.Confidence = warning.Confidence
-		brakemanVuln.Title = warning.Type + ". " + warning.Message
-		brakemanVuln.Details = warning.Details + warning.Message
+		brakemanVuln.Title = fmt.Sprintf("Vulnerable Dependency: %s %s", warning.Type, warning.Message)
+		brakemanVuln.Details = warning.Details
 		brakemanVuln.File = warning.File
 		brakemanVuln.Line = strconv.Itoa(warning.Line)
 		brakemanVuln.Code = warning.Code

--- a/api/securitytest/brakeman.go
+++ b/api/securitytest/brakeman.go
@@ -61,6 +61,7 @@ func (brakemanScan *SecTestScanInfo) prepareBrakemanVulns() {
 		brakemanVuln.Language = "Ruby"
 		brakemanVuln.SecurityTool = "Brakeman"
 		brakemanVuln.Confidence = warning.Confidence
+		brakemanVuln.Title = warning.Type + ". " + warning.Message
 		brakemanVuln.Details = warning.Details + warning.Message
 		brakemanVuln.File = warning.File
 		brakemanVuln.Line = strconv.Itoa(warning.Line)

--- a/api/securitytest/gitleaks.go
+++ b/api/securitytest/gitleaks.go
@@ -111,7 +111,7 @@ func (gitleaksScan *SecTestScanInfo) prepareGitleaksVulns() {
 
 		gitleaksVuln := types.HuskyCIVulnerability{}
 		gitleaksVuln.SecurityTool = "GitLeaks"
-		gitleaksVuln.Details = issue.Rule + " @ [" + issue.Commit + "]"
+		gitleaksVuln.Title = issue.Rule + " sensitive data found"
 		gitleaksVuln.File = issue.File
 		gitleaksVuln.Code = issue.Line
 		gitleaksVuln.Title = "Hard Coded " + issue.Rule + " in: " + issue.File

--- a/api/securitytest/gitleaks.go
+++ b/api/securitytest/gitleaks.go
@@ -84,6 +84,7 @@ func (gitleaksScan *SecTestScanInfo) prepareGitleaksVulns() {
 		gitleaksVuln.Language = "Generic"
 		gitleaksVuln.SecurityTool = "Gitleaks"
 		gitleaksVuln.Severity = "low"
+		gitleaksVuln.Title = "Too big project for Gitleaks scan"
 		gitleaksVuln.Details = "It looks like your project is too big and huskyCI was not able to run Gitleaks."
 
 		gitleaksScan.Vulnerabilities.LowVulns = append(gitleaksScan.Vulnerabilities.LowVulns, gitleaksVuln)
@@ -95,6 +96,7 @@ func (gitleaksScan *SecTestScanInfo) prepareGitleaksVulns() {
 		gitleaksVuln.Language = "Generic"
 		gitleaksVuln.SecurityTool = "Gitleaks"
 		gitleaksVuln.Severity = "low"
+		gitleaksVuln.Title = "Gitleaks internal error"
 		gitleaksVuln.Details = "Internal error running Gitleaks."
 
 		gitleaksScan.Vulnerabilities.LowVulns = append(gitleaksScan.Vulnerabilities.LowVulns, gitleaksVuln)

--- a/api/securitytest/gitleaks.go
+++ b/api/securitytest/gitleaks.go
@@ -112,6 +112,7 @@ func (gitleaksScan *SecTestScanInfo) prepareGitleaksVulns() {
 		gitleaksVuln.Details = issue.Rule + " @ [" + issue.Commit + "]"
 		gitleaksVuln.File = issue.File
 		gitleaksVuln.Code = issue.Line
+		gitleaksVuln.Title = "Hard Coded " + issue.Rule + " in: " + issue.File
 
 		switch issue.Rule {
 		case "PKCS8", "RSA", "SSH", "PGP", "EC":

--- a/api/securitytest/gosec.go
+++ b/api/securitytest/gosec.go
@@ -71,6 +71,7 @@ func (gosecScan *SecTestScanInfo) prepareGosecVulns() {
 		gosecVuln := types.HuskyCIVulnerability{}
 		gosecVuln.Language = "Go"
 		gosecVuln.SecurityTool = "GoSec"
+		gosecVuln.Title = issue.Details + " - rule " + issue.RuleID
 		gosecVuln.Severity = issue.Severity
 		gosecVuln.Confidence = issue.Confidence
 		gosecVuln.Details = issue.Details

--- a/api/securitytest/gosec.go
+++ b/api/securitytest/gosec.go
@@ -71,7 +71,7 @@ func (gosecScan *SecTestScanInfo) prepareGosecVulns() {
 		gosecVuln := types.HuskyCIVulnerability{}
 		gosecVuln.Language = "Go"
 		gosecVuln.SecurityTool = "GoSec"
-		gosecVuln.Title = issue.Details + " - rule " + issue.RuleID
+		gosecVuln.Title = issue.Details
 		gosecVuln.Severity = issue.Severity
 		gosecVuln.Confidence = issue.Confidence
 		gosecVuln.Details = issue.Details

--- a/api/securitytest/npmaudit.go
+++ b/api/securitytest/npmaudit.go
@@ -92,6 +92,7 @@ func (npmAuditScan *SecTestScanInfo) prepareNpmAuditVulns() {
 		npmauditVuln.Language = "JavaScript"
 		npmauditVuln.SecurityTool = "NpmAudit"
 		npmauditVuln.Severity = "low"
+		npmauditVuln.Title = "No package-lock.json found."
 		npmauditVuln.Details = "It looks like your project doesn't have a package-lock.json file. If you use NPM to handle your dependencies, it would be a good idea to commit it so huskyCI can check for vulnerabilities."
 
 		npmAuditScan.Vulnerabilities.LowVulns = append(npmAuditScan.Vulnerabilities.LowVulns, npmauditVuln)

--- a/api/securitytest/npmaudit.go
+++ b/api/securitytest/npmaudit.go
@@ -27,6 +27,7 @@ type Vulnerability struct {
 	VulnerableVersions string    `json:"vulnerable_versions"`
 	Severity           string    `json:"severity"`
 	Overview           string    `json:"overview"`
+	Title              string    `json:"title"`
 }
 
 // Finding holds the version of a given security issue found
@@ -101,6 +102,7 @@ func (npmAuditScan *SecTestScanInfo) prepareNpmAuditVulns() {
 		npmauditVuln := types.HuskyCIVulnerability{}
 		npmauditVuln.Language = "JavaScript"
 		npmauditVuln.SecurityTool = "NpmAudit"
+		npmauditVuln.Title = issue.Title + " - " + "(" + issue.ModuleName + ", " + issue.VulnerableVersions + ")"
 		npmauditVuln.Details = issue.Overview
 		npmauditVuln.VunerableBelow = issue.VulnerableVersions
 		npmauditVuln.Code = issue.ModuleName

--- a/api/securitytest/npmaudit.go
+++ b/api/securitytest/npmaudit.go
@@ -6,6 +6,7 @@ package securitytest
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/globocom/huskyCI/api/log"
@@ -103,7 +104,7 @@ func (npmAuditScan *SecTestScanInfo) prepareNpmAuditVulns() {
 		npmauditVuln := types.HuskyCIVulnerability{}
 		npmauditVuln.Language = "JavaScript"
 		npmauditVuln.SecurityTool = "NpmAudit"
-		npmauditVuln.Title = issue.Title + " - " + "(" + issue.ModuleName + ", " + issue.VulnerableVersions + ")"
+		npmauditVuln.Title = fmt.Sprintf("Vulnerable Dependency: %s %s (%s)", issue.ModuleName, issue.VulnerableVersions, issue.Title)
 		npmauditVuln.Details = issue.Overview
 		npmauditVuln.VunerableBelow = issue.VulnerableVersions
 		npmauditVuln.Code = issue.ModuleName

--- a/api/securitytest/safety.go
+++ b/api/securitytest/safety.go
@@ -94,6 +94,7 @@ func (safetyScan *SecTestScanInfo) prepareSafetyVulns() {
 		safetyVuln.Language = "Python"
 		safetyVuln.SecurityTool = "Safety"
 		safetyVuln.Severity = "low"
+		safetyVuln.Title = "No requirements.txt found."
 		safetyVuln.Details = "It looks like your project doesn't have a requirements.txt file. huskyCI was not able to run safety properly."
 
 		huskyCIsafetyResults.LowVulns = append(huskyCIsafetyResults.LowVulns, safetyVuln)
@@ -110,6 +111,7 @@ func (safetyScan *SecTestScanInfo) prepareSafetyVulns() {
 			safetyVuln.Language = "Python"
 			safetyVuln.SecurityTool = "Safety"
 			safetyVuln.Severity = "low"
+			safetyVuln.Title = "Safety scan warning."
 			safetyVuln.Details = util.AdjustWarningMessage(warning)
 
 			huskyCIsafetyResults.LowVulns = append(huskyCIsafetyResults.LowVulns, safetyVuln)

--- a/api/securitytest/safety.go
+++ b/api/securitytest/safety.go
@@ -127,6 +127,7 @@ func (safetyScan *SecTestScanInfo) prepareSafetyVulns() {
 		safetyVuln.Severity = "high"
 		safetyVuln.Details = issue.Comment
 		safetyVuln.Code = issue.Dependency + " " + issue.Version
+		safetyVuln.Title = issue.Dependency + " (" + issue.Below + ")"
 		safetyVuln.VunerableBelow = issue.Below
 
 		huskyCIsafetyResults.HighVulns = append(huskyCIsafetyResults.HighVulns, safetyVuln)

--- a/api/securitytest/safety.go
+++ b/api/securitytest/safety.go
@@ -7,6 +7,7 @@ package securitytest
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/globocom/huskyCI/api/log"
@@ -129,7 +130,7 @@ func (safetyScan *SecTestScanInfo) prepareSafetyVulns() {
 		safetyVuln.Severity = "high"
 		safetyVuln.Details = issue.Comment
 		safetyVuln.Code = issue.Dependency + " " + issue.Version
-		safetyVuln.Title = issue.Dependency + " (" + issue.Below + ")"
+		safetyVuln.Title = fmt.Sprintf("Vulnerable Dependency: %s (%s)", issue.Dependency, issue.Below)
 		safetyVuln.VunerableBelow = issue.Below
 
 		huskyCIsafetyResults.HighVulns = append(huskyCIsafetyResults.HighVulns, safetyVuln)

--- a/api/securitytest/spotbugs.go
+++ b/api/securitytest/spotbugs.go
@@ -151,7 +151,7 @@ func (spotbugsScan *SecTestScanInfo) prepareSpotBugsVulns() {
 		spotbugsVuln := types.HuskyCIVulnerability{}
 		spotbugsVuln.Language = "Java"
 		spotbugsVuln.SecurityTool = "SpotBugs"
-		spotbugsVuln.Title = "Error while running spotbugs scan."
+		spotbugsVuln.Title = "Error while running SpotBugs scan."
 		spotbugsVuln.Details = fmt.Sprintf("An error occured running huskyCI scan on your Java project: %s", spotbugsScan.ErrorFound.Error())
 		spotbugsVuln.Severity = "LOW"
 		spotbugsVuln.Confidence = "HIGH"
@@ -172,7 +172,7 @@ func (spotbugsScan *SecTestScanInfo) prepareSpotBugsVulns() {
 			spotbugsVuln.Code = fmt.Sprintf("Code beetween Line %s and Line %s.", startLine, endLine)
 			spotbugsVuln.Line = startLine
 			spotbugsVuln.File = spotbugsOutput.SpotBugsIssue[i].SourceLine[j].SourcePath
-			spotbugsVuln.Title = spotbugsVuln.Details + " in " + spotbugsVuln.File
+			spotbugsVuln.Title = spotbugsVuln.Details
 
 			switch spotbugsOutput.SpotBugsIssue[i].Priority {
 			case "1":

--- a/api/securitytest/spotbugs.go
+++ b/api/securitytest/spotbugs.go
@@ -45,6 +45,7 @@ type SpotBugsIssue struct {
 	Abbreviation string       `xml:"abbrev,attr"`
 	Category     string       `xml:"category,attr"`
 	SourceLine   []SourceLine `xml:"SourceLine"`
+	ShortMessage string       `xml:"ShortMessage"`
 }
 
 // Error is the struct that holds errors that happened in analysis
@@ -150,6 +151,7 @@ func (spotbugsScan *SecTestScanInfo) prepareSpotBugsVulns() {
 		spotbugsVuln := types.HuskyCIVulnerability{}
 		spotbugsVuln.Language = "Java"
 		spotbugsVuln.SecurityTool = "SpotBugs"
+		spotbugsVuln.Title = "Error while running spotbugs scan."
 		spotbugsVuln.Details = fmt.Sprintf("An error occured running huskyCI scan on your Java project: %s", spotbugsScan.ErrorFound.Error())
 		spotbugsVuln.Severity = "LOW"
 		spotbugsVuln.Confidence = "HIGH"
@@ -170,6 +172,7 @@ func (spotbugsScan *SecTestScanInfo) prepareSpotBugsVulns() {
 			spotbugsVuln.Code = fmt.Sprintf("Code beetween Line %s and Line %s.", startLine, endLine)
 			spotbugsVuln.Line = startLine
 			spotbugsVuln.File = spotbugsOutput.SpotBugsIssue[i].SourceLine[j].SourcePath
+			spotbugsVuln.Title = spotbugsVuln.Details + " in " + spotbugsVuln.File
 
 			switch spotbugsOutput.SpotBugsIssue[i].Priority {
 			case "1":

--- a/api/securitytest/tfsec.go
+++ b/api/securitytest/tfsec.go
@@ -69,6 +69,7 @@ func (tfsecScan *SecTestScanInfo) prepareTFSecVulns() {
 		tfsecVuln.Language = "HCL"
 		tfsecVuln.SecurityTool = "TFSec"
 		tfsecVuln.Severity = result.Severity
+		tfsecVuln.Title = result.Description
 		tfsecVuln.Details = result.RuleID + " @ [" + result.Description + "]"
 		startLine := strconv.Itoa(result.Location.StartLine)
 		endLine := strconv.Itoa(result.Location.EndLine)

--- a/api/securitytest/yarnaudit.go
+++ b/api/securitytest/yarnaudit.go
@@ -102,6 +102,7 @@ func (yarnAuditScan *SecTestScanInfo) prepareYarnAuditVulns() {
 		yarnauditVuln.Language = "JavaScript"
 		yarnauditVuln.SecurityTool = "YarnAudit"
 		yarnauditVuln.Severity = "low"
+		yarnauditVuln.Title = "No yarn.lock found."
 		yarnauditVuln.Details = "It looks like your project doesn't have a yarn.lock file. If you use Yarn to handle your dependencies, it would be a good idea to commit it so huskyCI can check for vulnerabilities."
 
 		yarnAuditScan.Vulnerabilities.LowVulns = append(yarnAuditScan.Vulnerabilities.LowVulns, yarnauditVuln)
@@ -113,6 +114,7 @@ func (yarnAuditScan *SecTestScanInfo) prepareYarnAuditVulns() {
 		yarnauditVuln.Language = "JavaScript"
 		yarnauditVuln.SecurityTool = "YarnAudit"
 		yarnauditVuln.Severity = "low"
+		yarnauditVuln.Title = "Error while running yarn audit scan."
 		yarnauditVuln.Details = "Yarn returned an error"
 
 		yarnAuditScan.Vulnerabilities.LowVulns = append(yarnAuditScan.Vulnerabilities.LowVulns, yarnauditVuln)

--- a/api/securitytest/yarnaudit.go
+++ b/api/securitytest/yarnaudit.go
@@ -28,6 +28,7 @@ type YarnIssue struct {
 	VulnerableVersions string        `json:"vulnerable_versions"`
 	Severity           string        `json:"severity"`
 	Overview           string        `json:"overview"`
+	Title              string        `json:"title"`
 }
 
 // YarnFinding holds the version of a given yarn security issue found
@@ -123,6 +124,7 @@ func (yarnAuditScan *SecTestScanInfo) prepareYarnAuditVulns() {
 		yarnauditVuln.Language = "JavaScript"
 		yarnauditVuln.SecurityTool = "YarnAudit"
 		yarnauditVuln.Details = issue.Overview
+		yarnauditVuln.Title = issue.Title + " - " + "(" + issue.ModuleName + ", " + issue.VulnerableVersions + ")"
 		yarnauditVuln.VunerableBelow = issue.VulnerableVersions
 		yarnauditVuln.Code = issue.ModuleName
 		yarnauditVuln.Occurrences = 1

--- a/api/securitytest/yarnaudit.go
+++ b/api/securitytest/yarnaudit.go
@@ -6,6 +6,7 @@ package securitytest
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/globocom/huskyCI/api/log"
@@ -126,7 +127,7 @@ func (yarnAuditScan *SecTestScanInfo) prepareYarnAuditVulns() {
 		yarnauditVuln.Language = "JavaScript"
 		yarnauditVuln.SecurityTool = "YarnAudit"
 		yarnauditVuln.Details = issue.Overview
-		yarnauditVuln.Title = issue.Title + " - " + "(" + issue.ModuleName + ", " + issue.VulnerableVersions + ")"
+		yarnauditVuln.Title = fmt.Sprintf("Vulnerable Dependency: %s %s (%s)", issue.ModuleName, issue.VulnerableVersions, issue.Title)
 		yarnauditVuln.VunerableBelow = issue.VulnerableVersions
 		yarnauditVuln.Code = issue.ModuleName
 		yarnauditVuln.Occurrences = 1

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -84,6 +84,7 @@ type HuskyCIVulnerability struct {
 	Code           string `bson:"code,omitempty" json:"code,omitempty"`
 	Details        string `bson:"details" json:"details,omitempty"`
 	Type           string `bson:"type,omitempty" json:"type,omitempty"`
+	Title          string `bson:"title,omitempty" json:"title,omitempty"`
 	VunerableBelow string `bson:"vulnerablebelow,omitempty" json:"vulnerablebelow,omitempty"`
 	Version        string `bson:"version,omitempty" json:"version,omitempty"`
 	Occurrences    int    `bson:"occurrences,omitempty" json:"occurrences,omitempty"`

--- a/cli/types/types.go
+++ b/cli/types/types.go
@@ -100,6 +100,7 @@ type HuskyCIVulnerability struct {
 	Code           string `json:"code,omitempty"`
 	Details        string `json:"details,omitempty"`
 	Type           string `json:"type,omitempty"`
+	Title          string `json:"title,omitempty"`
 	VunerableBelow string `json:"vulnerablebelow,omitempty"`
 	Version        string `json:"version,omitempty"`
 	Occurrences    int    `json:"occurrences,omitempty"`

--- a/client/analysis/output.go
+++ b/client/analysis/output.go
@@ -340,6 +340,7 @@ func printSTDOUTOutputGosec(issues []types.HuskyCIVulnerability) {
 		fmt.Printf("[HUSKYCI][!] Tool: %s\n", issue.SecurityTool)
 		fmt.Printf("[HUSKYCI][!] Severity: %s\n", issue.Severity)
 		fmt.Printf("[HUSKYCI][!] Confidence: %s\n", issue.Confidence)
+		fmt.Printf("[HUSKYCI][!] Title: %s\n", issue.Title)
 		fmt.Printf("[HUSKYCI][!] Details: %s\n", issue.Details)
 		fmt.Printf("[HUSKYCI][!] File: %s\n", issue.File)
 		fmt.Printf("[HUSKYCI][!] Line: %s\n", issue.Line)
@@ -354,6 +355,7 @@ func printSTDOUTOutputBandit(issues []types.HuskyCIVulnerability) {
 		fmt.Printf("[HUSKYCI][!] Tool: %s\n", issue.SecurityTool)
 		fmt.Printf("[HUSKYCI][!] Severity: %s\n", issue.Severity)
 		fmt.Printf("[HUSKYCI][!] Confidence: %s\n", issue.Confidence)
+		fmt.Printf("[HUSKYCI][!] Title: %s\n", issue.Title)
 		fmt.Printf("[HUSKYCI][!] Details: %s\n", issue.Details)
 		fmt.Printf("[HUSKYCI][!] File: %s\n", issue.File)
 		fmt.Printf("[HUSKYCI][!] Line: %s\n", issue.Line)
@@ -371,6 +373,7 @@ func printSTDOUTOutputSafety(issues []types.HuskyCIVulnerability) {
 			fmt.Printf("[HUSKYCI][!] Code: %s\n", issue.Code)
 			fmt.Printf("[HUSKYCI][!] Vulnerable Below: %s\n", issue.VunerableBelow)
 		}
+		fmt.Printf("[HUSKYCI][!] Title: %s\n", issue.Title)
 		fmt.Printf("[HUSKYCI][!] Details: %s\n", issue.Details)
 	}
 }
@@ -381,6 +384,7 @@ func printSTDOUTOutputBrakeman(issues []types.HuskyCIVulnerability) {
 		fmt.Printf("[HUSKYCI][!] Language: %s\n", issue.Language)
 		fmt.Printf("[HUSKYCI][!] Tool: %s\n", issue.SecurityTool)
 		fmt.Printf("[HUSKYCI][!] Confidence: %s\n", issue.Confidence)
+		fmt.Printf("[HUSKYCI][!] Title: %s\n", issue.Title)
 		fmt.Printf("[HUSKYCI][!] Details: %s\n", issue.Details)
 		fmt.Printf("[HUSKYCI][!] File: %s\n", issue.File)
 		fmt.Printf("[HUSKYCI][!] Line: %s\n", issue.Line)
@@ -400,6 +404,7 @@ func printSTDOUTOutputNpmAudit(issues []types.HuskyCIVulnerability) {
 			fmt.Printf("[HUSKYCI][!] Version: %s\n", issue.Version)
 			fmt.Printf("[HUSKYCI][!] Vulnerable Below: %s\n", issue.VunerableBelow)
 		}
+		fmt.Printf("[HUSKYCI][!] Title: %s\n", issue.Title)
 		fmt.Printf("[HUSKYCI][!] Details: %s\n", issue.Details)
 	}
 }
@@ -416,6 +421,7 @@ func printSTDOUTOutputYarnAudit(issues []types.HuskyCIVulnerability) {
 			fmt.Printf("[HUSKYCI][!] Version: %s\n", issue.Version)
 			fmt.Printf("[HUSKYCI][!] Vulnerable Below: %s\n", issue.VunerableBelow)
 		}
+		fmt.Printf("[HUSKYCI][!] Title: %s\n", issue.Title)
 		fmt.Printf("[HUSKYCI][!] Details: %s\n", issue.Details)
 	}
 }
@@ -427,6 +433,7 @@ func printSTDOUTOutputSpotBugs(issues []types.HuskyCIVulnerability) {
 		fmt.Printf("[HUSKYCI][!] Tool: %s\n", issue.SecurityTool)
 		fmt.Printf("[HUSKYCI][!] Severity: %s\n", issue.Severity)
 		fmt.Printf("[HUSKYCI][!] Confidence: %s\n", issue.Confidence)
+		fmt.Printf("[HUSKYCI][!] Title: %s\n", issue.Title)
 		fmt.Printf("[HUSKYCI][!] Details: %s\n", issue.Details)
 		fmt.Printf("[HUSKYCI][!] File: %s\n", issue.File)
 		fmt.Printf("[HUSKYCI][!] Line: %s\n", issue.Line)
@@ -440,6 +447,7 @@ func printSTDOUTOutputTFSec(issues []types.HuskyCIVulnerability) {
 		fmt.Printf("[HUSKYCI][!] Language: %s\n", issue.Language)
 		fmt.Printf("[HUSKYCI][!] Tool: %s\n", issue.SecurityTool)
 		fmt.Printf("[HUSKYCI][!] Severity: %s\n", issue.Severity)
+		fmt.Printf("[HUSKYCI][!] Title: %s\n", issue.Title)
 		fmt.Printf("[HUSKYCI][!] Details: %s\n", issue.Details)
 		fmt.Printf("[HUSKYCI][!] File: %s\n", issue.File)
 		fmt.Printf("[HUSKYCI][!] Line: %s\n", issue.Line)
@@ -452,6 +460,7 @@ func printSTDOUTOutputGitleaks(issues []types.HuskyCIVulnerability) {
 		fmt.Println()
 		fmt.Printf("[HUSKYCI][!] Tool: %s\n", issue.SecurityTool)
 		fmt.Printf("[HUSKYCI][!] Severity: %s\n", issue.Severity)
+		fmt.Printf("[HUSKYCI][!] Title: %s\n", issue.Title)
 		fmt.Printf("[HUSKYCI][!] Details: %s\n", issue.Details)
 		fmt.Printf("[HUSKYCI][!] File: %s\n", issue.File)
 		fmt.Printf("[HUSKYCI][!] Code: %s\n", issue.Code)

--- a/client/types/npmaudit.go
+++ b/client/types/npmaudit.go
@@ -18,6 +18,7 @@ type Vulnerability struct {
 	VulnerableVersions string    `json:"vulnerable_versions"`
 	Severity           string    `json:"severity"`
 	Overview           string    `json:"overview"`
+	Title              string    `json:"title"`
 }
 
 // Finding holds the version of a given security issue found

--- a/client/types/types.go
+++ b/client/types/types.go
@@ -101,6 +101,7 @@ type HuskyCIVulnerability struct {
 	Code           string `json:"code,omitempty"`
 	Details        string `json:"details,omitempty"`
 	Type           string `json:"type,omitempty"`
+	Title          string `json:"title,omitempty"`
 	VunerableBelow string `json:"vulnerablebelow,omitempty"`
 	Version        string `json:"version,omitempty"`
 	Occurrences    int    `json:"occurrences,omitempty"`


### PR DESCRIPTION
### Description

Closes #490
### Proposed Changes

Introduce new `Title` field in `HuskyCIVulnerability` to easily integrate HuskyCi and DefectDojo. You can check [here](https://github.com/DefectDojo/django-DefectDojo/tree/master/dojo/tools) how each scanning tool plugin in DefectDojo is building `title` field. I did similar mapping where possible - cannot reuse this logic in tfsec (now DD is not integrated with tfsec) and with spotbugs (current plugin that is used in spotbugs don't provide `ShortMessage` field).

### Testing
Scan different `poc` branches in HuskyCI project and look for `title` parameter in `huskyciresults` at each findings.

#### Example with java:
Export env variables:
```
export HUSKYCI_CLIENT_REPO_URL="https://github.com/globocom/huskyCI.git"
export HUSKYCI_CLIENT_REPO_BRANCH="poc-java-spotbugs"
```

Run client:
`make run-client`

Analysis output:
```
{
...
"huskyciresults":
{
...
"javaresults": {
            "spotbugsoutput": {
                "mediumvulns": [
                    {
                        "language": "Java",
                        "securitytool": "SpotBugs",
                        "severity": "MEDIUM",
                        "confidence": "MEDIUM",
                        "file": "com/mycompany/app/App.java",
                        "line": "12",
                        "code": "Code beetween Line 12 and Line 12.",
                        "details": "PREDICTABLE_RANDOM",
                        "type": "SECPR",
                        "title": "PREDICTABLE_RANDOM in com/mycompany/app/App.java"
                    }
                ]
            }
        },
}
...
}
```
