### PR TITLE
Bumping the mongo image version so it works on Apple Silicon machines

### DIFF
--- a/deployments/docker-compose.yml
+++ b/deployments/docker-compose.yml
@@ -54,7 +54,7 @@ services:
 
     mongodb:
         container_name: huskyCI_MongoDB
-        image: mongo:4.2.2
+        image: mongo:4.2.24
         environment:
             MONGO_INITDB_ROOT_USERNAME: huskyCIUser
             MONGO_INITDB_ROOT_PASSWORD: huskyCIPassword


### PR DESCRIPTION
### Description

As a M2 Macbook user, I tried to start using huskyCI, I wasn't able to run `make install` with the following error:
![Screenshot 2023-12-06 at 9 01 53 AM](https://github.com/globocom/huskyCI/assets/146845443/ef96ca4c-b4d3-45a5-83b4-62be83dc5dfa)

After verifying Dockerhub, I could confirm the tag being used (`4.2.2`), only supports `linux/amd64`:
![image](https://github.com/globocom/huskyCI/assets/146845443/941e5ea2-7c85-4eb0-b772-f29aa4a32ffc)

Bumping the mongo image version to `4.2.24`, which supports `linux/arm64/v8`, made it work.

### Proposed Changes

Update mongo image tag from `4.2.2` to `4.2.24`.

### Testing

Run the following on a Apple Silicone machine:

```
make install
```
