### PR TITLE
Bump tfsec's version to v0.24.1

### DIFF
--- a/api/config.yaml
+++ b/api/config.yaml
@@ -338,7 +338,7 @@ gitleaks:
 tfsec:
   name: tfsec
   image: huskyci/tfsec
-  imageTag: "v0.21.0"
+  imageTag: "v0.24.1"
   cmd: |+
     mkdir -p ~/.ssh &&
     echo '%GIT_PRIVATE_SSH_KEY%' > ~/.ssh/huskyci_id_rsa &&


### PR DESCRIPTION
### Description

After seeing some instability being caused due to an older `tfsec` version, I decided to try and update to the latest one, `v0.24.1`, to see if there were any improvements.

Also, a new image has been created and made available on Docker Hub:
https://hub.docker.com/r/huskyci/tfsec/tags

### Proposed Changes

Bump `tfsec` version from `v0.19.0` to `v0.24.1` in `api/config.yaml`.
