### PR TITLE
Adjust Title STDOUT and update API release/security tests versions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ If security issues are found in the code, the severity, the confidence, the file
 [HUSKYCI][*] poc-python-bandit -> https://github.com/globocom/huskyCI.git
 [HUSKYCI][*] huskyCI analysis started! yDS9tb9mdt4QnnyvOBp3eVAXE1nWpTRQ
 
+[HUSKYCI][!] Title: Use of exec detected.
 [HUSKYCI][!] Language: Python
 [HUSKYCI][!] Tool: Bandit
 [HUSKYCI][!] Severity: MEDIUM
@@ -38,20 +39,37 @@ If security issues are found in the code, the severity, the confidence, the file
 7 exec(command)
 8
 
+[HUSKYCI][!] Title: Possible hardcoded password: 'password123!'
+[HUSKYCI][!] Language: Python
+[HUSKYCI][!] Tool: Bandit
+[HUSKYCI][!] Severity: LOW
+[HUSKYCI][!] Confidence: MEDIUM
+[HUSKYCI][!] Details: Possible hardcoded password: 'password123!'
+[HUSKYCI][!] File: ./main.py
+[HUSKYCI][!] Line: 1
+[HUSKYCI][!] Code:
+1 secret = 'password123!'
+2
+3 password = 'thisisnotapassword' #nohusky
+4
+
 [HUSKYCI][SUMMARY] Python -> huskyci/bandit:1.6.2
 [HUSKYCI][SUMMARY] High: 0
 [HUSKYCI][SUMMARY] Medium: 1
-[HUSKYCI][SUMMARY] Low: 0
-[HUSKYCI][SUMMARY] NoSecHusky: 0
+[HUSKYCI][SUMMARY] Low: 1
+[HUSKYCI][SUMMARY] NoSecHusky: 1
 
 [HUSKYCI][SUMMARY] Total
 [HUSKYCI][SUMMARY] High: 0
 [HUSKYCI][SUMMARY] Medium: 1
-[HUSKYCI][SUMMARY] Low: 0
-[HUSKYCI][SUMMARY] NoSecHusky: 0
+[HUSKYCI][SUMMARY] Low: 1
+[HUSKYCI][SUMMARY] NoSecHusky: 1
 
