### PR TITLE
Revert "Update GitLeaks security test version to 6.1.2"

### DIFF
--- a/api/config.yaml
+++ b/api/config.yaml
@@ -311,7 +311,7 @@ spotbugs:
 gitleaks:
   name: gitleaks
   image: huskyci/gitleaks
-  imageTag: "v6.1.2"
+  imageTag: "2.1.0"
   cmd: |+
     mkdir -p ~/.ssh &&
     echo '%GIT_PRIVATE_SSH_KEY%' > ~/.ssh/huskyci_id_rsa &&
@@ -321,15 +321,13 @@ gitleaks:
     GIT_TERMINAL_PROMPT=0 git clone -b %GIT_BRANCH% --single-branch %GIT_REPO% code --quiet 2> /tmp/errorGitCloneGitleaks
     if [ $? -eq 0 ]; then
         touch /tmp/results.json
-        $(which gitleaks) --timeout 5m --report=/tmp/results.json --repo-path=./code --branch=%GIT_BRANCH% --repo-config &> /tmp/errorGitleaks
-        if [ $? -eq 2 ]; then #no gitleaks config file found
-            $(which gitleaks) --timeout 5m --report=/tmp/results.json --repo-path=./code --branch=%GIT_BRANCH% &> /tmp/errorGitleaks
-            if [ $? -eq 2 ]; then
-                echo 'ERROR_RUNNING_GITLEAKS'
-                cat /tmp/errorGitleaks
-            else
-                jq -j -M -c . /tmp/results.json
-            fi
+        timeout -t 360 $(which gitleaks) --log=warn --report=/tmp/results.json --repo-path=./code --branch=%GIT_BRANCH% --repo-config &> /tmp/errorGitleaks
+        if [[ $? -eq 124 || $? -eq 143 ]]; then #timeout exit codes
+            echo 'ERROR_TIMEOUT_GITLEAKS'
+            cat /tmp/errorGitleaks
+        elif [ $? -eq 2 ]; then
+            echo 'ERROR_RUNNING_GITLEAKS'
+            cat /tmp/errorGitleaks
         else
             jq -j -M -c . /tmp/results.json
         fi

--- a/api/securitytest/gitleaks.go
+++ b/api/securitytest/gitleaks.go
@@ -22,13 +22,14 @@ type GitLeaksIssue struct {
 	Offender      string `json:"offender"`
 	Rule          string `json:"rule"`
 	Info          string `json:"info"`
-	CommitMessage string `json:"commitMessage"`
+	CommitMessage string `json:"commitMsg"`
 	Author        string `json:"author"`
 	Email         string `json:"email"`
 	File          string `json:"file"`
 	Repository    string `json:"repo"`
 	Date          string `json:"date"`
 	Tags          string `json:"tags"`
+	Severity      string `json:"severity"`
 }
 
 func analyseGitleaks(gitleaksScan *SecTestScanInfo) error {
@@ -37,6 +38,15 @@ func analyseGitleaks(gitleaksScan *SecTestScanInfo) error {
 
 	// nil cOutput states that no Issues were found.
 	if gitleaksScan.Container.COutput == "" {
+		gitleaksScan.prepareContainerAfterScan()
+		return nil
+	}
+
+	// if gitleaks timeout, a warning will be generated as a low vuln
+	gitleaksTimeout := strings.Contains(gitleaksScan.Container.COutput, "ERROR_TIMEOUT_GITLEAKS")
+	if gitleaksTimeout {
+		gitleaksScan.GitleaksTimeout = true
+		gitleaksScan.prepareGitleaksVulns()
 		gitleaksScan.prepareContainerAfterScan()
 		return nil
 	}
@@ -69,6 +79,18 @@ func (gitleaksScan *SecTestScanInfo) prepareGitleaksVulns() {
 	huskyCIgitleaksResults := types.HuskyCISecurityTestOutput{}
 	gitleaksOutput := gitleaksScan.FinalOutput.(GitleaksOutput)
 
+	if gitleaksScan.GitleaksTimeout {
+		gitleaksVuln := types.HuskyCIVulnerability{}
+		gitleaksVuln.Language = "Generic"
+		gitleaksVuln.SecurityTool = "Gitleaks"
+		gitleaksVuln.Severity = "low"
+		gitleaksVuln.Title = "Too big project for Gitleaks scan"
+		gitleaksVuln.Details = "It looks like your project is too big and huskyCI was not able to run Gitleaks."
+
+		gitleaksScan.Vulnerabilities.LowVulns = append(gitleaksScan.Vulnerabilities.LowVulns, gitleaksVuln)
+		return
+	}
+
 	if gitleaksScan.GitleaksErrorRunning {
 		gitleaksVuln := types.HuskyCIVulnerability{}
 		gitleaksVuln.Language = "Generic"
@@ -92,7 +114,6 @@ func (gitleaksScan *SecTestScanInfo) prepareGitleaksVulns() {
 		gitleaksVuln.Title = issue.Rule + " sensitive data found"
 		gitleaksVuln.File = issue.File
 		gitleaksVuln.Code = issue.Line
-		gitleaksVuln.Details = issue.Commit
 		gitleaksVuln.Title = "Hard Coded " + issue.Rule + " in: " + issue.File
 
 		switch issue.Rule {

--- a/client/analysis/output.go
+++ b/client/analysis/output.go
@@ -461,7 +461,7 @@ func printSTDOUTOutputGitleaks(issues []types.HuskyCIVulnerability) {
 		fmt.Printf("[HUSKYCI][!] Title: %s\n", issue.Title)
 		fmt.Printf("[HUSKYCI][!] Tool: %s\n", issue.SecurityTool)
 		fmt.Printf("[HUSKYCI][!] Severity: %s\n", issue.Severity)
-		fmt.Printf("[HUSKYCI][!] Details: Commit hash %s\n", issue.Details)
+		fmt.Printf("[HUSKYCI][!] Details: %s\n", issue.Details)
 		fmt.Printf("[HUSKYCI][!] File: %s\n", issue.File)
 		fmt.Printf("[HUSKYCI][!] Code: %s\n", issue.Code)
 	}


### PR DESCRIPTION
## Reverts globocom/huskyCI#505

After some more tests on our internal pipeline, this new version of `GitLeaks` doesn't seem to behave in the same manner as the previous one and must be reverted. 

In the `v6.1.2` `GitLeaks` version, by setting the `--repo-config` flag, the tool tries to find the config file, `.gitleaks.toml`, and overwrites its own default set of rules by the ones present in it. The issue we're facing is that repositories that only want to add `allowlist` rules will also need to input the default settings for the tool to work with them.

The code here developed is functional and working and there is an ongoing [issue](https://github.com/zricethezav/gitleaks/issues/429) in `GitLeaks` repository that addresses this matter. After it's finished and merged, we'd simply need to merge the `Update-Gitleaks` branch back.