### PR TITLE
Update GitLeaks security test version to 6.1.2

### DIFF
--- a/api/config.yaml
+++ b/api/config.yaml
@@ -311,7 +311,7 @@ spotbugs:
 gitleaks:
   name: gitleaks
   image: huskyci/gitleaks
-  imageTag: "v6.1.0"
+  imageTag: "v6.1.2"
   cmd: |+
     mkdir -p ~/.ssh &&
     echo '%GIT_PRIVATE_SSH_KEY%' > ~/.ssh/huskyci_id_rsa &&

--- a/api/config.yaml
+++ b/api/config.yaml
@@ -311,7 +311,7 @@ spotbugs:
 gitleaks:
   name: gitleaks
   image: huskyci/gitleaks
-  imageTag: "2.1.0"
+  imageTag: "v6.1.0"
   cmd: |+
     mkdir -p ~/.ssh &&
     echo '%GIT_PRIVATE_SSH_KEY%' > ~/.ssh/huskyci_id_rsa &&
@@ -321,13 +321,15 @@ gitleaks:
     GIT_TERMINAL_PROMPT=0 git clone -b %GIT_BRANCH% --single-branch %GIT_REPO% code --quiet 2> /tmp/errorGitCloneGitleaks
     if [ $? -eq 0 ]; then
         touch /tmp/results.json
-        timeout -t 360 $(which gitleaks) --log=warn --report=/tmp/results.json --repo-path=./code --branch=%GIT_BRANCH% --repo-config &> /tmp/errorGitleaks
-        if [[ $? -eq 124 || $? -eq 143 ]]; then #timeout exit codes
-            echo 'ERROR_TIMEOUT_GITLEAKS'
-            cat /tmp/errorGitleaks
-        elif [ $? -eq 2 ]; then
-            echo 'ERROR_RUNNING_GITLEAKS'
-            cat /tmp/errorGitleaks
+        $(which gitleaks) --timeout 5m --report=/tmp/results.json --repo-path=./code --branch=%GIT_BRANCH% --repo-config &> /tmp/errorGitleaks
+        if [ $? -eq 2 ]; then #no gitleaks config file found
+            $(which gitleaks) --timeout 5m --report=/tmp/results.json --repo-path=./code --branch=%GIT_BRANCH% &> /tmp/errorGitleaks
+            if [ $? -eq 2 ]; then
+                echo 'ERROR_RUNNING_GITLEAKS'
+                cat /tmp/errorGitleaks
+            else
+                jq -j -M -c . /tmp/results.json
+            fi
         else
             jq -j -M -c . /tmp/results.json
         fi

--- a/api/securitytest/gitleaks.go
+++ b/api/securitytest/gitleaks.go
@@ -92,6 +92,7 @@ func (gitleaksScan *SecTestScanInfo) prepareGitleaksVulns() {
 		gitleaksVuln.Title = issue.Rule + " sensitive data found"
 		gitleaksVuln.File = issue.File
 		gitleaksVuln.Code = issue.Line
+		gitleaksVuln.Details = issue.Commit
 		gitleaksVuln.Title = "Hard Coded " + issue.Rule + " in: " + issue.File
 
 		switch issue.Rule {

--- a/api/securitytest/gitleaks.go
+++ b/api/securitytest/gitleaks.go
@@ -22,14 +22,13 @@ type GitLeaksIssue struct {
 	Offender      string `json:"offender"`
 	Rule          string `json:"rule"`
 	Info          string `json:"info"`
-	CommitMessage string `json:"commitMsg"`
+	CommitMessage string `json:"commitMessage"`
 	Author        string `json:"author"`
 	Email         string `json:"email"`
 	File          string `json:"file"`
 	Repository    string `json:"repo"`
 	Date          string `json:"date"`
 	Tags          string `json:"tags"`
-	Severity      string `json:"severity"`
 }
 
 func analyseGitleaks(gitleaksScan *SecTestScanInfo) error {
@@ -38,15 +37,6 @@ func analyseGitleaks(gitleaksScan *SecTestScanInfo) error {
 
 	// nil cOutput states that no Issues were found.
 	if gitleaksScan.Container.COutput == "" {
-		gitleaksScan.prepareContainerAfterScan()
-		return nil
-	}
-
-	// if gitleaks timeout, a warning will be generated as a low vuln
-	gitleaksTimeout := strings.Contains(gitleaksScan.Container.COutput, "ERROR_TIMEOUT_GITLEAKS")
-	if gitleaksTimeout {
-		gitleaksScan.GitleaksTimeout = true
-		gitleaksScan.prepareGitleaksVulns()
 		gitleaksScan.prepareContainerAfterScan()
 		return nil
 	}
@@ -78,18 +68,6 @@ func (gitleaksScan *SecTestScanInfo) prepareGitleaksVulns() {
 
 	huskyCIgitleaksResults := types.HuskyCISecurityTestOutput{}
 	gitleaksOutput := gitleaksScan.FinalOutput.(GitleaksOutput)
-
-	if gitleaksScan.GitleaksTimeout {
-		gitleaksVuln := types.HuskyCIVulnerability{}
-		gitleaksVuln.Language = "Generic"
-		gitleaksVuln.SecurityTool = "Gitleaks"
-		gitleaksVuln.Severity = "low"
-		gitleaksVuln.Title = "Too big project for Gitleaks scan"
-		gitleaksVuln.Details = "It looks like your project is too big and huskyCI was not able to run Gitleaks."
-
-		gitleaksScan.Vulnerabilities.LowVulns = append(gitleaksScan.Vulnerabilities.LowVulns, gitleaksVuln)
-		return
-	}
 
 	if gitleaksScan.GitleaksErrorRunning {
 		gitleaksVuln := types.HuskyCIVulnerability{}

--- a/client/analysis/output.go
+++ b/client/analysis/output.go
@@ -461,7 +461,7 @@ func printSTDOUTOutputGitleaks(issues []types.HuskyCIVulnerability) {
 		fmt.Printf("[HUSKYCI][!] Title: %s\n", issue.Title)
 		fmt.Printf("[HUSKYCI][!] Tool: %s\n", issue.SecurityTool)
 		fmt.Printf("[HUSKYCI][!] Severity: %s\n", issue.Severity)
-		fmt.Printf("[HUSKYCI][!] Details: %s\n", issue.Details)
+		fmt.Printf("[HUSKYCI][!] Details: Commit hash %s\n", issue.Details)
 		fmt.Printf("[HUSKYCI][!] File: %s\n", issue.File)
 		fmt.Printf("[HUSKYCI][!] Code: %s\n", issue.Code)
 	}


### PR DESCRIPTION
### Description

Update the GitLeaks security test to the latest version.

### Proposed Changes

This PR aims to update the GitLeaks security test to version `6.1.2`, update the commands needed to run in `api/config.yml`, and modify the output to feature the offender commit hash. The output should now look like this:

![image](https://user-images.githubusercontent.com/40367872/92158496-5fa1b580-ee02-11ea-955b-3e7720a186c5.png)


If applied, the `GitLeaks` timeout will be reduced from 6 minutes to 5 minutes, but this can easily be changed later if desired.

### Testing

```
make install
```

Update env-vars to point to the `poc-gitleaks` test branch.

```
make run-client
```