### PR TITLE
Create switch between docker and kubernetes

### DIFF
--- a/api/config.yaml
+++ b/api/config.yaml
@@ -1,6 +1,6 @@
 enry:
   name: enry
-  image: docker-hub.artifactory.globoi.com/huskyci/enry
+  image: huskyci/enry
   imageTag: dev-b78a58c
   cmd: |+
     mkdir -p ~/.ssh &&
@@ -22,7 +22,7 @@ enry:
 
 gitauthors:
   name: gitauthors
-  image: docker-hub.artifactory.globoi.com/huskyci/gitauthors
+  image: huskyci/gitauthors
   imageTag: "2.18.4"
   cmd: |+
     mkdir -p ~/.ssh &&
@@ -56,7 +56,7 @@ gitauthors:
 
 gosec:
   name: gosec
-  image: docker-hub.artifactory.globoi.com/huskyci/gosec
+  image: huskyci/gosec
   imageTag: v2.3.0
   cmd: |+
     mkdir -p ~/.ssh &&
@@ -92,7 +92,7 @@ gosec:
 
 bandit:
   name: bandit
-  image: docker-hub.artifactory.globoi.com/huskyci/bandit
+  image: huskyci/bandit
   imageTag: "1.6.2"
   cmd: |+
      mkdir -p ~/.ssh &&
@@ -118,7 +118,7 @@ bandit:
 
 brakeman:
   name: brakeman
-  image: docker-hub.artifactory.globoi.com/huskyci/brakeman
+  image: huskyci/brakeman
   imageTag: "4.8.2"
   cmd: |+
     mkdir -p ~/.ssh &&
@@ -155,7 +155,7 @@ brakeman:
 
 safety:
   name: safety
-  image: docker-hub.artifactory.globoi.com/huskyci/safety
+  image: huskyci/safety
   imageTag: "1.9.0"
   cmd: |+
     mkdir -p ~/.ssh &&
@@ -201,7 +201,7 @@ safety:
 
 npmaudit:
   name: npmaudit
-  image: docker-hub.artifactory.globoi.com/huskyci/npmaudit
+  image: huskyci/npmaudit
   imageTag: "6.14.5"
   cmd: |+
     mkdir -p ~/.ssh &&
@@ -234,7 +234,7 @@ npmaudit:
 
 yarnaudit:
   name: yarnaudit
-  image: docker-hub.artifactory.globoi.com/huskyci/yarnaudit
+  image: huskyci/yarnaudit
   imageTag: "1.22.4"
   cmd: |+
     mkdir -p ~/.ssh &&
@@ -270,7 +270,7 @@ yarnaudit:
 
 spotbugs:
   name: spotbugs
-  image: docker-hub.artifactory.globoi.com/huskyci/spotbugs
+  image: huskyci/spotbugs
   imageTag: "4.0.0-beta4"
   cmd: |+
     mkdir -p ~/.ssh &&
@@ -326,7 +326,7 @@ spotbugs:
 
 gitleaks:
   name: gitleaks
-  image: docker-hub.artifactory.globoi.com/huskyci/gitleaks
+  image: huskyci/gitleaks
   imageTag: "v.7.6.1"
   cmd: |+
     mkdir -p ~/.ssh &&
@@ -357,7 +357,7 @@ gitleaks:
 
 tfsec:
   name: tfsec
-  image: docker-hub.artifactory.globoi.com/huskyci/tfsec
+  image: huskyci/tfsec
   imageTag: "0.58.15"
   cmd: |+
     mkdir -p ~/.ssh &&
@@ -382,7 +382,7 @@ tfsec:
 
 securitycodescan:
   name: securitycodescan
-  image: docker-hub.artifactory.globoi.com/huskyci/securitycodescan
+  image: huskyci/securitycodescan
   imageTag: "v5.6.2"
   cmd: |+
     mkdir -p ~/.ssh &&

--- a/api/dockers/huskydocker.go
+++ b/api/dockers/huskydocker.go
@@ -34,7 +34,7 @@ func configureImagePath(image, tag string) (string, string) {
 }
 
 // DockerRun starts a new container and returns its output and an error.
