### PR TITLE
Fix #526: Local setup fails starting API due to non-unique hmac

### DIFF
--- a/deployments/dockerfiles/api.Dockerfile
+++ b/deployments/dockerfiles/api.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang
+FROM golang:1.15
 
 ADD api/ /go/src/github.com/globocom/huskyCI/api/
 WORKDIR /go/src/github.com/globocom/huskyCI/api/


### PR DESCRIPTION
### Description

For some reason, the latest version of GoLang (Go1.16.x) generates a panic error in the hmac package (`the hash function does not produce unique values`).
This error occurs when huskyCI sends the hash function using an anonymous function in the argument.

> `hashedPass := pbkdf2.Key([]byte(DefaultAPIPassword), salt, iterations, keyLength, func() hash.Hash {
> 	return hashFunction
> })`

If we send the hash algorithm directly to the function argument, the error will not occur. As I show in the example below:

> `hashedPass := pbkdf2.Key([]byte(DefaultAPIPassword), salt, iterations, keyLength, sha512.New)`

However, sending the hash algorithm in this way is not recommended.

Closes #526

### Proposed Changes

The simplest way to fix temporarily  this problem is change the version of GoLang in the API Dockerfile to version 1.15.