### PR TITLE
enhancement: make security test timeout configurable via env variable

### DIFF
--- a/api/analysis/analysis.go
+++ b/api/analysis/analysis.go
@@ -29,6 +29,7 @@ func StartAnalysis(RID string, repository types.Repository) {
 	// step 2: run enry as huskyCI initial step
 	enryScan := securitytest.SecTestScanInfo{}
 	enryScan.SecurityTestName = "enry"
+	enryScan.TimeOut = repository.TimeOut
 	allScansResults := securitytest.RunAllInfo{}
 
 	defer func() {

--- a/api/securitytest/run.go
+++ b/api/securitytest/run.go
@@ -103,6 +103,7 @@ func (results *RunAllInfo) runGenericScans(enryScan SecTestScanInfo) error {
 		go func(genericTest *types.SecurityTest) {
 			defer wg.Done()
 			newGenericScan := SecTestScanInfo{}
+			newGenericScan.TimeOut = enryScan.TimeOut
 			if err := newGenericScan.New(enryScan.RID, enryScan.URL, enryScan.Branch, genericTest.Name); err != nil {
 				select {
 				case <-syncChan:
@@ -166,6 +167,7 @@ func (results *RunAllInfo) runLanguageScans(enryScan SecTestScanInfo) error {
 		go func(languageTest *types.SecurityTest) {
 			defer wg.Done()
 			newLanguageScan := SecTestScanInfo{}
+			newLanguageScan.TimeOut = enryScan.TimeOut
 			if err := newLanguageScan.New(enryScan.RID, enryScan.URL, enryScan.Branch, languageTest.Name); err != nil {
 				select {
 				case <-syncChan:

--- a/api/securitytest/securitytest.go
+++ b/api/securitytest/securitytest.go
@@ -33,6 +33,7 @@ type SecTestScanInfo struct {
 	Branch                string
 	SecurityTestName      string
 	ErrorFound            error
+	TimeOut               int
 	ReqNotFound           bool
 	WarningFound          bool
 	PackageNotFound       bool
@@ -71,7 +72,12 @@ func (scanInfo *SecTestScanInfo) setSecurityTestContainer(securityTestName strin
 
 // Start starts a new huskyCI scan!
 func (scanInfo *SecTestScanInfo) Start() error {
-	if err := scanInfo.dockerRun(scanInfo.Container.SecurityTest.TimeOutInSeconds); err != nil {
+	// Override default timeout if a custom timeout is passed
+	timeOut := scanInfo.TimeOut
+	if timeOut == 0 {
+		timeOut = scanInfo.Container.SecurityTest.TimeOutInSeconds
+	}
+	if err := scanInfo.dockerRun(timeOut); err != nil {
 		scanInfo.ErrorFound = err
 		scanInfo.prepareContainerAfterScan()
 		return err

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -12,6 +12,7 @@ import (
 type Repository struct {
 	URL       string    `bson:"repositoryURL" json:"repositoryURL"`
 	Branch    string    `json:"repositoryBranch"`
+	TimeOut   int       `json:"timeOutInSeconds"`
 	CreatedAt time.Time `bson:"createdAt" json:"createdAt"`
 }
 

--- a/client/analysis/analysis.go
+++ b/client/analysis/analysis.go
@@ -27,6 +27,7 @@ func StartAnalysis() (string, error) {
 	requestPayload := types.JSONPayload{
 		RepositoryURL:    config.RepositoryURL,
 		RepositoryBranch: config.RepositoryBranch,
+		TimeOutInSeconds: config.TimeOutInSeconds,
 	}
 
 	marshalPayload, err := json.Marshal(requestPayload)

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -7,6 +7,7 @@ package config
 import (
 	"errors"
 	"os"
+	"strconv"
 )
 
 // RepositoryURL stores the repository URL of the project to be analyzed.
@@ -24,6 +25,9 @@ var HuskyToken string
 // HuskyUseTLS stores if huskyCI is to use an HTTPS connection.
 var HuskyUseTLS bool
 
+// Timeout in Seconds for huskyCI tests
+var TimeOutInSeconds int
+
 // SetConfigs sets all configuration needed to start the client.
 func SetConfigs() {
 	RepositoryURL = os.Getenv(`HUSKYCI_CLIENT_REPO_URL`)
@@ -31,6 +35,7 @@ func SetConfigs() {
 	HuskyAPI = os.Getenv(`HUSKYCI_CLIENT_API_ADDR`)
 	HuskyToken = os.Getenv(`HUSKYCI_CLIENT_TOKEN`)
 	HuskyUseTLS = getUseTLS()
+	TimeOutInSeconds, _ = strconv.Atoi(os.Getenv(`HUSKYCI_CLIENT_TESTS_TIMEOUT`))
 }
 
 // CheckEnvVars checks if all environment vars are set.

--- a/client/types/types.go
+++ b/client/types/types.go
@@ -23,6 +23,7 @@ var IsJSONoutput bool
 type JSONPayload struct {
 	RepositoryURL    string `json:"repositoryURL"`
 	RepositoryBranch string `json:"repositoryBranch"`
+	TimeOutInSeconds int    `json:"timeOutInSeconds"`
 }
 
 // Target is the struct that represents HuskyCI API target


### PR DESCRIPTION
Security Test timeouts are currently hardcoded in API's
config.yml.

Provide user options to use a environment variable
HUSKYCI_CLIENT_TESTS_TIMEOUT in the client code. All requests
send to the API henceforth will contain that timeout.

On the API side, if a non zero custom timeout is detected, it
shall override the default timeouts for the security tests.

Signed-off-by: Dwaipayan Ray <dwaipayanray1@gmail.com>

### Description

Adds support for setting Security Test timeout from the client side
using environment variables.

Closes #509 

### Proposed Changes

Add custom timeout handling logic in both the api and client. Timeout is
completely optional and no function signatures were changed. So, there 
are no breaking changes.

### Testing

```
make install
export HUSKYCI_CLIENT_TESTS_TIMEOUT=1
make run-client-linux
```
