### PR TITLE
feat: adding brakeman.ignore support to huskyci

### DIFF
--- a/api/config.yaml
+++ b/api/config.yaml
@@ -129,8 +129,13 @@ brakeman:
     GIT_TERMINAL_PROMPT=0 git clone -b %GIT_BRANCH% --single-branch %GIT_REPO% code --quiet 2> /tmp/errorGitCloneBrakeman
     if [ $? -eq 0 ]; then
       if [ -d /code/app ]; then
-        brakeman -q -o results.json /code
-        jq -j -M -c . results.json
+        if [ -f /code/brakeman.ignore ]; then
+          brakeman -q -i /code/brakeman.ignore -o results.json /code
+          jq -j -M -c . results.json
+        else
+          brakeman -q -o results.json /code
+          jq -j -M -c . results.json
+        fi
       else
         mv code app
         brakeman -q -o results.json .

--- a/api/config.yaml
+++ b/api/config.yaml
@@ -137,7 +137,10 @@ brakeman:
         jq -j -M -c . results.json
       else
         mv code app
-        brakeman -q -o results.json .
+        if [ -f /app/brakeman.ignore ]; then
+          brakeman -q -i /app/brakeman.ignore -o results.json .
+        else
+          brakeman -q -o results.json .
         jq -j -M -c . results.json
       fi
     else

--- a/api/config.yaml
+++ b/api/config.yaml
@@ -141,6 +141,7 @@ brakeman:
           brakeman -q -i /app/brakeman.ignore -o results.json .
         else
           brakeman -q -o results.json .
+        fi
         jq -j -M -c . results.json
       fi
     else

--- a/api/config.yaml
+++ b/api/config.yaml
@@ -131,11 +131,10 @@ brakeman:
       if [ -d /code/app ]; then
         if [ -f /code/brakeman.ignore ]; then
           brakeman -q -i /code/brakeman.ignore -o results.json /code
-          jq -j -M -c . results.json
         else
           brakeman -q -o results.json /code
-          jq -j -M -c . results.json
         fi
+        jq -j -M -c . results.json
       else
         mv code app
         brakeman -q -o results.json .

--- a/api/securitytest/brakeman.go
+++ b/api/securitytest/brakeman.go
@@ -16,6 +16,7 @@ import (
 // BrakemanOutput is the struct that holds issues and stats found on a Brakeman scan.
 type BrakemanOutput struct {
 	Warnings []WarningItem `json:"warnings"`
+	IgnoredWarnings []WarningItem `json:"ignored_warnings"`
 }
 
 // WarningItem is the struct that holds all detailed information of a vulnerability found.
@@ -77,6 +78,20 @@ func (brakemanScan *SecTestScanInfo) prepareBrakemanVulns() {
 		case "Low":
 			huskyCIbrakemanResults.LowVulns = append(huskyCIbrakemanResults.LowVulns, brakemanVuln)
 		}
+	}
+	for _, ignoredWarning := range brakemanOutput.IgnoredWarnings {
+		brakemanVuln := types.HuskyCIVulnerability{}
+		brakemanVuln.Language = "Ruby"
+		brakemanVuln.SecurityTool = "Brakeman"
+		brakemanVuln.Confidence = ignoredWarning.Confidence
+		brakemanVuln.Title = fmt.Sprintf("Vulnerable Dependency: %s %s", ignoredWarning.Type, ignoredWarning.Message)
+		brakemanVuln.Severity = "NOSEC"
+		brakemanVuln.Details = ignoredWarning.Details
+		brakemanVuln.File = ignoredWarning.File
+		brakemanVuln.Line = strconv.Itoa(ignoredWarning.Line)
+		brakemanVuln.Code = ignoredWarning.Code
+		brakemanVuln.Type = ignoredWarning.Type
+		huskyCIbrakemanResults.NoSecVulns = append(huskyCIbrakemanResults.NoSecVulns, brakemanVuln)
 	}
 
 	brakemanScan.Vulnerabilities = huskyCIbrakemanResults

--- a/client/analysis/output.go
+++ b/client/analysis/output.go
@@ -199,7 +199,7 @@ func prepareAllSummary(analysis types.Analysis) {
 		types.FoundInfo = true
 	}
 
-	totalNoSec = outputJSON.Summary.BanditSummary.NoSecVuln + outputJSON.Summary.GosecSummary.NoSecVuln + outputJSON.Summary.GitleaksSummary.NoSecVuln
+	totalNoSec = outputJSON.Summary.BrakemanSummary.NoSecVuln + outputJSON.Summary.BanditSummary.NoSecVuln + outputJSON.Summary.GosecSummary.NoSecVuln + outputJSON.Summary.GitleaksSummary.NoSecVuln
 
 	totalLow = outputJSON.Summary.BrakemanSummary.LowVuln + outputJSON.Summary.SafetySummary.LowVuln + outputJSON.Summary.BanditSummary.LowVuln + outputJSON.Summary.GosecSummary.LowVuln + outputJSON.Summary.NpmAuditSummary.LowVuln + outputJSON.Summary.YarnAuditSummary.LowVuln + outputJSON.Summary.GitleaksSummary.LowVuln + outputJSON.Summary.SpotBugsSummary.LowVuln + outputJSON.Summary.TFSecSummary.LowVuln
 

--- a/client/analysis/output.go
+++ b/client/analysis/output.go
@@ -123,6 +123,7 @@ func prepareAllSummary(analysis types.Analysis) {
 	}
 
 	// Brakeman summary
+	outputJSON.Summary.BrakemanSummary.NoSecVuln = len(outputJSON.RubyResults.HuskyCIBrakemanOutput.NoSecVulns)
 	outputJSON.Summary.BrakemanSummary.LowVuln = len(outputJSON.RubyResults.HuskyCIBrakemanOutput.LowVulns)
 	outputJSON.Summary.BrakemanSummary.MediumVuln = len(outputJSON.RubyResults.HuskyCIBrakemanOutput.MediumVulns)
 	outputJSON.Summary.BrakemanSummary.HighVuln = len(outputJSON.RubyResults.HuskyCIBrakemanOutput.HighVulns)


### PR DESCRIPTION
### Description

This PR aims to add brakeman.ignore file support to HuskyCI.

Since there is no current implementation for utilizing "#nohusky" as referenced in #508  adding support to brakeman.ignore will help dealing with false-positives on the CI flow.

### Proposed Changes

Adding to the api/config.yaml in the brakeman section a if statement verifying if there is a brakeman.ignore file on the target project root folder, if yes run brakeman with the file as a parameter.

It requires a bit of manual work to generate the ignore file, since it is only generated by brakeman itself, one would have to run it manually, validate the findings and ignore them as the tools [documentation](https://brakemanscanner.org/docs/ignoring_false_positives/)

### Testing
The branch of poc-ruby-brakeman on my [forked repo](https://github.com/GabhenDM/huskyCI/tree/poc-ruby-brakeman) contains a brakeman.ignore removing two other warnings that would show up at a HuskyCI analysis result.

Running this current build agaisnt that repo should be enough to validate the implementation. 

🐼 