### PR TITLE
Adjust tfsec Dockerfile to use latest version

### DIFF
--- a/api/config.yaml
+++ b/api/config.yaml
@@ -337,7 +337,7 @@ gitleaks:
 tfsec:
   name: tfsec
   image: huskyci/tfsec
-  imageTag: "v0.19.0"
+  imageTag: "v0.21.0"
   cmd: |+
     mkdir -p ~/.ssh &&
     echo 'GIT_PRIVATE_SSH_KEY' > ~/.ssh/huskyci_id_rsa &&

--- a/deployments/dockerfiles/tfsec/Dockerfile
+++ b/deployments/dockerfiles/tfsec/Dockerfile
@@ -2,12 +2,10 @@
 # https://hub.docker.com/r/huskyci/tfsec/
 FROM golang:1.13-alpine
 
-ARG TFSEC_VERSION=v0.19.0
-
 RUN apk update && apk upgrade \
-	&& apk add git jq openssh-client
+	&& apk add git jq openssh-client curl
 
-RUN wget https://github.com/liamg/tfsec/releases/download/${TFSEC_VERSION}/tfsec-linux-amd64
+RUN set -o pipefail && curl https://api.github.com/repos/liamg/tfsec/releases/latest | jq -r ".assets[] | select(.name | contains(\"tfsec-linux-amd64\")) | .browser_download_url" | xargs wget
 
 RUN mv tfsec-linux-amd64 tfsec
 


### PR DESCRIPTION
### Description

tfsec's version fixed at "v0.19.0" inside the Dockerfile.

### Proposed Changes

The build stage of our Dockerfile now consults the Github API and retrieve the download link of the latest release of tfsec.

### Testing

Inside the root directory of huskyci's repository execute:

```sh
docker build deployments/dockerfiles/tfsec/ -t huskyci/tfsec:latest
```

Now wait for the build and then execute the following command to check tfsec's version inside our `huskyci/tfsec` container:

```sh
docker run --rm huskyci/tfsec:latest ./tfsec -v
```