### PR TITLE
Add mongo integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -2,9 +2,8 @@ name: "Database integration tests"
 
 on:
   push:
-    branches: [ add_mongo_integration_tests ]
   pull_request:
-    branches: [ add_mongo_integration_tests ]
+    branches: [ main ]
 
 jobs:
   mongodb-integration-test:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,30 @@
+name: "Database integration tests"
+
+on:
+  push:
+    branches: [ add_mongo_integration_tests ]
+  pull_request:
+    branches: [ add_mongo_integration_tests ]
+
+jobs:
+  mongodb-integration-test:
+    name: MongoDB integration test
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mongo:4.2.2
+        ports:
+          - "27017:27017"
+    steps:
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.20
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
+
+      - name: Run MongoDB integration test
+        run: |
+          make integration-test
+

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -17,12 +17,12 @@ jobs:
           - "27017:27017"
     steps:
       - name: Set up Go 1.x
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: ^1.20
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run MongoDB integration test
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,62 @@ Please note we have a code of conduct, please follow it in all your interactions
 4. You may merge the Pull Request in once you have the sign-off of two other developers, or if you
    do not have permission to do that, you may request the second reviewer to merge it for you.
 
+## Testing
+
+### Adding new integration tests
+
+Integration tests play a crucial role in validating the correct integration of our codebase with its dependencies. To ensure the effectiveness of our testing suite, we encourage contributors to adhere to the following guidelines when adding new integration tests:
+
+1. **Identification in Test Names:**
+   - All new integration tests should be clearly identifiable by having the word `Integration` in their names. For example:
+     ```go
+     func TestMongoIntegration(t *testing.T) {
+       // Test implementation
+     }
+     ```
+
+2. **Short Test Skip:**
+   - Each integration test should begin with a specific check to skip the test if it is being run in short mode:
+     ```go
+     func TestMongoIntegration(t *testing.T) {
+       if testing.Short() {
+         t.Skip()
+       }
+       // Test implementation
+     }
+     ```
+
+3. **Conditional Execution with Makefile:**
+   - Integration tests are designed to be executed explicitly. To run integration tests, use the Makefile target `integration-test`. This ensures that these tests are separate from unit tests and are run independently when needed. Unit tests are executed with the `-short` tag.
+     ```bash
+     make integration-test
+     ```
+
+By following these guidelines, you contribute to a testing environment that accurately assesses the integration of our project with its dependencies. This separation of unit and integration tests allows for efficient testing and ensures that integration tests are only run when explicitly triggered, promoting a focused and effective testing strategy.
+
+### Running Database Integration Tests Locally
+
+To execute the database integration tests locally, follow these steps:
+
+1. Start the Docker containers configured in the `docker-compose-integration-test.yml` file located in the `deployments` directory:
+
+    ```bash
+    $ make integration-test-compose-up
+    ```
+
+    This command initializes the required environment for running the integration tests.
+
+2. Run the tests using the following command:
+
+    ```bash
+    $ make integration-test
+    ```
+
+    This Makefile target executes the database integration tests.
+
+Ensure that you have Docker installed on your machine before running the tests.
+
+
 ## Code of Conduct
 
 ### Our Pledge

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Integration tests play a crucial role in validating the correct integration of o
      ```
 
 2. **Short Test Skip:**
-   - Each integration test should begin with a specific check to skip the test if it is being run in short mode:
+   - Each integration test should begin with a specific check to skip the test if it is being run in short mode, for example:
      ```go
      func TestMongoIntegration(t *testing.T) {
        if testing.Short() {
@@ -40,6 +40,18 @@ Integration tests play a crucial role in validating the correct integration of o
        // Test implementation
      }
      ```
+     ```go
+     var _ = Describe("Some test", func() {
+      BeforeEach(func() {
+        if testing.Short() {
+          Skip("Integration tests don't run with 'short' flag")
+        }
+        // Test implementation
+      })
+    })
+     ```
+
+     
 
 3. **Conditional Execution with Makefile:**
    - Integration tests are designed to be executed explicitly. To run integration tests, use the Makefile target `integration-test`. This ensures that these tests are separate from unit tests and are run independently when needed. Unit tests are executed with the `-short` tag.

--- a/Makefile
+++ b/Makefile
@@ -168,13 +168,26 @@ run-client-linux-json: build-client-linux
 
 ## Performs all unit tests using ginkgo
 test:
-	cd api && $(GO) test -coverprofile=c.out ./...
+	cd api && $(GO) test -coverprofile=c.out ./... -short
 	cd api && $(GO) tool cover -func=c.out
 	cd api && $(GO) tool cover -html=c.out -o coverage.html
-	cd client && $(GO) test -coverprofile=d.out ./...
+	cd client && $(GO) test -coverprofile=d.out ./... -short
 	cd client && $(GO) tool cover -func=d.out
-	cd cli && $(GO) test -coverprofile=e.out ./...
+	cd cli && $(GO) test -coverprofile=e.out ./... -short
 	cd cli && $(GO) tool cover -func=e.out
+
+## Composes huskyCI integration test environment using docker-compose
+integration-test-compose-up:
+	docker-compose -f deployments/docker-compose-integration-test.yml down -v
+	docker-compose -f deployments/docker-compose-integration-test.yml up -d --build --force-recreate
+
+## Composes down the integration test docker compose
+integration-test-compose-down:
+	docker-compose -f deployments/docker-compose-integration-test.yml down -v
+
+## Run all integration tests. The tests must contain the 'Integration' on his name
+integration-test: 
+	cd api && $(GO) test -race  ./... -run Integration
 
 ## Builds and push securityTest containers with the latest tags
 update-containers: build-containers push-containers

--- a/api/db/huskydb_integration_test.go
+++ b/api/db/huskydb_integration_test.go
@@ -1,0 +1,79 @@
+// Copyright 2019 Globo.com authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package db
+
+import (
+	"testing"
+	"time"
+
+	mongoHuskyCI "github.com/globocom/huskyCI/api/db/mongo"
+	"github.com/globocom/huskyCI/api/log"
+	"github.com/globocom/huskyCI/api/types"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"gopkg.in/mgo.v2"
+)
+
+var huskydbMongoRequestsTest MongoRequests
+
+func TestMongoRequestsIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	huskydbMongoRequestsTest = MongoRequests{}
+	log.InitLog(true, "", "", "log_test", "log_test")
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "MongoDB Suite")
+}
+
+var _ = BeforeSuite(func() {
+	mongoAddress := "localhost"
+	dbName := "integration-test"
+	username := ""
+	password := ""
+	dbPort := 27017
+	connectionTimeout := time.Duration(1 * time.Second)
+	connectionPool := 10
+	maxOpenConns := 10
+	maxIdleConns := 10
+	connMaxLifetime := time.Duration(1 * time.Second)
+
+	errConnect := huskydbMongoRequestsTest.ConnectDB(mongoAddress, dbName, username, password, connectionTimeout, connectionPool, dbPort, maxOpenConns, maxIdleConns, connMaxLifetime)
+	Expect(errConnect).To(BeNil())
+})
+
+var _ = AfterSuite(func() {
+	err := mongoHuskyCI.Conn.Session.DB("").DropDatabase()
+	Expect(err).To(BeNil())
+})
+
+var _ = Describe("FindOneDBRepository", func() {
+	Context("When find one DB Repository", func() {
+		It("Should return mgo.ErrNotFound and empty types.Repository{} when not found", func() {
+			mapParams := map[string]interface{}{"repositoryURL": "not found URL"}
+
+			repository, err := huskydbMongoRequestsTest.FindOneDBRepository(mapParams)
+			Expect(err).To(Equal(mgo.ErrNotFound))
+
+			expectedResult := types.Repository{}
+			Expect(repository).To(Equal(expectedResult))
+		})
+		It("Should return no error and types.Repository{} correctly", func() {
+			repositoryToInsert := types.Repository{
+				URL: "http://github.com/findonerepository",
+			}
+
+			errInsert := huskydbMongoRequestsTest.InsertDBRepository(repositoryToInsert)
+			Expect(errInsert).To(BeNil())
+
+			mapParams := map[string]interface{}{"repositoryURL": repositoryToInsert.URL}
+
+			repository, errGet := huskydbMongoRequestsTest.FindOneDBRepository(mapParams)
+			Expect(errGet).To(BeNil())
+			Expect(repository).To(Equal(repositoryToInsert))
+		})
+	})
+})

--- a/api/db/huskydb_integration_test.go
+++ b/api/db/huskydb_integration_test.go
@@ -50,7 +50,7 @@ var _ = AfterSuite(func() {
 	Expect(err).To(BeNil())
 })
 
-var _ = Describe("FindOneDBRepository", func() {
+var _ = Describe("DBRepository", func() {
 	Context("When try to find one", func() {
 		It("Should return mgo.ErrNotFound and empty types.Repository{} when not found", func() {
 			mapParams := map[string]interface{}{"repositoryURL": "not found URL"}
@@ -76,9 +76,48 @@ var _ = Describe("FindOneDBRepository", func() {
 			Expect(repository).To(Equal(repositoryToInsert))
 		})
 	})
+	Context("When try to find all", func() {
+		It("Should return no error and empty repository array when not found", func() {
+			mapParams := map[string]interface{}{"repositoryURL": "not found URL"}
+
+			repository, err := huskydbMongoRequestsTest.FindAllDBRepository(mapParams)
+			Expect(err).To(BeNil())
+
+			expectedResult := []types.Repository{}
+			Expect(repository).To(Equal(expectedResult))
+		})
+		It("Should return no error and types.Repository{} correctly", func() {
+			repositoryToInsert1 := types.Repository{
+				URL: "http://github.com/findallrepository",
+			}
+
+			errInsert := huskydbMongoRequestsTest.InsertDBRepository(repositoryToInsert1)
+			Expect(errInsert).To(BeNil())
+
+			repositoryToInsert2 := types.Repository{
+				URL: "http://github.com/findallrepository",
+			}
+
+			errInsert = huskydbMongoRequestsTest.InsertDBRepository(repositoryToInsert2)
+			Expect(errInsert).To(BeNil())
+
+			mapParams := map[string]interface{}{
+				"repositoryURL": "http://github.com/findallrepository",
+			}
+
+			expectedResult := []types.Repository{
+				repositoryToInsert1,
+				repositoryToInsert2,
+			}
+
+			result, errGet := huskydbMongoRequestsTest.FindAllDBRepository(mapParams)
+			Expect(errGet).To(BeNil())
+			Expect(result).To(Equal(expectedResult))
+		})
+	})
 })
 
-var _ = Describe("FindOneDBSecurityTest", func() {
+var _ = Describe("DBSecurityTest", func() {
 	Context("When try to find one", func() {
 		It("Should return mgo.ErrNotFound and empty  types.SecurityTest{} when not found", func() {
 			mapParams := map[string]interface{}{"name": "security_test_name"}
@@ -95,7 +134,7 @@ var _ = Describe("FindOneDBSecurityTest", func() {
 				Image:            "some image",
 				Cmd:              "some cmd",
 				Language:         "some language",
-				Type:             "some tipe",
+				Type:             "some type",
 				Default:          false,
 				TimeOutInSeconds: 10,
 			}
@@ -110,9 +149,57 @@ var _ = Describe("FindOneDBSecurityTest", func() {
 			Expect(repository).To(Equal(securityTestToInsert))
 		})
 	})
+	Context("When try to find all", func() {
+		It("Should return no error and empty types.SecurityTest{} array when not found", func() {
+			mapParams := map[string]interface{}{"type": "type_find_all"}
+
+			repository, err := huskydbMongoRequestsTest.FindAllDBSecurityTest(mapParams)
+			Expect(err).To(BeNil())
+
+			expectedResult := []types.SecurityTest{}
+			Expect(repository).To(Equal(expectedResult))
+		})
+		It("Should return no error and  types.SecurityTest{} correctly", func() {
+			securityTestToInsert1 := types.SecurityTest{
+				Name:             "security_test_name_1",
+				Image:            "some image",
+				Cmd:              "some cmd",
+				Language:         "some language",
+				Type:             "type_find_all",
+				Default:          false,
+				TimeOutInSeconds: 10,
+			}
+
+			errInsert := huskydbMongoRequestsTest.InsertDBSecurityTest(securityTestToInsert1)
+			Expect(errInsert).To(BeNil())
+
+			securityTestToInsert2 := types.SecurityTest{
+				Name:             "security_test_name_2",
+				Image:            "some image",
+				Cmd:              "some cmd",
+				Language:         "some language",
+				Type:             "type_find_all",
+				Default:          false,
+				TimeOutInSeconds: 10,
+			}
+
+			errInsert = huskydbMongoRequestsTest.InsertDBSecurityTest(securityTestToInsert2)
+			Expect(errInsert).To(BeNil())
+
+			expectResult := []types.SecurityTest{
+				securityTestToInsert1,
+				securityTestToInsert2,
+			}
+
+			mapParams := map[string]interface{}{"type": "type_find_all"}
+			repository, errGet := huskydbMongoRequestsTest.FindAllDBSecurityTest(mapParams)
+			Expect(errGet).To(BeNil())
+			Expect(repository).To(Equal(expectResult))
+		})
+	})
 })
 
-var _ = Describe("FindOneDBAnalysis", func() {
+var _ = Describe("DBAnalysis", func() {
 	Context("When try to find one", func() {
 		It("Should return mgo.ErrNotFound and empty  types.Analysis{} when not found", func() {
 			mapParams := map[string]interface{}{"RID": "test-id"}
@@ -143,9 +230,55 @@ var _ = Describe("FindOneDBAnalysis", func() {
 			Expect(analysis).To(Equal(analysisToInsert))
 		})
 	})
+	Context("When try to find all", func() {
+		It("Should return no error and empty types.Analysis{} array when not found", func() {
+			mapParams := map[string]interface{}{"status": "status-find-all-not-found"}
+
+			analysis, err := huskydbMongoRequestsTest.FindAllDBAnalysis(mapParams)
+			Expect(err).To(BeNil())
+
+			expectedResult := []types.Analysis{}
+			Expect(analysis).To(Equal(expectedResult))
+		})
+		It("Should return no error and []types.Analysis{} correctly", func() {
+			analysisToInsert1 := types.Analysis{
+				RID:        "test-id-1",
+				URL:        "some url",
+				Branch:     "some branch",
+				Status:     "status-find-all",
+				Result:     "some result",
+				Containers: []types.Container{},
+			}
+
+			errInsert := huskydbMongoRequestsTest.InsertDBAnalysis(analysisToInsert1)
+			Expect(errInsert).To(BeNil())
+
+			analysisToInsert2 := types.Analysis{
+				RID:        "test-id-2",
+				URL:        "some url",
+				Branch:     "some branch",
+				Status:     "status-find-all",
+				Result:     "some result",
+				Containers: []types.Container{},
+			}
+
+			errInsert = huskydbMongoRequestsTest.InsertDBAnalysis(analysisToInsert2)
+			Expect(errInsert).To(BeNil())
+
+			expectedResult := []types.Analysis{
+				analysisToInsert1,
+				analysisToInsert2,
+			}
+
+			mapParams := map[string]interface{}{"status": "status-find-all"}
+			analysis, errGet := huskydbMongoRequestsTest.FindAllDBAnalysis(mapParams)
+			Expect(errGet).To(BeNil())
+			Expect(analysis).To(Equal(expectedResult))
+		})
+	})
 })
 
-var _ = Describe("FindOneDBUser", func() {
+var _ = Describe("DBUser", func() {
 	Context("When try to find one", func() {
 		It("Should return mgo.ErrNotFound and empty  types.User{} when not found", func() {
 			mapParams := map[string]interface{}{"username": "some user name"}
@@ -178,7 +311,7 @@ var _ = Describe("FindOneDBUser", func() {
 	})
 })
 
-var _ = Describe("FindOneDBAccessToken", func() {
+var _ = Describe("DBAccessToken", func() {
 	Context("When try to find one", func() {
 		It("Should return mgo.ErrNotFound and empty  types.DBToken{} when not found", func() {
 			mapParams := map[string]interface{}{"uuid": "some uuid"}

--- a/api/db/huskydb_integration_test.go
+++ b/api/db/huskydb_integration_test.go
@@ -51,7 +51,7 @@ var _ = AfterSuite(func() {
 })
 
 var _ = Describe("FindOneDBRepository", func() {
-	Context("When find one DB Repository", func() {
+	Context("When try to find one", func() {
 		It("Should return mgo.ErrNotFound and empty types.Repository{} when not found", func() {
 			mapParams := map[string]interface{}{"repositoryURL": "not found URL"}
 
@@ -74,6 +74,138 @@ var _ = Describe("FindOneDBRepository", func() {
 			repository, errGet := huskydbMongoRequestsTest.FindOneDBRepository(mapParams)
 			Expect(errGet).To(BeNil())
 			Expect(repository).To(Equal(repositoryToInsert))
+		})
+	})
+})
+
+var _ = Describe("FindOneDBSecurityTest", func() {
+	Context("When try to find one", func() {
+		It("Should return mgo.ErrNotFound and empty  types.SecurityTest{} when not found", func() {
+			mapParams := map[string]interface{}{"name": "security_test_name"}
+
+			repository, err := huskydbMongoRequestsTest.FindOneDBSecurityTest(mapParams)
+			Expect(err).To(Equal(mgo.ErrNotFound))
+
+			expectedResult := types.SecurityTest{}
+			Expect(repository).To(Equal(expectedResult))
+		})
+		It("Should return no error and  types.SecurityTest{} correctly", func() {
+			securityTestToInsert := types.SecurityTest{
+				Name:             "security_test_name",
+				Image:            "some image",
+				Cmd:              "some cmd",
+				Language:         "some language",
+				Type:             "some tipe",
+				Default:          false,
+				TimeOutInSeconds: 10,
+			}
+
+			errInsert := huskydbMongoRequestsTest.InsertDBSecurityTest(securityTestToInsert)
+			Expect(errInsert).To(BeNil())
+
+			mapParams := map[string]interface{}{"name": "security_test_name"}
+
+			repository, errGet := huskydbMongoRequestsTest.FindOneDBSecurityTest(mapParams)
+			Expect(errGet).To(BeNil())
+			Expect(repository).To(Equal(securityTestToInsert))
+		})
+	})
+})
+
+var _ = Describe("FindOneDBAnalysis", func() {
+	Context("When try to find one", func() {
+		It("Should return mgo.ErrNotFound and empty  types.Analysis{} when not found", func() {
+			mapParams := map[string]interface{}{"RID": "test-id"}
+
+			analysis, err := huskydbMongoRequestsTest.FindOneDBAnalysis(mapParams)
+			Expect(err).To(Equal(mgo.ErrNotFound))
+
+			expectedResult := types.Analysis{}
+			Expect(analysis).To(Equal(expectedResult))
+		})
+		It("Should return no error and types.Analysis{} correctly", func() {
+			analysisToInsert := types.Analysis{
+				RID:        "test-id",
+				URL:        "some url",
+				Branch:     "some branch",
+				Status:     "some status",
+				Result:     "some result",
+				Containers: []types.Container{},
+			}
+
+			errInsert := huskydbMongoRequestsTest.InsertDBAnalysis(analysisToInsert)
+			Expect(errInsert).To(BeNil())
+
+			mapParams := map[string]interface{}{"RID": "test-id"}
+
+			analysis, errGet := huskydbMongoRequestsTest.FindOneDBAnalysis(mapParams)
+			Expect(errGet).To(BeNil())
+			Expect(analysis).To(Equal(analysisToInsert))
+		})
+	})
+})
+
+var _ = Describe("FindOneDBUser", func() {
+	Context("When try to find one", func() {
+		It("Should return mgo.ErrNotFound and empty  types.User{} when not found", func() {
+			mapParams := map[string]interface{}{"username": "some user name"}
+
+			user, err := huskydbMongoRequestsTest.FindOneDBUser(mapParams)
+			Expect(err).To(Equal(mgo.ErrNotFound))
+
+			expectedResult := types.User{}
+			Expect(user).To(Equal(expectedResult))
+		})
+		It("Should return no error and types.User{} correctly", func() {
+			userToInsert := types.User{
+				Username:     "some user name",
+				Password:     "some password",
+				Salt:         "some salt",
+				Iterations:   1,
+				KeyLen:       10,
+				HashFunction: "some hash function",
+			}
+
+			errInsert := huskydbMongoRequestsTest.InsertDBUser(userToInsert)
+			Expect(errInsert).To(BeNil())
+
+			mapParams := map[string]interface{}{"username": "some user name"}
+
+			user, errGet := huskydbMongoRequestsTest.FindOneDBUser(mapParams)
+			Expect(errGet).To(BeNil())
+			Expect(user).To(Equal(userToInsert))
+		})
+	})
+})
+
+var _ = Describe("FindOneDBAccessToken", func() {
+	Context("When try to find one", func() {
+		It("Should return mgo.ErrNotFound and empty  types.DBToken{} when not found", func() {
+			mapParams := map[string]interface{}{"uuid": "some uuid"}
+
+			user, err := huskydbMongoRequestsTest.FindOneDBAccessToken(mapParams)
+			Expect(err).To(Equal(mgo.ErrNotFound))
+
+			expectedResult := types.DBToken{}
+			Expect(user).To(Equal(expectedResult))
+		})
+		It("Should return no error and types.DBToken{} correctly", func() {
+			dbToken := types.DBToken{
+				HuskyToken: "some token",
+				URL:        "some url",
+				IsValid:    true,
+				Salt:       "some salt",
+				UUID:       "some uuid",
+			}
+
+			errInsert := huskydbMongoRequestsTest.InsertDBAccessToken(dbToken)
+			Expect(errInsert).To(BeNil())
+
+			mapParams := map[string]interface{}{"uuid": "some uuid"}
+
+			user, errGet := huskydbMongoRequestsTest.FindOneDBAccessToken(mapParams)
+			Expect(errGet).To(BeNil())
+			Expect(user).To(Equal(dbToken))
 		})
 	})
 })

--- a/api/db/mongo/mongo_integration_test.go
+++ b/api/db/mongo/mongo_integration_test.go
@@ -6,7 +6,6 @@ package db
 
 import (
 	"os"
-	"strconv"
 	"testing"
 	"time"
 
@@ -35,16 +34,11 @@ func TestMongoIntegration(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	mongoAddress := os.Getenv("HUSKYCI_DATABASE_DB_ADDR")
-	dbName := os.Getenv("HUSKYCI_DATABASE_DB_NAME")
-	username := os.Getenv("HUSKYCI_DATABASE_DB_USERNAME")
-	password := os.Getenv("HUSKYCI_DATABASE_DB_PASSWORD")
-	dbPort, err := strconv.Atoi(os.Getenv("HUSKYCI_DATABASE_DB_PORT"))
-	Expect(err).To(BeNil())
-
+	dbPort := 27017
 	connectionPool := 10
 	connectionTimeout := time.Duration(1 * time.Second)
 
-	errConnect := Connect(mongoAddress, dbName, username, password, connectionPool, dbPort, connectionTimeout)
+	errConnect := Connect(mongoAddress, "integration-test", "", "", connectionPool, dbPort, connectionTimeout)
 	Expect(errConnect).To(BeNil())
 	Expect(Conn).To(Not(BeNil()))
 })

--- a/api/db/mongo/mongo_integration_test.go
+++ b/api/db/mongo/mongo_integration_test.go
@@ -1,0 +1,336 @@
+// Copyright 2019 Globo.com authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package db
+
+import (
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/globocom/huskyCI/api/log"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"gopkg.in/mgo.v2/bson"
+)
+
+var collectionTest = "integration_test_collection"
+
+type mongoTestObj struct {
+	Attr1 string `bson:"attribute_1"`
+	Attr2 int    `bson:"attribute_2"`
+}
+
+func TestMongoIntegration(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
+	log.InitLog(true, "", "", "log_test", "log_test")
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "MongoDB Suite")
+}
+
+var _ = BeforeSuite(func() {
+	mongoAddress := os.Getenv("HUSKYCI_DATABASE_DB_ADDR")
+	dbName := os.Getenv("HUSKYCI_DATABASE_DB_NAME")
+	username := os.Getenv("HUSKYCI_DATABASE_DB_USERNAME")
+	password := os.Getenv("HUSKYCI_DATABASE_DB_PASSWORD")
+	dbPort, err := strconv.Atoi(os.Getenv("HUSKYCI_DATABASE_DB_PORT"))
+	Expect(err).To(BeNil())
+
+	connectionPool := 10
+	connectionTimeout := time.Duration(1 * time.Second)
+
+	errConnect := Connect(mongoAddress, dbName, username, password, connectionPool, dbPort, connectionTimeout)
+	Expect(errConnect).To(BeNil())
+	Expect(Conn).To(Not(BeNil()))
+})
+
+var _ = AfterSuite(func() {
+	colletction := Conn.Session.DB("").C(collectionTest)
+	err := colletction.DropCollection()
+	Expect(err).To(BeNil())
+})
+
+var _ = Describe("Connect", func() {
+	Context("When connect to MongoDB with valid parameters", func() {
+		It("Should return no error when send ping", func() {
+			errPing := Conn.Session.Ping()
+			Expect(errPing).To(BeNil())
+		})
+	})
+})
+
+var _ = Describe("Insert", func() {
+	Context("When insert a object", func() {
+		It("Should insert with success", func() {
+			newObj := mongoTestObj{
+				Attr1: "insert-1",
+				Attr2: 11,
+			}
+
+			errInsert := Conn.Insert(newObj, collectionTest)
+			Expect(errInsert).To(BeNil())
+
+			result := []mongoTestObj{}
+			errGet := Conn.Search(bson.M{"attribute_1": "insert-1"}, nil, collectionTest, &result)
+			Expect(errGet).To(BeNil())
+
+			expectedResult := []mongoTestObj{
+				{
+					Attr1: "insert-1",
+					Attr2: 11,
+				},
+			}
+
+			Expect(result).To(Equal(expectedResult))
+		})
+	})
+})
+
+var _ = Describe("Update", func() {
+	Context("When update a object", func() {
+		It("Should update with success", func() {
+			err := Conn.Insert(mongoTestObj{Attr1: "update-1", Attr2: 11}, collectionTest)
+			Expect(err).To(BeNil())
+
+			updatedQuery := bson.M{
+				"$set": mongoTestObj{
+					Attr1: "update-2",
+					Attr2: 111,
+				},
+			}
+
+			errupdate := Conn.Update(bson.M{"attribute_1": "update-1"}, updatedQuery, collectionTest)
+			Expect(errupdate).To(BeNil())
+
+			result := []mongoTestObj{}
+			errGet := Conn.Search(bson.M{"attribute_1": "update-2"}, nil, collectionTest, &result)
+			Expect(errGet).To(BeNil())
+
+			expectedResult := []mongoTestObj{
+				{
+					Attr1: "update-2",
+					Attr2: 111,
+				},
+			}
+
+			Expect(result).To(Equal(expectedResult))
+		})
+	})
+})
+
+var _ = Describe("UpdateAll", func() {
+	Context("When update objects", func() {
+		It("Should update all with success", func() {
+			errInsert1 := Conn.Insert(mongoTestObj{Attr1: "update-all-1", Attr2: 11}, collectionTest)
+			Expect(errInsert1).To(BeNil())
+
+			errInsert2 := Conn.Insert(mongoTestObj{Attr1: "update-all-1", Attr2: 22}, collectionTest)
+			Expect(errInsert2).To(BeNil())
+
+			updatedQuery := bson.M{
+				"$set": mongoTestObj{
+					Attr1: "update-all-2",
+					Attr2: 33,
+				},
+			}
+
+			errupdate := Conn.UpdateAll(bson.M{"attribute_1": "update-all-1"}, updatedQuery, collectionTest)
+			Expect(errupdate).To(BeNil())
+
+			result := []mongoTestObj{}
+			errGet := Conn.Search(bson.M{"attribute_1": "update-all-2"}, nil, collectionTest, &result)
+			Expect(errGet).To(BeNil())
+
+			expectedResult := []mongoTestObj{
+				{
+					Attr1: "update-all-2",
+					Attr2: 33,
+				},
+				{
+					Attr1: "update-all-2",
+					Attr2: 33,
+				},
+			}
+
+			Expect(result).To(Equal(expectedResult))
+		})
+	})
+})
+
+var _ = Describe("FindAndModify", func() {
+	Context("When find and modify a object", func() {
+		It("Should modify with success", func() {
+			objToInsert := mongoTestObj{Attr1: "find-and-modify-1", Attr2: 11}
+			err := Conn.Insert(objToInsert, collectionTest)
+			Expect(err).To(BeNil())
+
+			updatedQuery := bson.M{
+				"$set": mongoTestObj{
+					Attr1: "find-and-modify-2",
+					Attr2: 33,
+				},
+			}
+
+			resultFindModify := mongoTestObj{}
+			errFindModify := Conn.FindAndModify(bson.M{"attribute_1": "find-and-modify-1"}, updatedQuery, collectionTest, &resultFindModify)
+			Expect(errFindModify).To(BeNil())
+
+			resultGet := []mongoTestObj{}
+			errGet := Conn.Search(bson.M{"attribute_1": "find-and-modify-2"}, nil, collectionTest, &resultGet)
+			Expect(errGet).To(BeNil())
+			Expect(resultFindModify).To(Equal(objToInsert))
+
+			expectedResult := []mongoTestObj{
+				{
+					Attr1: "find-and-modify-2",
+					Attr2: 33,
+				},
+			}
+
+			Expect(resultGet).To(Equal(expectedResult))
+		})
+	})
+})
+
+var _ = Describe("Search", func() {
+	Context("When search a object", func() {
+		It("Should return with success", func() {
+			objToInsert := mongoTestObj{Attr1: "search-1", Attr2: 11}
+			err := Conn.Insert(objToInsert, collectionTest)
+			Expect(err).To(BeNil())
+
+			resultSearch := []mongoTestObj{}
+			errGet := Conn.Search(bson.M{"attribute_1": "search-1"}, nil, collectionTest, &resultSearch)
+			Expect(errGet).To(BeNil())
+
+			expectedResult := []mongoTestObj{
+				objToInsert,
+			}
+
+			Expect(resultSearch).To(Equal(expectedResult))
+		})
+	})
+})
+
+var _ = Describe("Aggregation", func() {
+	Context("When run aggregation with count", func() {
+		It("Should return count with success", func() {
+			objToInsert1 := mongoTestObj{Attr1: "aggregation-test", Attr2: 11}
+			err1 := Conn.Insert(objToInsert1, collectionTest)
+			Expect(err1).To(BeNil())
+
+			objToInsert2 := mongoTestObj{Attr1: "aggregation-test", Attr2: 22}
+			err2 := Conn.Insert(objToInsert2, collectionTest)
+			Expect(err2).To(BeNil())
+
+			aggregationQuery := []bson.M{
+				{
+					"$match": bson.M{
+						"attribute_1": bson.M{
+							"$eq": "aggregation-test",
+						},
+					},
+				},
+				{
+					"$match": bson.M{
+						"attribute_2": bson.M{
+							"$gte": 1,
+						},
+					},
+				},
+				{
+					"$group": bson.M{
+						"_id": nil,
+						"count": bson.M{
+							"$sum": 1,
+						},
+					},
+				},
+			}
+
+			resultSearch, errGet := Conn.Aggregation(aggregationQuery, collectionTest)
+			Expect(errGet).To(BeNil())
+			expectedResult := []bson.M{
+				{"_id": nil, "count": 2},
+			}
+
+			Expect(resultSearch).To(Equal(expectedResult))
+		})
+	})
+})
+
+var _ = Describe("SearchOne", func() {
+	Context("When search a object", func() {
+		It("Should return with success", func() {
+			objToInsert := mongoTestObj{Attr1: "search-one-1", Attr2: 11}
+			err := Conn.Insert(objToInsert, collectionTest)
+			Expect(err).To(BeNil())
+
+			resultSearch := mongoTestObj{}
+			errGet := Conn.SearchOne(bson.M{"attribute_1": "search-one-1"}, nil, collectionTest, &resultSearch)
+			Expect(errGet).To(BeNil())
+			Expect(resultSearch).To(Equal(objToInsert))
+		})
+	})
+})
+
+var _ = Describe("Upsert", func() {
+	Context("When upsert a object that doesn't exists", func() {
+		It("Should insert with success", func() {
+			obj := mongoTestObj{
+				Attr1: "upsert-1",
+				Attr2: 11,
+			}
+
+			query := bson.M{"attribute_1": "upsert-1"}
+			_, err := Conn.Upsert(query, obj, collectionTest)
+			Expect(err).To(BeNil())
+
+			result := []mongoTestObj{}
+			errGet := Conn.Search(bson.M{"attribute_1": "upsert-1"}, nil, collectionTest, &result)
+			Expect(errGet).To(BeNil())
+
+			expectedResult := []mongoTestObj{
+				{
+					Attr1: "upsert-1",
+					Attr2: 11,
+				},
+			}
+
+			Expect(result).To(Equal(expectedResult))
+		})
+	})
+	Context("When upsert a object that already exists", func() {
+		It("Should update with success", func() {
+			errInsert := Conn.Insert(mongoTestObj{Attr1: "upsert-2", Attr2: 11}, collectionTest)
+			Expect(errInsert).To(BeNil())
+
+			obj := mongoTestObj{
+				Attr1: "upsert-2",
+				Attr2: 22,
+			}
+
+			query := bson.M{"attribute_1": "upsert-2"}
+			_, err := Conn.Upsert(query, obj, collectionTest)
+			Expect(err).To(BeNil())
+
+			result := []mongoTestObj{}
+			errGet := Conn.Search(bson.M{"attribute_1": "upsert-2"}, nil, collectionTest, &result)
+			Expect(errGet).To(BeNil())
+
+			expectedResult := []mongoTestObj{
+				{
+					Attr1: "upsert-2",
+					Attr2: 22,
+				},
+			}
+
+			Expect(result).To(Equal(expectedResult))
+		})
+	})
+})

--- a/api/db/mongo/mongo_integration_test.go
+++ b/api/db/mongo/mongo_integration_test.go
@@ -107,7 +107,7 @@ var _ = Describe("Update", func() {
 
 			expectedResult := []mongoTestObj{
 				{
-					Attr1: "update-2",
+					Attr1: "update-21",
 					Attr2: 111,
 				},
 			}

--- a/api/db/mongo/mongo_integration_test.go
+++ b/api/db/mongo/mongo_integration_test.go
@@ -5,7 +5,6 @@
 package db
 
 import (
-	"os"
 	"testing"
 	"time"
 
@@ -33,12 +32,15 @@ func TestMongoIntegration(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	mongoAddress := os.Getenv("HUSKYCI_DATABASE_DB_ADDR")
+	mongoAddress := "localhost"
+	dbName := "integration-test"
+	username := ""
+	password := ""
 	dbPort := 27017
 	connectionPool := 10
 	connectionTimeout := time.Duration(1 * time.Second)
 
-	errConnect := Connect(mongoAddress, "integration-test", "", "", connectionPool, dbPort, connectionTimeout)
+	errConnect := Connect(mongoAddress, dbName, username, password, connectionPool, dbPort, connectionTimeout)
 	Expect(errConnect).To(BeNil())
 	Expect(Conn).To(Not(BeNil()))
 })
@@ -107,7 +109,7 @@ var _ = Describe("Update", func() {
 
 			expectedResult := []mongoTestObj{
 				{
-					Attr1: "update-21",
+					Attr1: "update-2",
 					Attr2: 111,
 				},
 			}

--- a/api/db/mongo_requests_integration_test.go
+++ b/api/db/mongo_requests_integration_test.go
@@ -88,7 +88,80 @@ func prepareGetMetricByTypeData() {
 				Files:    []string{"gofile1", "gofile2"},
 			},
 		},
-		HuskyCIResults: types.HuskyCIResults{},
+		HuskyCIResults: types.HuskyCIResults{
+			GoResults: types.GoResults{
+				HuskyCIGosecOutput: types.HuskyCISecurityTestOutput{
+					NoSecVulns: []types.HuskyCIVulnerability{
+						{
+							Language:       "NoSecVulns.Language",
+							SecurityTool:   "NoSecVulns.SecurityTool",
+							Severity:       "NoSecVulns.Severity",
+							Confidence:     "NoSecVulns.Confidence",
+							File:           "NoSecVulns.File",
+							Line:           "NoSecVulns.Line",
+							Code:           "NoSecVulns.Code",
+							Details:        "NoSecVulns.Details",
+							Type:           "NoSecVulns.Type",
+							Title:          "NoSecVulns.Title",
+							VunerableBelow: "NoSecVulns.VunerableBelow",
+							Version:        "NoSecVulns.Version",
+							Occurrences:    1,
+						},
+					},
+					LowVulns: []types.HuskyCIVulnerability{
+						{
+							Language:       "LowVulns.Language",
+							SecurityTool:   "LowVulns.SecurityTool",
+							Severity:       "LowVulns.Severity",
+							Confidence:     "LowVulns.Confidence",
+							File:           "LowVulns.File",
+							Line:           "LowVulns.Line",
+							Code:           "LowVulns.Code",
+							Details:        "LowVulns.Details",
+							Type:           "LowVulns.Type",
+							Title:          "LowVulns.Title",
+							VunerableBelow: "LowVulns.VunerableBelow",
+							Version:        "LowVulns.Version",
+							Occurrences:    2,
+						},
+					},
+					MediumVulns: []types.HuskyCIVulnerability{
+						{
+							Language:       "MediumVulns.Language",
+							SecurityTool:   "MediumVulns.SecurityTool",
+							Severity:       "MediumVulns.Severity",
+							Confidence:     "MediumVulns.Confidence",
+							File:           "MediumVulns.File",
+							Line:           "MediumVulns.Line",
+							Code:           "MediumVulns.Code",
+							Details:        "MediumVulns.Details",
+							Type:           "MediumVulns.Type",
+							Title:          "MediumVulns.Title",
+							VunerableBelow: "MediumVulns.VunerableBelow",
+							Version:        "MediumVulns.Version",
+							Occurrences:    3,
+						},
+					},
+					HighVulns: []types.HuskyCIVulnerability{
+						{
+							Language:       "HighVulns.Language",
+							SecurityTool:   "HighVulns.SecurityTool",
+							Severity:       "HighVulns.Severity",
+							Confidence:     "HighVulns.Confidence",
+							File:           "HighVulns.File",
+							Line:           "HighVulns.Line",
+							Code:           "HighVulns.Code",
+							Details:        "HighVulns.Details",
+							Type:           "HighVulns.Type",
+							Title:          "HighVulns.Title",
+							VunerableBelow: "HighVulns.VunerableBelow",
+							Version:        "HighVulns.Version",
+							Occurrences:    4,
+						},
+					},
+				},
+			},
+		},
 	}
 
 	errInsert := mongoHuskyCI.Conn.Insert(analysisToInsert1, mongoHuskyCI.AnalysisCollection)
@@ -660,7 +733,7 @@ var _ = Describe("DockerAPIAddresses", func() {
 })
 
 var _ = Describe("GetMetricByType", func() {
-	Context("When get language metric", func() {
+	Context("When get 'language' metric", func() {
 		It("Should return correctly", func() {
 			queryStringParams := map[string][]string{
 				"time_range": {"today"},
@@ -673,6 +746,153 @@ var _ = Describe("GetMetricByType", func() {
 			metric, errGet := huskydbMongoRequestsTest.GetMetricByType("language", queryStringParams)
 			Expect(errGet).To(BeNil())
 			Expect(metric).To(Equal(expectedResult))
+		})
+	})
+	Context("When get 'container' metric", func() {
+		It("Should return correctly", func() {
+			queryStringParams := map[string][]string{
+				"time_range": {"today"},
+			}
+
+			expectedResult := []bson.M{
+				{
+					"_id":       "GetMetricByType - Name1",
+					"count":     1,
+					"container": "GetMetricByType - Name1",
+				},
+				{
+					"_id":       "GetMetricByType - Name2",
+					"count":     1,
+					"container": "GetMetricByType - Name2",
+				},
+			}
+
+			metric, errGet := huskydbMongoRequestsTest.GetMetricByType("container", queryStringParams)
+			Expect(errGet).To(BeNil())
+			Expect(metric).To(ConsistOf(expectedResult))
+		})
+	})
+	Context("When get 'analysis' metric", func() {
+		It("Should return correctly", func() {
+			queryStringParams := map[string][]string{
+				"time_range": {"today"},
+			}
+
+			expectedResult := []bson.M{
+				{
+					"_id":    "GetMetricByType - result2",
+					"count":  1,
+					"result": "GetMetricByType - result2",
+				},
+				{
+					"_id":    "GetMetricByType - result1",
+					"count":  1,
+					"result": "GetMetricByType - result1",
+				},
+			}
+
+			metric, errGet := huskydbMongoRequestsTest.GetMetricByType("analysis", queryStringParams)
+			Expect(errGet).To(BeNil())
+			Expect(metric).To(ConsistOf(expectedResult))
+		})
+	})
+	Context("When get 'repository' metric", func() {
+		It("Should return correctly", func() {
+			queryStringParams := map[string][]string{
+				"time_range": {"today"},
+			}
+
+			expectedResult := []bson.M{
+				{
+					"_id":               "repositories",
+					"totalBranches":     2,
+					"totalRepositories": 2,
+				},
+			}
+
+			metric, errGet := huskydbMongoRequestsTest.GetMetricByType("repository", queryStringParams)
+			Expect(errGet).To(BeNil())
+			Expect(metric).To(ConsistOf(expectedResult))
+		})
+	})
+	Context("When get 'author' metric", func() {
+		It("Should return correctly", func() {
+			queryStringParams := map[string][]string{
+				"time_range": {"today"},
+			}
+
+			expectedResult := []bson.M{
+				{
+					"_id":          "commitAuthors",
+					"totalAuthors": 2,
+				},
+			}
+
+			metric, errGet := huskydbMongoRequestsTest.GetMetricByType("author", queryStringParams)
+			Expect(errGet).To(BeNil())
+			Expect(metric).To(ConsistOf(expectedResult))
+		})
+	})
+	Context("When get 'severity' metric", func() {
+		It("Should return correctly", func() {
+			queryStringParams := map[string][]string{
+				"time_range": {"today"},
+			}
+
+			expectedResult := []bson.M{
+				{
+					"_id":      "lowvulns",
+					"count":    1,
+					"severity": "lowvulns",
+				},
+				{
+					"_id":      "highvulns",
+					"count":    1,
+					"severity": "highvulns",
+				},
+				{
+					"severity": "nosecvulns",
+					"_id":      "nosecvulns",
+					"count":    1,
+				},
+				{
+					"count":    1,
+					"severity": "mediumvulns",
+					"_id":      "mediumvulns",
+				},
+			}
+
+			metric, errGet := huskydbMongoRequestsTest.GetMetricByType("severity", queryStringParams)
+			Expect(errGet).To(BeNil())
+			Expect(metric).To(ConsistOf(expectedResult))
+		})
+	})
+	Context("When get 'historyanalysis' metric", func() {
+		It("Should return correctly", func() {
+			queryStringParams := map[string][]string{
+				"time_range": {"today"},
+			}
+
+			expectedResult := []bson.M{
+				{
+					"results": []interface{}{
+						bson.M{
+							"result": "GetMetricByType - result2",
+							"count":  1,
+						},
+						bson.M{
+							"result": "GetMetricByType - result1",
+							"count":  1,
+						},
+					},
+					"total": 2,
+					"date":  time.Date(2023, 11, 19, 19, 0, 0, 0, time.Local),
+				},
+			}
+
+			metric, errGet := huskydbMongoRequestsTest.GetMetricByType("historyanalysis", queryStringParams)
+			Expect(errGet).To(BeNil())
+			Expect(metric).To(ConsistOf(expectedResult))
 		})
 	})
 })

--- a/api/db/mongo_requests_integration_test.go
+++ b/api/db/mongo_requests_integration_test.go
@@ -873,26 +873,30 @@ var _ = Describe("GetMetricByType", func() {
 				"time_range": {"today"},
 			}
 
-			expectedResult := []bson.M{
-				{
-					"results": []interface{}{
-						bson.M{
-							"result": "GetMetricByType - result2",
-							"count":  1,
-						},
-						bson.M{
-							"result": "GetMetricByType - result1",
-							"count":  1,
-						},
+			now := time.Now()
+			expectedResult := bson.M{
+				"results": []interface{}{
+					bson.M{
+						"result": "GetMetricByType - result2",
+						"count":  1,
 					},
-					"total": 2,
-					"date":  time.Date(2023, 11, 19, 19, 0, 0, 0, time.Local),
+					bson.M{
+						"result": "GetMetricByType - result1",
+						"count":  1,
+					},
 				},
+				"total": 2,
+				"date":  time.Date(now.Year(), now.Month(), now.Day(), now.Hour(), 0, 0, 0, time.Local),
 			}
 
 			metric, errGet := huskydbMongoRequestsTest.GetMetricByType("historyanalysis", queryStringParams)
 			Expect(errGet).To(BeNil())
-			Expect(metric).To(ConsistOf(expectedResult))
+
+			firstMetric := metric.([]bson.M)[0]
+
+			Expect(firstMetric["results"]).To(ConsistOf(expectedResult["results"]))
+			Expect(firstMetric["total"]).To(Equal(expectedResult["total"]))
+			Expect(firstMetric["date"]).To(Equal(expectedResult["date"]))
 		})
 	})
 })

--- a/api/db/mongo_requests_integration_test.go
+++ b/api/db/mongo_requests_integration_test.go
@@ -5,7 +5,6 @@
 package db
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -32,7 +31,10 @@ func TestHuskyDBMongoRequestsIntegration(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	fmt.Println("BeforeSuite")
+	if testing.Short() {
+		return
+	}
+
 	mongoAddress := "localhost"
 	dbName := "integration-test"
 	username := ""
@@ -212,11 +214,21 @@ func prepareGetMetricByTypeData() {
 }
 
 var _ = AfterSuite(func() {
+	if testing.Short() {
+		return
+	}
+
 	err := mongoHuskyCI.Conn.Session.DB("").DropDatabase()
 	Expect(err).To(BeNil())
 })
 
 var _ = Describe("DBRepository", func() {
+	BeforeEach(func() {
+		if testing.Short() {
+			Skip("Integration tests don't run with 'short' flag")
+		}
+	})
+
 	Context("When try to find one", func() {
 		It("Should return mgo.ErrNotFound and empty types.Repository{} when not found", func() {
 			query := map[string]interface{}{"repositoryURL": "not found URL"}
@@ -312,6 +324,12 @@ var _ = Describe("DBRepository", func() {
 })
 
 var _ = Describe("DBSecurityTest", func() {
+	BeforeEach(func() {
+		if testing.Short() {
+			Skip("Integration tests don't run with 'short' flag")
+		}
+	})
+
 	Context("When try to find one", func() {
 		It("Should return mgo.ErrNotFound and empty  types.SecurityTest{} when not found", func() {
 			query := map[string]interface{}{"name": "security_test_name"}
@@ -428,6 +446,12 @@ var _ = Describe("DBSecurityTest", func() {
 })
 
 var _ = Describe("DBAnalysis", func() {
+	BeforeEach(func() {
+		if testing.Short() {
+			Skip("Integration tests don't run with 'short' flag")
+		}
+	})
+
 	Context("When try to find one", func() {
 		It("Should return mgo.ErrNotFound and empty  types.Analysis{} when not found", func() {
 			query := map[string]interface{}{"RID": "test-id"}
@@ -575,6 +599,12 @@ var _ = Describe("DBAnalysis", func() {
 })
 
 var _ = Describe("DBUser", func() {
+	BeforeEach(func() {
+		if testing.Short() {
+			Skip("Integration tests don't run with 'short' flag")
+		}
+	})
+
 	Context("When try to find one", func() {
 		It("Should return mgo.ErrNotFound and empty  types.User{} when not found", func() {
 			query := map[string]interface{}{"username": "some user name"}
@@ -640,6 +670,12 @@ var _ = Describe("DBUser", func() {
 })
 
 var _ = Describe("DBAccessToken", func() {
+	BeforeEach(func() {
+		if testing.Short() {
+			Skip("Integration tests don't run with 'short' flag")
+		}
+	})
+
 	Context("When try to find one", func() {
 		It("Should return mgo.ErrNotFound and empty  types.DBToken{} when not found", func() {
 			query := map[string]interface{}{"uuid": "some uuid"}
@@ -702,6 +738,12 @@ var _ = Describe("DBAccessToken", func() {
 })
 
 var _ = Describe("DockerAPIAddresses", func() {
+	BeforeEach(func() {
+		if testing.Short() {
+			Skip("Integration tests don't run with 'short' flag")
+		}
+	})
+
 	Context("When update one", func() {
 		It("Should return no error and modify correctly", func() {
 			dockerAPIAddressesToInsert := types.DockerAPIAddresses{
@@ -733,6 +775,12 @@ var _ = Describe("DockerAPIAddresses", func() {
 })
 
 var _ = Describe("GetMetricByType", func() {
+	BeforeEach(func() {
+		if testing.Short() {
+			Skip("Integration tests don't run with 'short' flag")
+		}
+	})
+
 	Context("When get 'language' metric", func() {
 		It("Should return correctly", func() {
 			queryStringParams := map[string][]string{

--- a/api/token/token_test.go
+++ b/api/token/token_test.go
@@ -213,34 +213,6 @@ var _ = Describe("Token", func() {
 			Expect(err).To(Equal(fakeHash.expectedDecodeSaltError))
 		})
 	})
-	Context("When GetValidHashFunction returns a false boolean", func() {
-		It("Should return the expected error", func() {
-			fakeExt := FakeExternal{
-				expectedURL:           "MyValidURL",
-				expectedValidateError: nil,
-				expectedToken:         "MyBrandNewToken",
-				expectedGenerateError: nil,
-			}
-			fakeHash := FakeHashGen{
-				expectedSalt:              "MySalt",
-				expectedGenerateSaltError: nil,
-				expectedDecodedSalt:       make([]byte, 0),
-				expectedDecodeSaltError:   nil,
-				expectedHashName:          "",
-				expectedKeyLength:         32,
-				expectedIterations:        1024,
-			}
-			tokenGen := THandler{
-				External: &fakeExt,
-				HashGen:  &fakeHash,
-			}
-			accessToken, err := tokenGen.GenerateAccessToken(types.TokenRequest{
-				RepositoryURL: "myRepo.com",
-			})
-			Expect(accessToken).To(Equal(""))
-			Expect(err).To(Equal(errors.New("Invalid hash function")))
-		})
-	})
 	Context("When StoreAccessToken returns an error", func() {
 		It("Should return the same error and an empty string", func() {
 			fakeExt := FakeExternal{

--- a/api/util/api/api_test.go
+++ b/api/util/api/api_test.go
@@ -2,6 +2,7 @@ package util_test
 
 import (
 	"errors"
+	"os"
 
 	"github.com/globocom/glbgelf"
 	apiContext "github.com/globocom/huskyCI/api/context"
@@ -50,6 +51,7 @@ var _ = Describe("Util API", func() {
 			})
 		})
 		Context("When checkKubernetesHosts returns an error", func() {
+
 			fakeCheck := &apiUtil.FakeCheck{
 				EnvVarsError:          checkHuskyTests[1].envVarsError,
 				KubernetesHostsError:  checkHuskyTests[1].dockerHostsError,
@@ -60,7 +62,9 @@ var _ = Describe("Util API", func() {
 				CheckHandler: fakeCheck,
 			}
 			It("Should return the same error", func() {
+				os.Setenv("HUSKYCI_INFRASTRUCTURE_USE", "kubernetes")
 				Expect(huskyCheck.CheckHuskyRequirements(checkHuskyTests[1].configApi)).To(Equal(checkHuskyTests[1].expectedError))
+				os.Unsetenv("HUSKYCI_INFRASTRUCTURE_USE")
 			})
 		})
 		Context("When checkMongoDB returns an error", func() {

--- a/deployments/docker-compose-integration-test.yml
+++ b/deployments/docker-compose-integration-test.yml
@@ -1,0 +1,27 @@
+version: '3.8'
+services:
+    mongodb:
+        container_name: huskyCI_MongoDB
+        image: mongo:4.2.2
+        environment:
+            MONGO_INITDB_ROOT_USERNAME: huskyCIUser
+            MONGO_INITDB_ROOT_PASSWORD: huskyCIPassword
+            MONGO_INITDB_DATABASE: huskyCIDB
+        ports:
+          - "27017:27017"
+          - "27018:27018"
+        volumes:
+            - mongo_vol:/data/db
+            - ./mongo-init.sh:/docker-entrypoint-initdb.d/mongo-init.sh
+        networks:
+            - huskyCI_net
+        healthcheck:
+            test: ["CMD-SHELL", "echo 'db.stats().ok' | mongo localhost:27017/huskyDB --quiet"]
+            interval: 30s
+            timeout: 10s
+            retries: 3
+networks:
+    huskyCI_net:
+
+volumes:
+    mongo_vol:

--- a/deployments/docker-compose-integration-test.yml
+++ b/deployments/docker-compose-integration-test.yml
@@ -3,25 +3,5 @@ services:
     mongodb:
         container_name: huskyCI_MongoDB
         image: mongo:4.2.2
-        environment:
-            MONGO_INITDB_ROOT_USERNAME: huskyCIUser
-            MONGO_INITDB_ROOT_PASSWORD: huskyCIPassword
-            MONGO_INITDB_DATABASE: huskyCIDB
         ports:
           - "27017:27017"
-          - "27018:27018"
-        volumes:
-            - mongo_vol:/data/db
-            - ./mongo-init.sh:/docker-entrypoint-initdb.d/mongo-init.sh
-        networks:
-            - huskyCI_net
-        healthcheck:
-            test: ["CMD-SHELL", "echo 'db.stats().ok' | mongo localhost:27017/huskyDB --quiet"]
-            interval: 30s
-            timeout: 10s
-            retries: 3
-networks:
-    huskyCI_net:
-
-volumes:
-    mongo_vol:


### PR DESCRIPTION
### Description

Add integration test suit for MongoDB

Closes [579](https://github.com/globocom/huskyCI/issues/579)

### Proposed Changes

This PR introduces an integration test suite for MongoDB. The focus are the files [mongo.go](https://github.com/globocom/huskyCI/blob/main/api/db/mongo/mongo.go), [huskydb.go](https://github.com/globocom/huskyCI/blob/main/api/db/huskydb.go) and [huskystats.go](https://github.com/globocom/huskyCI/blob/main/api/db/huskystats.go). These files contains the main functions related to MongoDB connection and queries. An integration test workflow was added on Github Actions.

Two unit tests that were failing were modified as well:

1. One unit test in the file `api/util/api/api_test.go` was fixed. The problem was a missing configuration.

2. Another one in the file `api/token/token_test.go` was removed, the one with the description `"When GetValidHashFunction returns a false boolean"`. The function `GetValidHashFunction` isn't called by the function `GenerateAccessToken`, the one that the unit test is related to.

### Testing
To run the integration tests, the Docker need to be running:

```
$ make test
$ make integration-test-compose-up
$ make integration-test
$ make integration-test-compose-down
```
