### PR TITLE
Unified go version api and api Dockerfile

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/globocom/huskyCI/api
 
-go 1.14
+go 1.15
 
 require (
 	github.com/Microsoft/go-winio v0.4.14 // indirect


### PR DESCRIPTION
### Description

### Proposed Changes
The go.mod specification of api is 1.14, but since the Dockerfile specification of api was 1.15, it was unified for consistency.

- api go.mod
   - https://github.com/globocom/huskyCI/blob/master/api/go.mod#L3
- api Dockerfile
    - https://github.com/globocom/huskyCI/blob/master/deployments/dockerfiles/api.Dockerfile#L1