### PR TITLE
Fixed the missing contributors hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ We have a few channels for contact, feel free to reach out to us at:
 
 ## Contributors
 
-This project exists thanks to all the [contributors]((https://github.com/globocom/huskyCI/graphs/contributors)). You rock!   ❤️🚀
+This project exists thanks to all the [contributors](https://github.com/globocom/huskyCI/graphs/contributors). You rock!   ❤️🚀
 
 ## License
 


### PR DESCRIPTION
### Description - Fixed the missing contributors hyperlink

Motivation for this PR. Linking the related issue is enough:

Closes #... Hacktoberfest

### Proposed Changes

Changes that this PR will introduce. Are there any breaking changes?

Line 97 was missing the contributors hyperlink, fixed the same with the right link by removing the extra brackets.
## Contributors
This project exists thanks to all the [contributors]((https://github.com/globocom/huskyCI/graphs/contributors)). You rock!   ❤️🚀

This project exists thanks to all the [contributors](https://github.com/globocom/huskyCI/graphs/contributors). You rock!   ❤️🚀
