### PR TITLE
Fix Gosec execution error

### DIFF
--- a/api/config.yaml
+++ b/api/config.yaml
@@ -68,7 +68,8 @@ gosec:
     gitURLSubtitute="%GIT_URL_TO_SUBSTITUTE%"
     if [ $gitURL != "nil" ] && [ $gitURLSubtitute != "nil" ]; then
       if [ "${#gitURL[@]}" == "${#gitURLSubtitute[@]}" ]; then
-        for (( i=0; i<${#gitURL[@]}; i++ ));
+        i = 0
+        while [ "$i" -le ${#gitURL[@]} ];
         do
           git config --global url."${gitURL[$i]}:".insteadOf "${gitURLSubtitute[$i]}"
         done


### PR DESCRIPTION
### Description

Closes #520 

### Proposed Changes

Changes that this PR will introduce. Are there any breaking changes?

Thanks to @somehowchris, we were able to identify an error with the execution command in gosec's huskyCI configuration.

The goal of this PR is to substitute the following code, [here in config.yaml](https://github.com/globocom/huskyCI/blob/master/api/config.yaml#L71), with one that is `sh` compatible:

```sh
for (( i=0; i<${#gitURL[@]}; i++ ));
```

Becomes:

```sh
i = 0
while [ "$i" -le ${#gitURL[@]} ];
```

### Testing

The following commands should be successful and return a valid huskyCI analysis:

``` sh
make install
source .env #(make sure the code being tested uses golang) 

make run-client #if using mac os
```
