### PR TITLE
Adjust new logic git URL substitute feature

### DIFF
--- a/api/config.yaml
+++ b/api/config.yaml
@@ -60,11 +60,15 @@ gosec:
   imageTag: v2.3.0
   cmd: |+
     mkdir -p ~/.ssh &&
-    echo '%GIT_PRIVATE_SSH_KEY%' > ~/.ssh/huskyci_id_rsa &&
-    chmod 600 ~/.ssh/huskyci_id_rsa &&
-    echo "IdentityFile ~/.ssh/huskyci_id_rsa" >> /etc/ssh/ssh_config &&
-    echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config
-    git config --global url."%GIT_SSH_URL%:".insteadOf "%GIT_URL_TO_SUBSTITUTE%"
+    echo '%GIT_PRIVATE_SSH_KEY%' > ~/.ssh/id_rsa &&
+    chmod 600 ~/.ssh/id_rsa &&
+    echo "IdentityFile ~/.ssh/id_rsa" >> /etc/ssh/ssh_config &&
+    echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config &&
+    gitURL="%GIT_SSH_URL%"
+    gitURLSubtitute="%GIT_URL_TO_SUBSTITUTE%"
+    if [ $gitURL != "nil" ] && [ $gitURLSubtitute != "nil" ]; then
+      git config --global url."$gitURL:".insteadOf "$gitURLSubtitute"
+    fi
     cd src
     GIT_TERMINAL_PROMPT=0 git clone -b %GIT_BRANCH% --single-branch %GIT_REPO% code --quiet 2> /tmp/errorGitCloneGosec
     if [ $? -eq 0 ]; then

--- a/api/util/util.go
+++ b/api/util/util.go
@@ -47,8 +47,8 @@ func HandleGitURLSubstitution(rawString string) string {
 	gitURLToSubstitute := os.Getenv("HUSKYCI_API_GIT_URL_TO_SUBSTITUTE")
 
 	if gitSSHURL == "" || gitURLToSubstitute == "" {
-		gitSSHURL = ""
-		gitURLToSubstitute = ""
+		gitSSHURL = "nil"
+		gitURLToSubstitute = "nil"
 	}
 	cmdReplaced := strings.Replace(rawString, "%GIT_SSH_URL%", gitSSHURL, -1)
 	cmdReplaced = strings.Replace(cmdReplaced, "%GIT_URL_TO_SUBSTITUTE%", gitURLToSubstitute, -1)


### PR DESCRIPTION
### Motivation

After #496, users are now facing some problems cloning internal repositories. By simply running `make install` and `make run-client` the following error is shown:

```
$ make run-client
[HUSKYCI][*] poc-golang-gosec -> https://github.com/globocom/huskyCI.git
[HUSKYCI][*] huskyCI analysis started! NsnbLvq3bCYzdA3A0EwmHKS4sf8pSwlr
[HUSKYCI][ERROR] Monitoring analysis NsnbLvq3bCYzdA3A0EwmHKS4sf8pSwlr: huskyCI encountered an error trying to execute this analysis: error cloning
make: *** [run-client] Error 1
```

### Proposed Changes

This Pull Request closes #501 by changing the logic when using the `git config global` command.

### Testing

Step 1: [Generate a RSA SSH key](https://gitlab.com/help/ssh/README#rsa-ssh-keys) and set it up in your Github/Gitlab.

Step 2: Add the `HUSKYCI_API_GIT_PRIVATE_SSH_KEY` environment variable to huskyCI_API service in docker-compose.yaml using the following pattern:

```yaml
HUSKYCI_API_GIT_PRIVATE_SSH_KEY: |
      -----BEGIN OPENSSH PRIVATE KEY-----
      b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAABFwAAAAdzc2gtcn
      ...
      -----END OPENSSH PRIVATE KEY----- 
```

Step 3: Install huskyCI locally and set `HUSKYCI_CLIENT_REPO_URL` using the SSH pattern URL (example: `git@gitlab.com:rafaveira3/internal-huskyci.git`)

```sh
make install
``` 

```sh
export HUSKYCI_CLIENT_REPO_URL="git@gitlab.com:rafaveira3/internal-huskyci.git"
export HUSKYCI_CLIENT_REPO_BRANCH="master"
export HUSKYCI_CLIENT_API_ADDR="http://localhost:8888"
export HUSKYCI_CLIENT_API_USE_HTTPS="false"
export HUSKYCI_CLIENT_TOKEN="YTdkMDk0YmEtMTA4ZS00MzVlLWJiYTAtM2Y5MDBlYzRmYzFiOm1JU2MtNnBYTWd0cW1IalRiRTJaTm9QNFp4VFpBRENaT2Z6eFlLSlVTNmM9" 
```

Step 4: Source .env and run:

```
. .env
```

```sh
$ make run-client
[HUSKYCI][*] master -> git@gitlab.com:rafaveira3/internal-huskyci.git
[HUSKYCI][*] huskyCI analysis started! OU5brSL13Av0VYUaDv88g9Xn6wWirsQ0
[HUSKYCI][!] Hold on! huskyCI is still running...
[HUSKYCI][!] Hold on! huskyCI is still running...

[HUSKYCI][!] Title: Blacklisted import crypto/md5: weak cryptographic primitive
[HUSKYCI][!] Language: Go
[HUSKYCI][!] Tool: GoSec
[HUSKYCI][!] Severity: MEDIUM
[HUSKYCI][!] Confidence: HIGH
[HUSKYCI][!] Details: Blacklisted import crypto/md5: weak cryptographic primitive
[HUSKYCI][!] File: /go/src/code/main.go
[HUSKYCI][!] Line: 4
[HUSKYCI][!] Code: "crypto/md5"

[HUSKYCI][!] Title: Use of weak cryptographic primitive
[HUSKYCI][!] Language: Go
[HUSKYCI][!] Tool: GoSec
[HUSKYCI][!] Severity: MEDIUM
[HUSKYCI][!] Confidence: HIGH
[HUSKYCI][!] Details: Use of weak cryptographic primitive
[HUSKYCI][!] File: /go/src/code/main.go
[HUSKYCI][!] Line: 15
[HUSKYCI][!] Code: md5.New()

[HUSKYCI][SUMMARY] Go -> huskyci/gosec:v2.3.0
[HUSKYCI][SUMMARY] High: 0
[HUSKYCI][SUMMARY] Medium: 2
[HUSKYCI][SUMMARY] Low: 0
[HUSKYCI][SUMMARY] NoSecHusky: 1

[HUSKYCI][SUMMARY] Total
[HUSKYCI][SUMMARY] High: 0
[HUSKYCI][SUMMARY] Medium: 2
[HUSKYCI][SUMMARY] Low: 0
[HUSKYCI][SUMMARY] NoSecHusky: 1

[HUSKYCI][*] The following securityTests were executed and no blocking vulnerabilities were found:
[HUSKYCI][*] [huskyci/gitleaks:2.1.0]
[HUSKYCI][*] Some HIGH/MEDIUM issues were found in these securityTests:
[HUSKYCI][*] [huskyci/gosec:v2.3.0]
make: *** [run-client] Error 190 
```
