### PR TITLE
Modifying new URL (getting started guide)

### DIFF
--- a/README-ptBR.md
+++ b/README-ptBR.md
@@ -75,7 +75,7 @@ ERROR: Job failed: exit code 190
 
 ## Primeiros Passos
 
-Você pode experimentar o huskyCI configurando um ambiente local usando o Docker Compose seguindo [este guia](https://huskyci.opensource.globo.com/docs/development/set-up-environment).
+Você pode experimentar o huskyCI configurando um ambiente local usando o Docker Compose seguindo [este guia](https://huskyci.opensource.globo.com/docs/quickstart/local-installation/).
 
 ## Documentação
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ ERROR: Job failed: exit code 190
 
 ## Getting Started
 
-You can try huskyCI by setting up a local environment using Docker Compose following [this guide](https://huskyci.opensource.globo.com/docs/development/set-up-environment).
+You can try huskyCI by setting up a local environment using Docker Compose following [this guide](https://huskyci.opensource.globo.com/docs/quickstart/local-installation/).
 
 ## Documentation
 


### PR DESCRIPTION
### Description

Changing the end of the page name to <strong>/quickstart/local-installation/</strong> where the ending address <strong>/development/set-up-environment</strong> was broken.<br>
<strong>/development/set-up-environment</strong><br>
<img width="1514" alt="Captura de Tela 2024-05-14 às 15 15 32" src="https://github.com/globocom/huskyCI/assets/112362301/df7311ed-6b13-4623-8b72-a799a5e201a6"><br>
<strong>/quickstart/local-installation/</strong><br>
<img width="1518" alt="Captura de Tela 2024-05-15 às 11 41 54" src="https://github.com/globocom/huskyCI/assets/112362301/c7fa9a52-6b71-450b-9e56-56f0d3ecc526">