-func DockerRun(image, imageTag, cmd, dockerHost string, timeOutInSeconds int) (string, string, error) {
+func DockerRun(image string, imageTag string, cmd string, dockerHost string, timeOutInSeconds int) (string, string, error) {
 
 	// step 1: create a new docker API client
 	d, err := NewDocker(dockerHost)

--- a/deployments/daemon.json
+++ b/deployments/daemon.json
@@ -1,7 +1,7 @@
 {
     "tls": true,
     "tlscacert": "/data/certs/ca.pem",
-    "tlscert": "/data/certs/server-cert.pem",
-    "tlskey": "/data/certs/server-key.pem",
+    "tlscert": "/data/certs/server-dockerapi-cert.pem",
+    "tlskey": "/data/certs/server-dockerapi-key.pem",
     "tlsverify": true
 }

--- a/deployments/docker-compose.yml
+++ b/deployments/docker-compose.yml
@@ -3,7 +3,7 @@ services:
 
     dockerapi:
         privileged: true
-        image: docker:stable-dind
+        image: docker:20.10.0-dind
         container_name: huskyCI_Docker_API
         command: "dockerd --host=unix:///var/run/docker.sock --host=tcp://0.0.0.0:2376"
         ports:
@@ -28,10 +28,11 @@ services:
             HUSKYCI_API_DEFAULT_PASSWORD: huskyCIPassword
             HUSKYCI_API_ALLOW_ORIGIN_CORS: "*"
             HUSKYCI_DOCKERAPI_ADDR: dockerapi
-            HUSKYCI_KUBERNETES_CONFIG_FILE_PATH: /go/src/github.com/globocom/huskyCI/kubeconfig
+            HUSKYCI_KUBERNETES_CONFIG_FILE_PATH: /go/src/github.com/globocom/huskyCI/kubeconfig/config.yaml
             HUSKYCI_KUBERNETES_NAMESPACE: default
             HUSKYCI_DOCKERAPI_TLS_VERIFY: 0
             HUSKYCI_DOCKERAPI_CERT_PATH: /go/src/github.com/globocom/huskyCI/
+            HUSKYCI_INFRASTRUCTURE_USE: docker
         build:
             context: ../
             dockerfile: deployments/dockerfiles/api.Dockerfile

--- a/deployments/kubeconfig/config.yaml
+++ b/deployments/kubeconfig/config.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: <KUBERNETES_CERT_AUTHORITY_DATA>
+    server: <KUBERNETES_SERVER_HOST>
+  name: <CLUSTER_NAME>
+contexts:
+- context:
+    cluster: <CLUSTER_NAME>
+    user: <CLUSTER_USER>
+  name: <CONTEXT_NAME>
+current-context: <CONTEXT_NAME>
+kind: Config
+preferences: {}
+users:
+- name: <CLUSTER_USER>
+  user:
+    client-certificate-data: <CLIENT_CERTIFICATE_DATA>
+    client-key-data: <CLIENT_KEY_DATA>

--- a/deployments/scripts/create-certs.sh
+++ b/deployments/scripts/create-certs.sh
@@ -104,11 +104,11 @@ function createServerCert {
     openssl genrsa -out $TARGETDIR/server-key.pem 4096
     openssl req -subj "/CN=$NAME" -new -key $TARGETDIR/server-key.pem -out $TARGETDIR/server.csr
     echo "subjectAltName = DNS:$NAME$IPSTRING" > $TARGETDIR/extfile.cnf
-    openssl x509 -passin pass:$PASSWORD -req -days $EXPIRATIONDAYS -in $TARGETDIR/server.csr -CA $TARGETDIR/ca.pem -CAkey $TARGETDIR/ca-key.pem -CAcreateserial -out $TARGETDIR/server-cert.pem -extfile $TARGETDIR/extfile.cnf
+    openssl x509 -passin pass:$PASSWORD -req -days $EXPIRATIONDAYS -in $TARGETDIR/server.csr -CA $TARGETDIR/ca.pem -CAkey $TARGETDIR/ca-key.pem -CAcreateserial -out $TARGETDIR/server-dockerapi-cert.pem -extfile $TARGETDIR/extfile.cnf
 
     rm $TARGETDIR/server.csr $TARGETDIR/extfile.cnf $TARGETDIR/ca.srl
-    mv $TARGETDIR/server-key.pem $TARGETDIR/server-$NAME-key.pem
-    mv $TARGETDIR/server-cert.pem $TARGETDIR/server-$NAME-cert.pem
+    mv $TARGETDIR/server-dockerapi-key.pem $TARGETDIR/server-$NAME-key.pem
+    mv $TARGETDIR/server-dockerapi-cert.pem $TARGETDIR/server-$NAME-cert.pem
     chmod 0400 $TARGETDIR/server-$NAME-key.pem
     chmod 0444 $TARGETDIR/server-$NAME-cert.pem
 }


### PR DESCRIPTION
### Description

This PR is motivated to create a switch between `Docker` and `Kubernetes` in HuskyCI.

### Proposed Changes

This PR proposes to use an environment variable to select between using `Docker` or `Kubernetes` in HuskyCI.

### Testing

To test in `Docker`, it is necessary to enter the value `docker` in the `HUSKYCI_INFRASTRUCTURE_USE` environment variable. 
After that, run the following commands:

```bash
make install
make run-client
```

To tests in `Kubernetes`, it is necessary to enter the value `kubernetes` in the `HUSKYCI_INFRASTRUCTURE_USE` environment variable. In this case, it is also necessary to enter the cluster settings in the `kubeconfig/config.yaml` file.

```bash
make install
make run-client
```