### PR TITLE
Add DefectDojo Compatible shield to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
   <a href="https://circleci.com/gh/globocom/huskyCI/tree/master"><img src="https://img.shields.io/circleci/build/github/globocom/huskyCI/master?token=415bfb6b5aa0dfce8d2129878a66326da9533150"/></a>
   <a href="https://github.com/rafaveira3/writing-and-presentations/blob/master/DEFCON-27-APP-SEC-VILLAGE-Rafael-Santos-huskyCI-Finding-security-flaws-in-CI-before-deploying-them.pdf"><img src="https://img.shields.io/badge/DEFCON%2027-AppSec%20Village-black"/></a>
 <a href="https://github.com/rafaveira3/contributions/blob/master/huskyCI-BlackHat-Europe-2019.pdf"><img src="https://img.shields.io/badge/Black%20Hat%20Europe%202019-Arsenal-black"/></a>
+<a href="https://defectdojo.readthedocs.io/en/latest/integrations.html#huskyci-report"><img src="https://img.shields.io/badge/DefectDojo-Compatible-brightgreen"/></a>
 </p>
 
 ## Introduction


### PR DESCRIPTION
### Description

huskyCI has been integrated into DefectDojo many available [Integrations](https://defectdojo.readthedocs.io/en/latest/integrations.html#huskyci-report), it would be nice to display this compatibility in an easy and friendly manner.

### Proposed Changes

The goal of this PR is to introduce a new shield to huskyCI's README.

<a href="https://defectdojo.readthedocs.io/en/latest/integrations.html#huskyci-report"><img src="https://img.shields.io/badge/DefectDojo-Compatible-brightgreen"/></a>

### Testing

Open the `README.md` file and look for the DefectDojo Compatible shield.