### PR TITLE
513 Add stats caching

### DIFF
--- a/api/context/context_test.go
+++ b/api/context/context_test.go
@@ -1,11 +1,11 @@
 package context_test
 
 import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-
 	"errors"
 	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 
 	. "github.com/globocom/huskyCI/api/context"
 	"github.com/globocom/huskyCI/api/db"
@@ -438,6 +438,7 @@ var _ = Describe("Context", func() {
 						TimeOutInSeconds: fakeCaller.expectedIntFromConfig,
 					},
 					DBInstance: &db.MongoRequests{},
+					Cache:      apiConfig.Cache, // cannot be compared due to channels inside the structure
 				}
 				Expect(apiConfig).To(Equal(expectedConfig))
 				Expect(err).To(BeNil())

--- a/api/go.mod
+++ b/api/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/onsi/ginkgo v1.12.1
 	github.com/onsi/gomega v1.10.0
 	github.com/opencontainers/go-digest v1.0.0 // indirect
+	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/spf13/viper v1.7.0
 	github.com/valyala/fasttemplate v1.1.0 // indirect
 	golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37

--- a/api/go.sum
+++ b/api/go.sum
@@ -164,6 +164,8 @@ github.com/onsi/gomega v1.10.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGco
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
+github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
+github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/api/server.go
+++ b/api/server.go
@@ -9,14 +9,15 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/labstack/echo"
+	"github.com/labstack/echo/middleware"
+
 	"github.com/globocom/huskyCI/api/auth"
 	apiContext "github.com/globocom/huskyCI/api/context"
 	"github.com/globocom/huskyCI/api/log"
 	"github.com/globocom/huskyCI/api/routes"
 	"github.com/globocom/huskyCI/api/util"
 	apiUtil "github.com/globocom/huskyCI/api/util/api"
-	"github.com/labstack/echo"
-	"github.com/labstack/echo/middleware"
 )
 
 func main() {


### PR DESCRIPTION
### Description

Add cache in the API to better serve the stats.

Closes #513

### Proposed Changes

Cache responses for the *stats* routes (using [go-cache](https://github.com/patrickmn/go-cache)).

The PR presents two new environment variables for the cache configuration:

- `HUSKYCI_CACHE_DEFAULT_EXPIRATION` (if not set equals 5m)
- `HUSKYCI_CACHE_CLEANUP_INTERVAL` (if not set equals 10m)

**This variables should be added on the HuskyCI [official documentation page](https://huskyci.opensource.globo.com/docs/api/env-vars)!**

### Testing

```
make install

# do it multiple times and also with another stats routes
curl http://localhost:8888/stats/author
```
