### PR TITLE
feat: allow multiple internal remotes

### DIFF
--- a/api/config.yaml
+++ b/api/config.yaml
@@ -67,7 +67,12 @@ gosec:
     gitURL="%GIT_SSH_URL%"
     gitURLSubtitute="%GIT_URL_TO_SUBSTITUTE%"
     if [ $gitURL != "nil" ] && [ $gitURLSubtitute != "nil" ]; then
-      git config --global url."$gitURL:".insteadOf "$gitURLSubtitute"
+      if [ "${#gitURL[@]}" == "${#gitURLSubtitute[@]}" ]; then
+        for (( i=0; i<${#gitURL[@]}; i++ ));
+        do
+          git config --global url."${gitURL[$i]}:".insteadOf "${gitURLSubtitute[$i]}"
+        done
+      fi
     fi
     cd src
     GIT_TERMINAL_PROMPT=0 git clone -b %GIT_BRANCH% --single-branch %GIT_REPO% code --quiet 2> /tmp/errorGitCloneGosec


### PR DESCRIPTION
### Description

Closes #497

### Proposed Changes

Allows substitution of multiple remotes. It should work with a single repository as it did before, so there are no breaking changes.

### Testing

Run huskyCI for a Go project that contains internal repositories from more than one source requiring SSH authentication.
```
HUSKYCI_API_GIT_SSH_URL=("gitlab@gitlab.example.com" "gitlab@gitlab.otherexample.com" "gitlab@gitlab.anotherexample.com")
HUSKYCI_API_GIT_URL_TO_SUBSTITUTE=("https://gitlab.example.com/" "https://gitlab.otherexample.com/" "https://gitlab.anotherexample.com/")
```