### PR TITLE
Update API tests to support changes made on #502

### DIFF
--- a/api/util/util_test.go
+++ b/api/util/util_test.go
@@ -52,9 +52,9 @@ var _ = Describe("Util", func() {
 	Describe("HandleGitURLSubstitution", func() {
 
 		rawString := "git config --global url.\"%GIT_SSH_URL%:\".insteadOf \"%GIT_URL_TO_SUBSTITUTE%\""
-		expectedURLToSubstituteNotEmpty := "git config --global url.\":\".insteadOf \"\""
-		expectedSSHURLNotEmpty := "git config --global url.\":\".insteadOf \"\""
-		expectedBothVarsEmpty := "git config --global url.\":\".insteadOf \"\""
+		expectedURLToSubstituteNotEmpty := "git config --global url.\"nil:\".insteadOf \"nil\""
+		expectedSSHURLNotEmpty := "git config --global url.\"nil:\".insteadOf \"nil\""
+		expectedBothVarsEmpty := "git config --global url.\"nil:\".insteadOf \"nil\""
 		expectedNotEmpty := "git config --global url.\"gitlab@gitlab.example.com:\".insteadOf \"https://gitlab.example.com/\""
 
 		Context("When rawString is not empty, HUSKYCI_API_GIT_SSH_URL is empty, but HUSKYCI_API_GIT_URL_TO_SUBSTITUTE is not empty", func() {


### PR DESCRIPTION
### Motivation

After #502, some of the tests needed to updated in order to run correctly.

### Proposed Changes

Update test logic to expect the new `nil` return string.

### Testing

```
make test
```
