### PR TITLE
Sanitize git authors email with invalid characters

### DIFF
--- a/api/config.yaml
+++ b/api/config.yaml
@@ -40,12 +40,9 @@ gitauthors:
     git checkout %GIT_BRANCH% --quiet
     if [ $? -eq 0 ]; then
       for i in $(git log origin/master.. --pretty="%ae" | sort -u); do
-        jsonMiddle="\"$i\",$jsonMiddle"
+        jsonMiddle="\"${i//[^A-Za-z0-9_\.@-]/}\",$jsonMiddle"
       done
-      length=${#jsonMiddle}
-      endindex=$(expr $length - 1)
-      authors="${jsonMiddle:0:$endindex}"
-      echo "{\"authors\":[$authors]}"
+      echo "{\"authors\":[${jsonMiddle%?}]}"
     else
       echo "ERROR_CLONING"
       cat /tmp/errorGitCloneEnry


### PR DESCRIPTION
### Description

Some commits have authors with user.email in invalid format, including characters like \n causing eventual breaks in the json generation for reading by the API.

```
$ ./huskyci-client
[HUSKYCI][*] PRJ-staging -> user@gitlab.com:prj/test.git
[HUSKYCI][*] huskyCI analysis started! 5917dde3-8fec-4279-bbbc-c74e216cb5c6
[HUSKYCI][ERROR] Monitoring analysis 5917dde3-8fec-4279-bbbc-c74e216cb5c6: huskyCI encountered an error trying to execute this analysis: invalid character '\n' in string literal
```

### Proposed Changes

This PR proposes to sanitize the user.email so that the output is always a valid json. No break changes

### Testing

```
$ i="user\/n\in;valid@email.com"
$ jsonMiddle="\"${i//[^A-Za-z0-9_\.@-]/}\",$jsonMiddle"
$ echo "{\"authors\":[${jsonMiddle%?}]}"
{"authors":["userninvalid@email.com"]}

```

Thks @fguisso and @henriporto 