-[HUSKYCI][*] Some HIGH/MEDIUM issues were found :(
-ERROR: Job failed: exit code 1
+[HUSKYCI][*] The following securityTests were executed and no blocking vulnerabilities were found:
+[HUSKYCI][*] [huskyci/gitleaks:2.1.0]
+[HUSKYCI][*] Some HIGH/MEDIUM issues were found in these securityTests:
+[HUSKYCI][*] [huskyci/bandit:1.6.2]
+ERROR: Job failed: exit code 190
 ```
 
 ## Getting Started

--- a/api/config.yaml
+++ b/api/config.yaml
@@ -1,7 +1,7 @@
 enry:
   name: enry
   image: huskyci/enry
-  imageTag: dev-697929e
+  imageTag: dev-b78a58c
   cmd: |+
     mkdir -p ~/.ssh &&
     echo 'GIT_PRIVATE_SSH_KEY' > ~/.ssh/huskyci_id_rsa &&
@@ -23,7 +23,7 @@ enry:
 gitauthors:
   name: gitauthors
   image: huskyci/gitauthors
-  imageTag: "2.18.2"
+  imageTag: "2.18.4"
   cmd: |+
     mkdir -p ~/.ssh &&
     echo 'GIT_PRIVATE_SSH_KEY' > ~/.ssh/huskyci_id_rsa &&
@@ -57,7 +57,7 @@ gitauthors:
 gosec:
   name: gosec
   image: huskyci/gosec
-  imageTag: v2.2.0
+  imageTag: v2.3.0
   cmd: |+
     mkdir -p ~/.ssh &&
     echo 'GIT_PRIVATE_SSH_KEY' > ~/.ssh/huskyci_id_rsa &&
@@ -109,7 +109,7 @@ bandit:
 brakeman:
   name: brakeman
   image: huskyci/brakeman
-  imageTag: "4.8.0"
+  imageTag: "4.8.2"
   cmd: |+
     mkdir -p ~/.ssh &&
     echo 'GIT_PRIVATE_SSH_KEY' > ~/.ssh/huskyci_id_rsa &&
@@ -138,7 +138,7 @@ brakeman:
 safety:
   name: safety
   image: huskyci/safety
-  imageTag: "1.8.5"
+  imageTag: "1.9.0"
   cmd: |+
     mkdir -p ~/.ssh &&
     echo 'GIT_PRIVATE_SSH_KEY' > ~/.ssh/huskyci_id_rsa &&
@@ -184,7 +184,7 @@ safety:
 npmaudit:
   name: npmaudit
   image: huskyci/npmaudit
-  imageTag: "6.13.6"
+  imageTag: "6.14.5"
   cmd: |+
     mkdir -p ~/.ssh &&
     echo 'GIT_PRIVATE_SSH_KEY' > ~/.ssh/huskyci_id_rsa &&
@@ -214,7 +214,7 @@ npmaudit:
 yarnaudit:
   name: yarnaudit
   image: huskyci/yarnaudit
-  imageTag: "1.21.1"
+  imageTag: "1.22.4"
   cmd: |+
     mkdir -p ~/.ssh &&
     echo 'GIT_PRIVATE_SSH_KEY' > ~/.ssh/huskyci_id_rsa &&

--- a/api/context/context.go
+++ b/api/context/context.go
@@ -145,12 +145,12 @@ func (dF DefaultConfig) GetAPIPort() int {
 
 // GetAPIVersion returns current API version
 func (dF DefaultConfig) GetAPIVersion() string {
-	return "0.13.0"
+	return "0.14.0"
 }
 
 // GetAPIReleaseDate returns current API release date
 func (dF DefaultConfig) GetAPIReleaseDate() string {
-	return "2020-02-28"
+	return "2020-06-24"
 }
 
 // GetAllowOriginValue returns the allow origin value

--- a/api/context/context_test.go
+++ b/api/context/context_test.go
@@ -296,8 +296,8 @@ var _ = Describe("Context", func() {
 				apiConfig, err := config.GetAPIConfig()
 				expectedConfig := &APIConfig{
 					Port:             fakeCaller.expectedIntegerValue,
-					Version:          "0.13.0",
-					ReleaseDate:      "2020-02-28",
+					Version:          "0.14.0",
+					ReleaseDate:      "2020-06-24",
 					AllowOriginValue: fakeCaller.expectedEnvVar,
 					UseTLS:           true,
 					GitPrivateSSHKey: fakeCaller.expectedEnvVar,

--- a/client/analysis/output.go
+++ b/client/analysis/output.go
@@ -303,15 +303,6 @@ func printAllSummary(analysis types.Analysis) {
 		fmt.Printf("[HUSKYCI][SUMMARY] NoSecHusky: %d\n", outputJSON.Summary.SpotBugsSummary.NoSecVuln)
 	}
 
-	if outputJSON.Summary.GitleaksSummary.FoundVuln || outputJSON.Summary.GitleaksSummary.FoundInfo {
-		fmt.Println()
-		fmt.Printf("[HUSKYCI][SUMMARY] Generic -> %s\n", gitleaksVersion)
-		fmt.Printf("[HUSKYCI][SUMMARY] High: %d\n", outputJSON.Summary.GitleaksSummary.HighVuln)
-		fmt.Printf("[HUSKYCI][SUMMARY] Medium: %d\n", outputJSON.Summary.GitleaksSummary.MediumVuln)
-		fmt.Printf("[HUSKYCI][SUMMARY] Low: %d\n", outputJSON.Summary.GitleaksSummary.LowVuln)
-		fmt.Printf("[HUSKYCI][SUMMARY] NoSecHusky: %d\n", outputJSON.Summary.GitleaksSummary.NoSecVuln)
-	}
-
 	if outputJSON.Summary.TFSecSummary.FoundVuln || outputJSON.Summary.TFSecSummary.FoundInfo {
 		fmt.Println()
 		fmt.Printf("[HUSKYCI][SUMMARY] HCL -> %s\n", tfsecVersion)
@@ -319,6 +310,15 @@ func printAllSummary(analysis types.Analysis) {
 		fmt.Printf("[HUSKYCI][SUMMARY] Medium: %d\n", outputJSON.Summary.TFSecSummary.MediumVuln)
 		fmt.Printf("[HUSKYCI][SUMMARY] Low: %d\n", outputJSON.Summary.TFSecSummary.LowVuln)
 		fmt.Printf("[HUSKYCI][SUMMARY] NoSecHusky: %d\n", outputJSON.Summary.TFSecSummary.NoSecVuln)
+	}
+
+	if outputJSON.Summary.GitleaksSummary.FoundVuln || outputJSON.Summary.GitleaksSummary.FoundInfo {
+		fmt.Println()
+		fmt.Printf("[HUSKYCI][SUMMARY] Generic -> %s\n", gitleaksVersion)
+		fmt.Printf("[HUSKYCI][SUMMARY] High: %d\n", outputJSON.Summary.GitleaksSummary.HighVuln)
+		fmt.Printf("[HUSKYCI][SUMMARY] Medium: %d\n", outputJSON.Summary.GitleaksSummary.MediumVuln)
+		fmt.Printf("[HUSKYCI][SUMMARY] Low: %d\n", outputJSON.Summary.GitleaksSummary.LowVuln)
+		fmt.Printf("[HUSKYCI][SUMMARY] NoSecHusky: %d\n", outputJSON.Summary.GitleaksSummary.NoSecVuln)
 	}
 
 	if outputJSON.Summary.TotalSummary.FoundVuln || outputJSON.Summary.TotalSummary.FoundInfo {
@@ -336,11 +336,11 @@ func printAllSummary(analysis types.Analysis) {
 func printSTDOUTOutputGosec(issues []types.HuskyCIVulnerability) {
 	for _, issue := range issues {
 		fmt.Println()
+		fmt.Printf("[HUSKYCI][!] Title: %s\n", issue.Title)
 		fmt.Printf("[HUSKYCI][!] Language: %s\n", issue.Language)
 		fmt.Printf("[HUSKYCI][!] Tool: %s\n", issue.SecurityTool)
 		fmt.Printf("[HUSKYCI][!] Severity: %s\n", issue.Severity)
 		fmt.Printf("[HUSKYCI][!] Confidence: %s\n", issue.Confidence)
-		fmt.Printf("[HUSKYCI][!] Title: %s\n", issue.Title)
 		fmt.Printf("[HUSKYCI][!] Details: %s\n", issue.Details)
 		fmt.Printf("[HUSKYCI][!] File: %s\n", issue.File)
 		fmt.Printf("[HUSKYCI][!] Line: %s\n", issue.Line)
@@ -351,11 +351,11 @@ func printSTDOUTOutputGosec(issues []types.HuskyCIVulnerability) {
 func printSTDOUTOutputBandit(issues []types.HuskyCIVulnerability) {
 	for _, issue := range issues {
 		fmt.Println()
+		fmt.Printf("[HUSKYCI][!] Title: %s\n", issue.Title)
 		fmt.Printf("[HUSKYCI][!] Language: %s\n", issue.Language)
 		fmt.Printf("[HUSKYCI][!] Tool: %s\n", issue.SecurityTool)
 		fmt.Printf("[HUSKYCI][!] Severity: %s\n", issue.Severity)
 		fmt.Printf("[HUSKYCI][!] Confidence: %s\n", issue.Confidence)
-		fmt.Printf("[HUSKYCI][!] Title: %s\n", issue.Title)
 		fmt.Printf("[HUSKYCI][!] Details: %s\n", issue.Details)
 		fmt.Printf("[HUSKYCI][!] File: %s\n", issue.File)
 		fmt.Printf("[HUSKYCI][!] Line: %s\n", issue.Line)
@@ -366,6 +366,7 @@ func printSTDOUTOutputBandit(issues []types.HuskyCIVulnerability) {
 func printSTDOUTOutputSafety(issues []types.HuskyCIVulnerability) {
 	for _, issue := range issues {
 		fmt.Println()
+		fmt.Printf("[HUSKYCI][!] Title: %s\n", issue.Title)
 		fmt.Printf("[HUSKYCI][!] Language: %s\n", issue.Language)
 		fmt.Printf("[HUSKYCI][!] Tool: %s\n", issue.SecurityTool)
 		fmt.Printf("[HUSKYCI][!] Severity: %s\n", issue.Severity)
@@ -373,7 +374,6 @@ func printSTDOUTOutputSafety(issues []types.HuskyCIVulnerability) {
 			fmt.Printf("[HUSKYCI][!] Code: %s\n", issue.Code)
 			fmt.Printf("[HUSKYCI][!] Vulnerable Below: %s\n", issue.VunerableBelow)
 		}
-		fmt.Printf("[HUSKYCI][!] Title: %s\n", issue.Title)
 		fmt.Printf("[HUSKYCI][!] Details: %s\n", issue.Details)
 	}
 }
@@ -381,10 +381,10 @@ func printSTDOUTOutputSafety(issues []types.HuskyCIVulnerability) {
 func printSTDOUTOutputBrakeman(issues []types.HuskyCIVulnerability) {
 	for _, issue := range issues {
 		fmt.Println()
+		fmt.Printf("[HUSKYCI][!] Title: %s\n", issue.Title)
 		fmt.Printf("[HUSKYCI][!] Language: %s\n", issue.Language)
 		fmt.Printf("[HUSKYCI][!] Tool: %s\n", issue.SecurityTool)
 		fmt.Printf("[HUSKYCI][!] Confidence: %s\n", issue.Confidence)
-		fmt.Printf("[HUSKYCI][!] Title: %s\n", issue.Title)
 		fmt.Printf("[HUSKYCI][!] Details: %s\n", issue.Details)
 		fmt.Printf("[HUSKYCI][!] File: %s\n", issue.File)
 		fmt.Printf("[HUSKYCI][!] Line: %s\n", issue.Line)
@@ -396,6 +396,7 @@ func printSTDOUTOutputBrakeman(issues []types.HuskyCIVulnerability) {
 func printSTDOUTOutputNpmAudit(issues []types.HuskyCIVulnerability) {
 	for _, issue := range issues {
 		fmt.Println()
+		fmt.Printf("[HUSKYCI][!] Title: %s\n", issue.Title)
 		fmt.Printf("[HUSKYCI][!] Language: %s\n", issue.Language)
 		fmt.Printf("[HUSKYCI][!] Tool: %s\n", issue.SecurityTool)
 		fmt.Printf("[HUSKYCI][!] Severity: %s\n", issue.Severity)
@@ -404,7 +405,6 @@ func printSTDOUTOutputNpmAudit(issues []types.HuskyCIVulnerability) {
 			fmt.Printf("[HUSKYCI][!] Version: %s\n", issue.Version)
 			fmt.Printf("[HUSKYCI][!] Vulnerable Below: %s\n", issue.VunerableBelow)
 		}
-		fmt.Printf("[HUSKYCI][!] Title: %s\n", issue.Title)
 		fmt.Printf("[HUSKYCI][!] Details: %s\n", issue.Details)
 	}
 }
@@ -412,6 +412,7 @@ func printSTDOUTOutputNpmAudit(issues []types.HuskyCIVulnerability) {
 func printSTDOUTOutputYarnAudit(issues []types.HuskyCIVulnerability) {
 	for _, issue := range issues {
 		fmt.Println()
+		fmt.Printf("[HUSKYCI][!] Title: %s\n", issue.Title)
 		fmt.Printf("[HUSKYCI][!] Language: %s\n", issue.Language)
 		fmt.Printf("[HUSKYCI][!] Tool: %s\n", issue.SecurityTool)
 		fmt.Printf("[HUSKYCI][!] Severity: %s\n", issue.Severity)
@@ -421,7 +422,6 @@ func printSTDOUTOutputYarnAudit(issues []types.HuskyCIVulnerability) {
 			fmt.Printf("[HUSKYCI][!] Version: %s\n", issue.Version)
 			fmt.Printf("[HUSKYCI][!] Vulnerable Below: %s\n", issue.VunerableBelow)
 		}
-		fmt.Printf("[HUSKYCI][!] Title: %s\n", issue.Title)
 		fmt.Printf("[HUSKYCI][!] Details: %s\n", issue.Details)
 	}
 }
@@ -429,11 +429,11 @@ func printSTDOUTOutputYarnAudit(issues []types.HuskyCIVulnerability) {
 func printSTDOUTOutputSpotBugs(issues []types.HuskyCIVulnerability) {
 	for _, issue := range issues {
 		fmt.Println()
+		fmt.Printf("[HUSKYCI][!] Title: %s\n", issue.Title)
 		fmt.Printf("[HUSKYCI][!] Language: %s\n", issue.Language)
 		fmt.Printf("[HUSKYCI][!] Tool: %s\n", issue.SecurityTool)
 		fmt.Printf("[HUSKYCI][!] Severity: %s\n", issue.Severity)
 		fmt.Printf("[HUSKYCI][!] Confidence: %s\n", issue.Confidence)
-		fmt.Printf("[HUSKYCI][!] Title: %s\n", issue.Title)
 		fmt.Printf("[HUSKYCI][!] Details: %s\n", issue.Details)
 		fmt.Printf("[HUSKYCI][!] File: %s\n", issue.File)
 		fmt.Printf("[HUSKYCI][!] Line: %s\n", issue.Line)
@@ -444,10 +444,10 @@ func printSTDOUTOutputSpotBugs(issues []types.HuskyCIVulnerability) {
 func printSTDOUTOutputTFSec(issues []types.HuskyCIVulnerability) {
 	for _, issue := range issues {
 		fmt.Println()
+		fmt.Printf("[HUSKYCI][!] Title: %s\n", issue.Title)
 		fmt.Printf("[HUSKYCI][!] Language: %s\n", issue.Language)
 		fmt.Printf("[HUSKYCI][!] Tool: %s\n", issue.SecurityTool)
 		fmt.Printf("[HUSKYCI][!] Severity: %s\n", issue.Severity)
-		fmt.Printf("[HUSKYCI][!] Title: %s\n", issue.Title)
 		fmt.Printf("[HUSKYCI][!] Details: %s\n", issue.Details)
 		fmt.Printf("[HUSKYCI][!] File: %s\n", issue.File)
 		fmt.Printf("[HUSKYCI][!] Line: %s\n", issue.Line)
@@ -458,9 +458,9 @@ func printSTDOUTOutputTFSec(issues []types.HuskyCIVulnerability) {
 func printSTDOUTOutputGitleaks(issues []types.HuskyCIVulnerability) {
 	for _, issue := range issues {
 		fmt.Println()
+		fmt.Printf("[HUSKYCI][!] Title: %s\n", issue.Title)
 		fmt.Printf("[HUSKYCI][!] Tool: %s\n", issue.SecurityTool)
 		fmt.Printf("[HUSKYCI][!] Severity: %s\n", issue.Severity)
-		fmt.Printf("[HUSKYCI][!] Title: %s\n", issue.Title)
 		fmt.Printf("[HUSKYCI][!] Details: %s\n", issue.Details)
 		fmt.Printf("[HUSKYCI][!] File: %s\n", issue.File)
 		fmt.Printf("[HUSKYCI][!] Code: %s\n", issue.Code)


### PR DESCRIPTION
### Description

After running the project we have realized that the Title position in client STDOUT could be the first one. As we are proposing this change, it would be a good idea to update security tests and also the API release/date version after the last huskyCI release (v0.14.0)

### Proposed Changes

This PR will rearrange the Title position and update old stuff. All security tests were update and are available at https://hub.docker.com/r/huskyci/

### Testing

By running `make run-client` the title should be the first one shown in STDOUT: 

```
make install
. .env
make run-client
```

```
[HUSKYCI][!] Title: Blacklisted import crypto/md5: weak cryptographic primitive
[HUSKYCI][!] Language: Go
[HUSKYCI][!] Tool: GoSec
[HUSKYCI][!] Severity: MEDIUM
[HUSKYCI][!] Confidence: HIGH
[HUSKYCI][!] Details: Blacklisted import crypto/md5: weak cryptographic primitive
[HUSKYCI][!] File: /go/src/code/api/util/util.go
[HUSKYCI][!] Line: 4
[HUSKYCI][!] Code: "crypto/md5"
```

To check the updated version, simply run:

```
curl localhost:8888/version
```

```
{"date":"2020-06-24","version":"0.14.0"}
```