### PR TITLE
[FIX] npm audit should audit only production dependencies

### DIFF
--- a/api/config.yaml
+++ b/api/config.yaml
@@ -213,7 +213,7 @@ npmaudit:
     if [ $? -eq 0 ]; then
       cd code
       if [ -f package-lock.json ]; then
-        npm audit --only=prod --json > /tmp/results.json 2> /tmp/errorNpmaudit
+        npm audit --production --json > /tmp/results.json 2> /tmp/errorNpmaudit
         jq -j -M -c . /tmp/results.json
       else
         if [ ! -f yarn.lock ]; then


### PR DESCRIPTION
### Description

npm is currently auditing all dependencies and should audit production dependencies only.

### Proposed Changes

This PR changes the command to start `npm audit` changing one of the options from `--only=prod` to `--production`.
The `--only=prod` option only works for the `npm audit fix` command.

### Testing

Inside our `huskyci/npmaudit` container create a `package.lock` file containing the following content:

```
{
  "name": "huskyci",
  "version": "1.0.0",
  "description": "Intentionally Vulnerable huskyCI test branch",
  "main": "app.js",
  "scripts": {
    "test": "echo \"Error: no test specified\" && exit 1"
  },
  "repository": {
    "type": "git",
    "url": "git+https://github.com/globocom/huskyCI.git"
  },
  "author": "huskyCI",
  "license": "ISC",
  "bugs": {
    "url": "https://github.com/globocom/huskyCI"
  },
  "homepage": "https://github.com/globocom/huskyCI#readme",
  "devDependencies": {
    "express": "^4.0.0"
  }
}
```

In the same folder create the file `package-lock.json` with the following content:

https://raw.githubusercontent.com/globocom/huskyCI/poc-javascript-npm/package-lock.json


Then proceed to execute the command that currently runs in our container:

```
npm audit --only=prod --json > /tmp/results.json 2> /tmp/errorNpmaudit
```

Verify that `/tmp/results.json` contains some vulnerabilities that should not be listed since our only dependency is listed inside `devDependencies`.

Now execute the proposed command:

```
npm audit --production --json > /tmp/results.json 2> /tmp/errorNpmaudit
```

The output should now show 0 vulnerabilities:

```
{
  "actions": [],
  "advisories": {},
  "muted": [],
  "metadata": {
    "vulnerabilities": {
      "info": 0,
      "low": 0,
      "moderate": 0,
      "high": 0,
      "critical": 0
    },
    "dependencies": 0,
    "devDependencies": 0,
    "optionalDependencies": 0,
    "totalDependencies": 0
  },
  "runId": "SOME_RUN_ID_HERE"
}
```