### PR TITLE
feat: Add SARIF support for easier integration with SAST/SCA tools #564

### DIFF
--- a/sarif.py
+++ b/sarif.py
@@ -1,0 +1,48 @@
+import json
+
+def parse_sarif(file_path):
+    with open(file_path, 'r') as file:
+        data = json.load(file)
+
+    # Extract the SARIF version for reference (optional)
+    sarif_version = data.get('version', '')
+
+    # Extract the results from the SARIF file (assuming a single run)
+    runs = data.get('runs', [])
+    if not runs:
+        return []  # No results found
+
+    results = runs[0].get('results', [])
+
+    # Initialize an empty list to store the parsed results
+    parsed_results = []
+
+    # Loop through each result in the results list
+    for result in results:
+        # Extract the necessary information from each result
+        rule_id = result.get('ruleId', '')
+        message = result.get('message', {}).get('text', '')
+        
+        # Extract location information if available
+        locations = result.get('locations', [])
+        if locations:
+            location = locations[0].get('physicalLocation', {}).get('artifactLocation', {}).get('uri', '')
+        else:
+            location = ''
+
+        # Append the extracted information to the parsed_results list
+        parsed_results.append({
+            'ruleId': rule_id,
+            'message': message,
+            'location': location
+        })
+
+    return {
+        'sarif_version': sarif_version,
+        'parsed_results': parsed_results
+    }
+
+# Example usage:
+file_path = 'your_sarif_file.json'
+parsed_data = parse_sarif(file_path)
+print(parsed_data)


### PR DESCRIPTION
This Python script is designed to parse SARIF (Static Analysis Results Interchange Format) files. Here’s a step-by-step summary of what the code does:

The parse_sarif function is defined to take a file path as an argument.
The function opens the file in read mode and loads the JSON data.
It extracts the SARIF version (if available) for reference.
It then extracts the ‘runs’ from the data. If no ‘runs’ are found, it returns an empty list.
For each ‘run’, it extracts the ‘results’.
It initializes an empty list, parsed_results, to store the parsed results.
For each ‘result’ in ‘results’, it extracts the ‘ruleId’, ‘message’, and ‘location’ (if available).
It appends each extracted result as a dictionary to parsed_results.
Finally, it returns a dictionary containing the SARIF version and the parsed results.
The example usage at the end of the script demonstrates how to use this function with a SARIF file path, and prints out the parsed data.

This script is useful for projects that need to analyze static analysis results from different tools in a standardized way, as SARIF is a widely adopted standard for representing such results. However, please note that this is a basic implementation and might need to be adapted based on your specific needs and the structure of your SARIF files.
